### PR TITLE
修改底层维护实例关联关系的 api

### DIFF
--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -122,6 +122,10 @@ const (
 )
 
 const (
+
+	// BKFIeldID the id definition
+	BKFieldID = "id"
+
 	// BKDefaultField the default field
 	BKDefaultField = "default"
 
@@ -539,6 +543,9 @@ const (
 
 	// BKTableNameObjClassifiction the table name of the object classification
 	BKTableNameObjClassifiction = "cc_ObjClassification"
+
+	// BKTableNameInstAsst the table name of the inst association
+	BKTableNameInstAsst = "cc_InstAsst"
 )
 
 const (

--- a/src/scene_server/topo_server/topo_service/actions/inst/inst.go
+++ b/src/scene_server/topo_server/topo_service/actions/inst/inst.go
@@ -299,7 +299,7 @@ func (cli *instAction) subCreateInst(req *restful.Request, defErr errors.Default
 			asstFieldVal[idxItem] = t
 		}
 	}
-	if err := cli.createInstAssociation(asstFieldVal); nil != err {
+	if err := cli.createInstAssociation(req, asstFieldVal); nil != err {
 		blog.Errorf("failed to create the inst association, error info is %s ", err.Error())
 	}
 
@@ -531,7 +531,7 @@ func (cli *instAction) DeleteInst(req *restful.Request, resp *restful.Response) 
 			input[common.BKInstIDField] = delItem.instID
 
 			// delete the association
-			if err := cli.deleteInstAssociation(delItem.instID, delItem.ownerID, delItem.objID); nil != err {
+			if err := cli.deleteInstAssociation(req, delItem.instID, delItem.ownerID, delItem.objID); nil != err {
 				blog.Errorf("failed to delete the association (%d %s %s), error info is %s", delItem.instID, delItem.ownerID, delItem.objID, err.Error())
 			}
 
@@ -661,7 +661,7 @@ func (cli *instAction) UpdateInst(req *restful.Request, resp *restful.Response) 
 		}
 
 		// set the inst association table
-		if err := cli.updateInstAssociation(instID, ownerID, objID, data); nil != err {
+		if err := cli.updateInstAssociation(req, instID, ownerID, objID, data); nil != err {
 			blog.Errorf("failed to update the inst association, error info is %s ", err.Error())
 		}
 

--- a/src/scene_server/topo_server/topo_service/actions/inst/inst.go
+++ b/src/scene_server/topo_server/topo_service/actions/inst/inst.go
@@ -104,11 +104,6 @@ func (cli *instAction) subCreateInst(req *restful.Request, defErr errors.Default
 					}
 
 					asstInst := metadata.InstAsst{}
-					id, err := cli.CC.InstCli.GetIncID(asstInst.TableName())
-					asstInst.ID = id
-					if nil != err {
-						blog.Error("faild to create id, error info is %s", err.Error())
-					}
 					asstInst.AsstInstID = iID
 					asstInst.AsstObjectID = asstDes[idxItem].AsstObjID
 					asstInst.ObjectID = objID

--- a/src/scene_server/topo_server/topo_service/actions/inst/inst_asst.go
+++ b/src/scene_server/topo_server/topo_service/actions/inst/inst_asst.go
@@ -23,6 +23,7 @@ import (
 	"configcenter/src/common/util"
 	"configcenter/src/source_controller/api/metadata"
 	"encoding/json"
+	"fmt"
 	simplejson "github.com/bitly/go-simplejson"
 	restful "github.com/emicklei/go-restful"
 	"io/ioutil"
@@ -44,14 +45,30 @@ type AssociationParams struct {
 	Condition map[string][]ConditionItem `json:"condition,omitempty"`
 }
 
-func (cli *instAction) createInstAssociation(instAsst []interface{}) error {
+func (cli *instAction) createInstAssociation(req *restful.Request, instAsst []interface{}) error {
 	if 0 == len(instAsst) {
 		return nil
 	}
-	return cli.CC.InstCli.InsertMuti(metadata.InstAsst{}.TableName(), instAsst...)
+	for _, item := range instAsst {
+		uURL := cli.CC.ObjCtrl() + "/object/v1/insts/" + common.BKTableNameInstAsst
+		inputJSON, err := json.Marshal(item)
+		if nil != err {
+			return err
+		}
+		objRes, err := httpcli.ReqHttp(req, uURL, common.HTTPCreate, []byte(inputJSON))
+		if nil != err {
+			return err
+		}
+
+		if _, ok := cli.IsSuccess([]byte(objRes)); !ok {
+			blog.Error("failed to create the inst asst , error info is %s", objRes)
+			continue
+		}
+	}
+	return nil
 }
 
-func (cli *instAction) updateInstAssociation(instID int, ownerID, objID string, input map[string]interface{}) error {
+func (cli *instAction) updateInstAssociation(req *restful.Request, instID int, ownerID, objID string, input map[string]interface{}) error {
 
 	// get association fields
 	asst := map[string]interface{}{}
@@ -126,22 +143,38 @@ func (cli *instAction) updateInstAssociation(instID int, ownerID, objID string, 
 		}
 	}
 
-	err := cli.deleteInstAssociation(instID, ownerID, objID)
+	err := cli.deleteInstAssociation(req, instID, ownerID, objID)
 	if nil != err {
 		blog.Errorf("faild to delete the old inst association, error info is %s", err.Error())
 		return err
 	}
 
-	return cli.createInstAssociation(asstFieldVal)
+	return cli.createInstAssociation(req, asstFieldVal)
 
 }
 
-func (cli *instAction) deleteInstAssociation(instID int, ownerID, objID string) error {
+func (cli *instAction) deleteInstAssociation(req *restful.Request, instID int, ownerID, objID string) error {
 
-	return cli.CC.InstCli.DelByCondition(metadata.InstAsst{}.TableName(), map[string]interface{}{
+	uURL := cli.CC.ObjCtrl() + "/object/v1/insts/" + common.BKTableNameInstAsst
+	input := map[string]interface{}{
 		common.BKInstIDField: instID,
 		common.BKObjIDField:  objID,
-	})
+	}
+	inputJSON, err := json.Marshal(input)
+	if nil != err {
+		return err
+	}
+	objRes, err := httpcli.ReqHttp(req, uURL, common.HTTPDelete, []byte(inputJSON))
+	if nil != err {
+		return err
+	}
+
+	if _, ok := cli.IsSuccess([]byte(objRes)); !ok {
+		blog.Error("failed to delete the inst asst , error info is %s", objRes)
+		return fmt.Errorf("failed to delete the inst asst, %s:%d", objID, instID)
+	}
+
+	return nil
 }
 
 func (cli *instAction) searchAssociationInst(req *restful.Request, objID string, searchParams map[string]interface{}) ([]int64, error) {

--- a/src/scene_server/topo_server/topo_service/actions/inst/inst_asst.go
+++ b/src/scene_server/topo_server/topo_service/actions/inst/inst_asst.go
@@ -99,12 +99,6 @@ func (cli *instAction) updateInstAssociation(req *restful.Request, instID int, o
 					}
 
 					asstInst := metadata.InstAsst{}
-					id, err := cli.CC.InstCli.GetIncID(asstInst.TableName())
-					asstInst.ID = id
-					if nil != err {
-						blog.Error("faild to create id, error info is %s", err.Error())
-					}
-
 					asstInst.InstID = int64(instID)
 					asstInst.AsstInstID = iID
 					asstInst.AsstObjectID = asstDes[idxItem].AsstObjID
@@ -114,11 +108,6 @@ func (cli *instAction) updateInstAssociation(req *restful.Request, instID int, o
 
 			case int64, int:
 				asstInst := metadata.InstAsst{}
-				id, err := cli.CC.InstCli.GetIncID(asstInst.TableName())
-				asstInst.ID = id
-				if nil != err {
-					blog.Error("faild to create id, error info is %s", err.Error())
-				}
 				asstInst.InstID = int64(instID)
 				asstInst.AsstInstID, _ = util.GetInt64ByInterface(t)
 				asstInst.AsstObjectID = asstDes[idxItem].AsstObjID
@@ -126,11 +115,6 @@ func (cli *instAction) updateInstAssociation(req *restful.Request, instID int, o
 				asstFieldVal = append(asstFieldVal, asstInst)
 			case json.Number:
 				asstInst := metadata.InstAsst{}
-				id, err := cli.CC.InstCli.GetIncID(asstInst.TableName())
-				asstInst.ID = id
-				if nil != err {
-					blog.Error("faild to create id, error info is %s", err.Error())
-				}
 				asstInst.InstID = int64(instID)
 				asstInst.AsstInstID, _ = t.Int64()
 				asstInst.AsstObjectID = asstDes[idxItem].AsstObjID

--- a/src/scene_server/topo_server/topo_service/actions/inst/inst_asst.go
+++ b/src/scene_server/topo_server/topo_service/actions/inst/inst_asst.go
@@ -322,6 +322,12 @@ func (cli *instAction) SelectInstsByAssociation(req *restful.Request, resp *rest
 			instCondition[common.BKInstIDField] = map[string]interface{}{
 				common.BKDBIN: targetInstIDS,
 			}
+		} else if 0 != len(js.Condition) {
+			if _, ok := js.Condition[objID]; !ok {
+				instCondition[common.BKInstIDField] = map[string]interface{}{
+					common.BKDBIN: targetInstIDS,
+				}
+			}
 		}
 
 		searchParams["condition"] = instCondition

--- a/src/scene_server/topo_server/topo_service/ccapi.go
+++ b/src/scene_server/topo_server/topo_service/ccapi.go
@@ -145,14 +145,6 @@ func (ccAPI *CCAPIServer) Start() error {
 	//check audit controller server
 	a.AuditCtrl = rdapi.GetRdAddrSrvHandle(types.CC_MODULE_AUDITCONTROLLER, a.AddrSrv)
 
-	// get the mongodb
-	go func() {
-		err := a.GetDataCli(config, "mongodb")
-		if err != nil {
-			blog.Error("connect mongodb error exit! err:%s", err.Error())
-		}
-	}()
-
 	//RDiscover
 	go func() {
 		err := ccAPI.rd.Start()

--- a/src/source_controller/api/metadata/object.go
+++ b/src/source_controller/api/metadata/object.go
@@ -146,7 +146,7 @@ func (PropertyGroup) TableName() string {
 
 // InstAsst an association definition between instances.
 type InstAsst struct {
-	ID           int64  `bson:"id" json:"id"`
+	ID           int64  `bson:"id" json:"-"`
 	InstID       int64  `bson:"bk_inst_id" json:"bk_inst_id"`
 	ObjectID     string `bson:"bk_obj_id" json:"bk_obj_id"`
 	AsstInstID   int64  `bson:"bk_asst_inst_id" json:"bk_asst_inst_id"`

--- a/src/source_controller/common/commondata/data.go
+++ b/src/source_controller/common/commondata/data.go
@@ -24,10 +24,10 @@ const (
 	CC_time_type_parse_flag = "cc_time_type"
 )
 
-var ObjTypeTableMap = map[string]string{common.BKInnerObjIDApp: "cc_ApplicationBase", common.BKInnerObjIDSet: "cc_SetBase", common.BKInnerObjIDModule: "cc_ModuleBase", common.BKINnerObjIDObject: "cc_ObjectBase", common.BKInnerObjIDHost: "cc_HostBase", common.BKInnerObjIDProc: "cc_Process", common.BKInnerObjIDPlat: "cc_PlatBase", common.BKTableNameInstAsst: BKTableNameInstAsst}
+var ObjTypeTableMap = map[string]string{common.BKInnerObjIDApp: "cc_ApplicationBase", common.BKInnerObjIDSet: "cc_SetBase", common.BKInnerObjIDModule: "cc_ModuleBase", common.BKINnerObjIDObject: "cc_ObjectBase", common.BKInnerObjIDHost: "cc_HostBase", common.BKInnerObjIDProc: "cc_Process", common.BKInnerObjIDPlat: "cc_PlatBase", common.BKTableNameInstAsst: common.BKTableNameInstAsst}
 
 var ObjTableMap = map[string]string{
-	common.BKInnerObjIDApp: "cc_ApplicationBase", common.BKInnerObjIDSet: "cc_SetBase", common.BKInnerObjIDModule: "cc_ModuleBase", common.BKINnerObjIDObject: "cc_ObjectBase", common.BKInnerObjIDHost: "cc_HostBase", common.BKInnerObjIDProc: "cc_Process", common.BKInnerObjIDPlat: "cc_PlatBase", common.BKTableNameInstAsst: BKTableNameInstAsst}
+	common.BKInnerObjIDApp: "cc_ApplicationBase", common.BKInnerObjIDSet: "cc_SetBase", common.BKInnerObjIDModule: "cc_ModuleBase", common.BKINnerObjIDObject: "cc_ObjectBase", common.BKInnerObjIDHost: "cc_HostBase", common.BKInnerObjIDProc: "cc_Process", common.BKInnerObjIDPlat: "cc_PlatBase", common.BKTableNameInstAsst: common.BKTableNameInstAsst}
 
 type DataBase struct {
 	ID         int       `auto_increment;primary_key"`

--- a/src/source_controller/common/commondata/data.go
+++ b/src/source_controller/common/commondata/data.go
@@ -1,15 +1,15 @@
 /*
  * Tencent is pleased to support the open source community by making 蓝鲸 available.
  * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
- * Licensed under the MIT License (the "License"); you may not use this file except 
+ * Licensed under the MIT License (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  * http://opensource.org/licenses/MIT
  * Unless required by applicable law or agreed to in writing, software distributed under
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific language governing permissions and 
+ * either express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package commondata
 
 import (
@@ -24,10 +24,10 @@ const (
 	CC_time_type_parse_flag = "cc_time_type"
 )
 
-var ObjTypeTableMap = map[string]string{common.BKInnerObjIDApp: "cc_ApplicationBase", common.BKInnerObjIDSet: "cc_SetBase", common.BKInnerObjIDModule: "cc_ModuleBase", common.BKINnerObjIDObject: "cc_ObjectBase", common.BKInnerObjIDHost: "cc_HostBase", common.BKInnerObjIDProc: "cc_Process", common.BKInnerObjIDPlat: "cc_PlatBase"}
+var ObjTypeTableMap = map[string]string{common.BKInnerObjIDApp: "cc_ApplicationBase", common.BKInnerObjIDSet: "cc_SetBase", common.BKInnerObjIDModule: "cc_ModuleBase", common.BKINnerObjIDObject: "cc_ObjectBase", common.BKInnerObjIDHost: "cc_HostBase", common.BKInnerObjIDProc: "cc_Process", common.BKInnerObjIDPlat: "cc_PlatBase", common.BKTableNameInstAsst: BKTableNameInstAsst}
 
 var ObjTableMap = map[string]string{
-	common.BKInnerObjIDApp: "cc_ApplicationBase", common.BKInnerObjIDSet: "cc_SetBase", common.BKInnerObjIDModule: "cc_ModuleBase", common.BKINnerObjIDObject: "cc_ObjectBase", common.BKInnerObjIDHost: "cc_HostBase", common.BKInnerObjIDProc: "cc_Process", common.BKInnerObjIDPlat: "cc_PlatBase"}
+	common.BKInnerObjIDApp: "cc_ApplicationBase", common.BKInnerObjIDSet: "cc_SetBase", common.BKInnerObjIDModule: "cc_ModuleBase", common.BKINnerObjIDObject: "cc_ObjectBase", common.BKInnerObjIDHost: "cc_HostBase", common.BKInnerObjIDProc: "cc_Process", common.BKInnerObjIDPlat: "cc_PlatBase", common.BKTableNameInstAsst: BKTableNameInstAsst}
 
 type DataBase struct {
 	ID         int       `auto_increment;primary_key"`

--- a/src/source_controller/common/instdata/object.go
+++ b/src/source_controller/common/instdata/object.go
@@ -1,15 +1,15 @@
 /*
  * Tencent is pleased to support the open source community by making 蓝鲸 available.
  * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
- * Licensed under the MIT License (the "License"); you may not use this file except 
+ * Licensed under the MIT License (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  * http://opensource.org/licenses/MIT
  * Unless required by applicable law or agreed to in writing, software distributed under
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific language governing permissions and 
+ * either express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package instdata
 
 import (
@@ -85,6 +85,8 @@ func GetIDNameByType(objType string) string {
 		return common.BKProcIDField
 	case common.BKInnerObjIDPlat:
 		return common.BKCloudIDField
+	case common.BKTableNameInstAsst:
+		return common.BKFieldID
 	default:
 		return common.BKInstIDField
 	}


### PR DESCRIPTION
修改底层维护实例关联关系的API，扩展object_controller 的insts 接口，支持对实例关系表的操作。
