### PR TITLE
v2 api updatehostbyappid add host not import_from value   close #526

### DIFF
--- a/src/scene_server/host_server/host_service/actions/phpapi/host.go
+++ b/src/scene_server/host_server/host_service/actions/phpapi/host.go
@@ -239,6 +239,7 @@ func (cli *hostAction) UpdateHostByAppID(req *restful.Request, resp *restful.Res
 				}
 			}
 			blog.Debug("procMap:%v", proMap)
+			proMap["import_from"] = common.HostAddMethodAPI
 			hostIDNew, err := phpapilogic.AddHost(req, proMap, cli.CC.ObjCtrl())
 
 			if nil != err {

--- a/src/scene_server/host_server/host_service/actions/phpapi/host.go
+++ b/src/scene_server/host_server/host_service/actions/phpapi/host.go
@@ -239,7 +239,7 @@ func (cli *hostAction) UpdateHostByAppID(req *restful.Request, resp *restful.Res
 				}
 			}
 			blog.Debug("procMap:%v", proMap)
-			proMap["import_from"] = common.HostAddMethodAPI
+			proMap["import_from"] = common.HostAddMethodAgent
 			hostIDNew, err := phpapilogic.AddHost(req, proMap, cli.CC.ObjCtrl())
 
 			if nil != err {


### PR DESCRIPTION
1. 解决通过agent安装的机器，主机详情的录入方式显示空白