### PR TITLE
fixbug: 修正拼写错误的函数名  #621

### DIFF
--- a/src/web_server/application/controllers/host.go
+++ b/src/web_server/application/controllers/host.go
@@ -47,7 +47,7 @@ func init() {
 // ImportHost import host
 func ImportHost(c *gin.Context) {
 	cc := api.NewAPIResource()
-	language := logics.GetLanugaeByHTTPRequest(c)
+	language := logics.GetLanguageByHTTPRequest(c)
 	defLang := cc.Lang.CreateDefaultCCLanguageIf(language)
 	defErr := cc.Error.CreateDefaultCCErrorIf(language)
 
@@ -121,7 +121,7 @@ func ExportHost(c *gin.Context) {
 
 	logics.SetProxyHeader(c)
 
-	language := logics.GetLanugaeByHTTPRequest(c)
+	language := logics.GetLanguageByHTTPRequest(c)
 	defLang := cc.Lang.CreateDefaultCCLanguageIf(language)
 	defErr := cc.Error.CreateDefaultCCErrorIf(language)
 
@@ -187,7 +187,7 @@ func BuildDownLoadExcelTemplate(c *gin.Context) {
 	if nil != err {
 		os.MkdirAll(dir, os.ModeDir|os.ModePerm)
 	}
-	language := logics.GetLanugaeByHTTPRequest(c)
+	language := logics.GetLanguageByHTTPRequest(c)
 	defLang := cc.Lang.CreateDefaultCCLanguageIf(language)
 	defErr := cc.Error.CreateDefaultCCErrorIf(language)
 

--- a/src/web_server/application/controllers/inst.go
+++ b/src/web_server/application/controllers/inst.go
@@ -40,7 +40,7 @@ func ImportInst(c *gin.Context) {
 	objID := c.Param(common.BKObjIDField)
 
 	cc := api.NewAPIResource()
-	language := logics.GetLanugaeByHTTPRequest(c)
+	language := logics.GetLanguageByHTTPRequest(c)
 	defLang := cc.Lang.CreateDefaultCCLanguageIf(language)
 	defErr := cc.Error.CreateDefaultCCErrorIf(language)
 
@@ -107,7 +107,7 @@ func ImportInst(c *gin.Context) {
 func ExportInst(c *gin.Context) {
 	logics.SetProxyHeader(c)
 	cc := api.NewAPIResource()
-	language := logics.GetLanugaeByHTTPRequest(c)
+	language := logics.GetLanguageByHTTPRequest(c)
 	defLang := cc.Lang.CreateDefaultCCLanguageIf(language)
 	defErr := cc.Error.CreateDefaultCCErrorIf(language)
 

--- a/src/web_server/application/controllers/object.go
+++ b/src/web_server/application/controllers/object.go
@@ -58,7 +58,7 @@ func ImportObject(c *gin.Context) {
 	objID := c.Param(common.BKObjIDField)
 
 	cc := api.NewAPIResource()
-	language := logics.GetLanugaeByHTTPRequest(c)
+	language := logics.GetLanguageByHTTPRequest(c)
 	defLang := cc.Lang.CreateDefaultCCLanguageIf(language)
 	defErr := cc.Error.CreateDefaultCCErrorIf(language)
 
@@ -225,7 +225,7 @@ func ExportObject(c *gin.Context) {
 
 	apiSite, _ := cc.AddrSrv.GetServer(types.CC_MODULE_APISERVER)
 
-	language := logics.GetLanugaeByHTTPRequest(c)
+	language := logics.GetLanguageByHTTPRequest(c)
 	defLang := cc.Lang.CreateDefaultCCLanguageIf(language)
 	defErr := cc.Error.CreateDefaultCCErrorIf(language)
 

--- a/src/web_server/application/logics/httpheader.go
+++ b/src/web_server/application/logics/httpheader.go
@@ -30,7 +30,7 @@ func SetProxyHeader(c *gin.Context) {
 	c.Request.Header.Add(common.BKHTTPOwnerID, ownerID)
 }
 
-func GetLanugaeByHTTPRequest(c *gin.Context) string {
+func GetLanguageByHTTPRequest(c *gin.Context) string {
 
 	cookieLanuage, err := c.Cookie(common.BKHTTPCookieLanugageKey)
 	if "" != cookieLanuage && nil == err {


### PR DESCRIPTION
#621 
### 修复的问题：
- 把拼写错误的函数名 GetLanugaeByHTTPRequest 修正为 GetLanguageByHTTPRequest
