### PR TITLE
 v2 api addset not support when topology level > 3   issue #676

### DIFF
--- a/src/api_server/ccapi/logics/v2/topo.go
+++ b/src/api_server/ccapi/logics/v2/topo.go
@@ -26,6 +26,7 @@ import (
 	httpcli "configcenter/src/common/http/httpclient"
 	"configcenter/src/common/paraparse"
 	"configcenter/src/common/util"
+	"configcenter/src/scene_server/topo_server/topo_service/manager"
 )
 
 func GetAppTopo(req *restful.Request, cc *api.APIResource, ownerID string, appID int64, conds common.KvMap) (map[string]interface{}, int) {
@@ -405,4 +406,47 @@ func getRspV3DataInfo(logPrex, rspV3 string) ([]interface{}, int) {
 	}
 
 	return data, 0
+}
+
+func CheckAppTopoIsThreeLevel(req *restful.Request, cc *api.APIResource) (bool, error) {
+	type mainLineItem struct {
+		Result bool                   `json:"result"`
+		Code   int                    `json:"bk_error_code"`
+		ErrMsg string                 `json:"bk_error_msg"`
+		Data   []manager.TopoModelRsp `json:"data"`
+	}
+	url := fmt.Sprintf("%s/topo/v1/model/%s", cc.TopoAPI(), util.GetActionOnwerID(req))
+	rspV3, err := httpcli.ReqHttp(req, url, common.HTTPSelectGet, nil)
+	blog.V(0).Infof("getAppInfo url:%s, input:%s ", url, rspV3)
+	if nil != err {
+		blog.Errorf("CheckAppTopoIsThreeLevel url:%s, error:%s ", url, err.Error())
+		return false, err
+	}
+
+	resMainLine := &mainLineItem{}
+	err = json.Unmarshal([]byte(rspV3), resMainLine)
+	if nil != err {
+		blog.Errorf("CheckAppTopoIsThreeLevel reply:%s, error:%s ", rspV3, err.Error())
+		return false, fmt.Errorf("check mainline topology reply:%s", rspV3)
+	}
+	if false == resMainLine.Result {
+		blog.Errorf("CheckAppTopoIsThreeLevel reply:%s, error:%s ", rspV3, err.Error())
+		return false, fmt.Errorf(resMainLine.ErrMsg)
+	}
+
+	for _, item := range resMainLine.Data {
+		if common.BKInnerObjIDApp == item.ObjID {
+			if common.BKInnerObjIDSet != item.NextObj {
+				return false, nil
+			}
+		}
+
+		if common.BKInnerObjIDSet == item.ObjID {
+			if common.BKInnerObjIDModule != item.NextObj {
+				return false, nil
+			}
+		}
+	}
+
+	return true, nil
 }


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- 使用v2 接口新加集群时， 当业务拓扑层级大于3级，提示用户使用新接口 
### 修复的问题：
- xxxx
