### PR TITLE
1. 修复有权限账号不能查看关联topo的bug

### DIFF
--- a/src/web_server/application/middleware/auth/public.go
+++ b/src/web_server/application/middleware/auth/public.go
@@ -110,7 +110,9 @@ func (m *publicAuth) ValidResAccess(pathArr []string, c *gin.Context) bool {
 	if types.SearchPatternRegexp.MatchString(pathStr) {
 		return true
 	}
-
+	if strings.Contains(pathStr, types.BK_INST_ASSOCIATION_TOPO_SEARCH) {
+		return true
+	}
 	//valid resource config
 	if types.ResPatternRegexp.MatchString(pathStr) {
 		blog.Debug("valid resource config: %v", pathStr)

--- a/src/web_server/application/middleware/types/types.go
+++ b/src/web_server/application/middleware/types/types.go
@@ -47,6 +47,7 @@ const (
 	BK_HOSTS_SNAP    = "hosts/snapshot"
 	BK_HOSTS_HIS     = "hosts/history"
 	BK_TOPO_MODEL    = "topo/model"
+	BK_INST_ASSOCIATION_TOPO_SEARCH = "inst/association/topo/search"
 )
 
 //bk topo


### PR DESCRIPTION
### 修复的问题：
-  修复有权限账号不能查看关联topo的bug
