### PR TITLE
修复自测的一些列问题

### DIFF
--- a/src/common/condition/condition.go
+++ b/src/common/condition/condition.go
@@ -33,6 +33,8 @@ type Condition interface {
 	GetLimit() int64
 	SetSort(sort string)
 	GetSort() string
+	SetFields(fields []string)
+	GetFields() []string
 	Field(fieldName string) Field
 	Parse(data types.MapStr) error
 	ToMapStr() types.MapStr
@@ -40,10 +42,11 @@ type Condition interface {
 
 // Condition the condition definition
 type condition struct {
-	start  int64
-	limit  int64
-	sort   string
-	fields []Field
+	start        int64
+	limit        int64
+	sort         string
+	fields       []Field
+	filterFields []string
 }
 
 // SetPage set the page
@@ -63,6 +66,13 @@ func (cli *condition) SetPage(page types.MapStr) error {
 	cli.sort = sort
 
 	return nil
+}
+
+func (cli *condition) SetFields(fields []string) {
+	cli.filterFields = fields
+}
+func (cli *condition) GetFields() []string {
+	return cli.filterFields
 }
 
 // Parse load the data into condition object

--- a/src/common/mapstr/mapstr.go
+++ b/src/common/mapstr/mapstr.go
@@ -173,7 +173,7 @@ func (cli MapStr) Float(key string) (float64, error) {
 func (cli MapStr) String(key string) (string, error) {
 	switch t := cli[key].(type) {
 	case nil:
-		return "", fmt.Errorf("the key(%s) is invalid", key)
+		return "", nil
 	default:
 		return fmt.Sprintf("%v", t), nil
 	case map[string]interface{}, []interface{}:

--- a/src/common/metadata/object_controller.go
+++ b/src/common/metadata/object_controller.go
@@ -67,12 +67,12 @@ type AttributeWrapper struct {
 type UpdateGroupCondition struct {
 	Condition struct {
 		ID      int64  `json:"id,omitempty"`
-		GroupID string `json:"bk_group_id"`
-		ObjID   string `json:"bk_obj_id"`
+		GroupID string `json:"bk_group_id,omitempty"`
+		ObjID   string `json:"bk_obj_id,omitempty"`
 	} `json:"condition"`
 
 	Data struct {
-		Name  string `json:"bk_group_name"`
+		Name  string `json:"bk_group_name,omitempty"`
 		Index int64  `json:"bk_group_index"`
 	} `json:"data"`
 }

--- a/src/scene_server/topo_server/core/model/object.go
+++ b/src/scene_server/topo_server/core/model/object.go
@@ -261,6 +261,7 @@ func (o *object) GetParentObject() ([]Object, error) {
 	cond := condition.CreateCondition()
 	cond.Field(meta.AssociationFieldSupplierAccount).Eq(o.params.SupplierAccount)
 	cond.Field(meta.AssociationFieldAssociationObjectID).Eq(o.obj.ObjectID)
+	cond.Field(meta.AssociationFieldObjectAttributeID).NotEq(common.BKChildStr)
 
 	return o.searchObjects(false, cond)
 }
@@ -269,6 +270,7 @@ func (o *object) GetChildObject() ([]Object, error) {
 	cond := condition.CreateCondition()
 	cond.Field(meta.AssociationFieldSupplierAccount).Eq(o.params.SupplierAccount)
 	cond.Field(meta.AssociationFieldObjectID).Eq(o.obj.ObjectID)
+	cond.Field(meta.AssociationFieldObjectAttributeID).NotEq(common.BKChildStr)
 
 	return o.searchObjects(true, cond)
 }

--- a/src/scene_server/topo_server/core/operation/association_mainline_object.go
+++ b/src/scene_server/topo_server/core/operation/association_mainline_object.go
@@ -198,6 +198,7 @@ func (a *association) CreateMainlineAssociation(params types.ContextParams, data
 	defaultInstNameAttr := currentObj.CreateAttribute()
 	defaultInstNameAttr.SetIsSystem(false)
 	defaultInstNameAttr.SetIsOnly(true)
+	defaultInstNameAttr.SetIsPre(true)
 	defaultInstNameAttr.SetIsEditable(true)
 	defaultInstNameAttr.SetType(common.FieldTypeLongChar)
 	defaultInstNameAttr.SetIsRequired(true)

--- a/src/scene_server/topo_server/core/operation/group.go
+++ b/src/scene_server/topo_server/core/operation/group.go
@@ -170,6 +170,8 @@ func (g *group) DeleteObjectAttributeGroup(params types.ContextParams, objID, pr
 
 func (g *group) UpdateObjectGroup(params types.ContextParams, cond *metadata.UpdateGroupCondition) error {
 
+	//fmt.Printf("\ncond:%#v\n", cond)
+
 	rsp, err := g.clientSet.ObjectController().Meta().UpdatePropertyGroup(context.Background(), params.Header, cond)
 
 	if nil != err {

--- a/src/scene_server/topo_server/core/operation/inst.go
+++ b/src/scene_server/topo_server/core/operation/inst.go
@@ -364,7 +364,7 @@ func (c *commonInst) hasHost(params types.ContextParams, targetInst inst.Inst) (
 
 	instIDS := []deletedInst{}
 	instIDS = append(instIDS, deletedInst{instID: id, obj: targetObj})
-	childInsts, err := targetInst.GetChildInst()
+	childInsts, err := targetInst.GetMainlineChildInst()
 	if nil != err {
 		return nil, false, err
 	}

--- a/src/scene_server/topo_server/core/operation/inst.go
+++ b/src/scene_server/topo_server/core/operation/inst.go
@@ -944,6 +944,10 @@ func (c *commonInst) FindOriginInst(params types.ContextParams, obj model.Object
 func (c *commonInst) FindInst(params types.ContextParams, obj model.Object, cond *metatype.QueryInput, needAsstDetail bool) (count int, results []inst.Inst, err error) {
 
 	rsp, err := c.FindOriginInst(params, obj, cond)
+	if nil != err {
+		blog.Errorf("[operation-inst] failed to find origin inst , error info is %s", err.Error())
+		return 0, nil, err
+	}
 
 	asstObjAttrs, err := c.asst.SearchObjectAssociation(params, obj.GetID())
 	if nil != err {

--- a/src/scene_server/topo_server/core/operation/inst_business.go
+++ b/src/scene_server/topo_server/core/operation/inst_business.go
@@ -214,6 +214,8 @@ func (b *business) FindBusiness(params types.ContextParams, obj model.Object, fi
 	query.Condition = cond.ToMapStr()
 	query.Limit = common.BKNoLimit
 	query.Fields = strings.Join(fields, ",")
+	query.Sort = cond.GetSort()
+	query.Start = int(cond.GetStart())
 
 	return b.inst.FindInst(params, obj, query, false)
 }

--- a/src/scene_server/topo_server/core/operation/inst_module.go
+++ b/src/scene_server/topo_server/core/operation/inst_module.go
@@ -76,6 +76,7 @@ func (m *module) CreateModule(params types.ContextParams, obj model.Object, bizI
 
 	data.Set(common.BKSetIDField, setID)
 	data.Set(common.BKAppIDField, bizID)
+	data.Set(common.BKDefaultField, 0)
 	//data.Set(common.CreateTimeField, util.GetCurrentTimeStr())
 
 	return m.inst.CreateInst(params, obj, data)

--- a/src/scene_server/topo_server/core/operation/inst_set.go
+++ b/src/scene_server/topo_server/core/operation/inst_set.go
@@ -79,6 +79,7 @@ func (s *set) hasHost(params types.ContextParams, bizID int64, setIDS []int64) (
 func (s *set) CreateSet(params types.ContextParams, obj model.Object, bizID int64, data mapstr.MapStr) (inst.Inst, error) {
 
 	data.Set(common.BKAppIDField, bizID)
+	data.Set(common.BKDefaultField, 0)
 	//data.Set(common.CreateTimeField, util.GetCurrentTimeStr())
 	return s.inst.CreateInst(params, obj, data)
 }

--- a/src/scene_server/topo_server/core/operation/supplementary_audit.go
+++ b/src/scene_server/topo_server/core/operation/supplementary_audit.go
@@ -129,6 +129,8 @@ func (a *auditLog) commitSnapshot(preData, currData *WrapperResult, action audit
 		bizID, err := targetItem.GetValues().String(common.BKAppIDField)
 		if nil != err {
 			blog.V(3).Infof("[audit] failed to get the bizid from the data(%#v), error info is %s", targetItem.GetValues(), err.Error())
+		}
+		if 0 == len(bizID) {
 			bizID = "0"
 		}
 		//fmt.Println("the data pre:", preDataTmp)

--- a/src/scene_server/topo_server/core/privilege/group.go
+++ b/src/scene_server/topo_server/core/privilege/group.go
@@ -61,7 +61,7 @@ func (u *userGroup) checkGroupNameRepeat(supplierAccount, groupID, groupName str
 
 	cond := condition.CreateCondition()
 	if 0 != len(groupID) {
-		cond.Field("group_id").Eq(groupID)
+		cond.Field("group_id").NotIn([]string{groupID})
 	}
 	cond.Field("group_name").Eq(groupName)
 

--- a/src/scene_server/topo_server/core/privilege/privilege.go
+++ b/src/scene_server/topo_server/core/privilege/privilege.go
@@ -68,7 +68,7 @@ func (u *userGroupPermission) SetUserGroupPermission(supplierAccount, groupID st
 		return u.params.Err.New(rsp.Code, rsp.ErrMsg)
 	}
 
-	if nil == rsp.Data.Privilege {
+	if nil == rsp.Data.Privilege || (0 == len(rsp.Data.Privilege.ModelConfig) && nil == rsp.Data.Privilege.SysConfig) {
 		rsp, err := u.client.ObjectController().Privilege().CreateUserGroupPrivi(context.Background(), supplierAccount, groupID, u.params.Header, permission)
 		if nil != err {
 			blog.Errorf("[privilege] failed to request object controller, error info is %s", err.Error())

--- a/src/scene_server/topo_server/core/privilege/role.go
+++ b/src/scene_server/topo_server/core/privilege/role.go
@@ -50,6 +50,13 @@ func (r *rolePermission) CreatePermission(supplierAccount, objID, propertyID str
 	}
 
 	if rsp.Result {
+		switch tmpData := rsp.Data.(type) {
+		case nil:
+		case map[string]interface{}:
+			if 0 == len(tmpData) {
+				goto CreatePri
+			}
+		}
 
 		rsp, err := r.client.ObjectController().Privilege().UpdateRolePri(context.Background(), supplierAccount, objID, propertyID, r.params.Header, data)
 		if nil != err {
@@ -65,6 +72,7 @@ func (r *rolePermission) CreatePermission(supplierAccount, objID, propertyID str
 		return nil
 	}
 
+CreatePri:
 	rsp, err = r.client.ObjectController().Privilege().CreateRolePri(context.Background(), supplierAccount, objID, propertyID, r.params.Header, data)
 
 	if nil != err {

--- a/src/scene_server/topo_server/core/privilege/role.go
+++ b/src/scene_server/topo_server/core/privilege/role.go
@@ -50,29 +50,31 @@ func (r *rolePermission) CreatePermission(supplierAccount, objID, propertyID str
 	}
 
 	if rsp.Result {
+		shouldCreate := false
 		switch tmpData := rsp.Data.(type) {
 		case nil:
 		case map[string]interface{}:
 			if 0 == len(tmpData) {
-				goto CreatePri
+				shouldCreate = true
 			}
 		}
 
-		rsp, err := r.client.ObjectController().Privilege().UpdateRolePri(context.Background(), supplierAccount, objID, propertyID, r.params.Header, data)
-		if nil != err {
-			blog.Errorf("[permission] failed to request object controller, error info is %s", err.Error())
-			return r.params.Err.Error(common.CCErrCommHTTPDoRequestFailed)
-		}
+		if !shouldCreate {
+			rsp, err := r.client.ObjectController().Privilege().UpdateRolePri(context.Background(), supplierAccount, objID, propertyID, r.params.Header, data)
+			if nil != err {
+				blog.Errorf("[permission] failed to request object controller, error info is %s", err.Error())
+				return r.params.Err.Error(common.CCErrCommHTTPDoRequestFailed)
+			}
 
-		if !rsp.Result {
-			blog.Errorf("[permission] failed to update the role, error info is %s", rsp.ErrMsg)
-			return r.params.Err.New(rsp.Code, rsp.ErrMsg)
-		}
+			if !rsp.Result {
+				blog.Errorf("[permission] failed to update the role, error info is %s", rsp.ErrMsg)
+				return r.params.Err.New(rsp.Code, rsp.ErrMsg)
+			}
 
-		return nil
+			return nil
+		}
 	}
 
-CreatePri:
 	rsp, err = r.client.ObjectController().Privilege().CreateRolePri(context.Background(), supplierAccount, objID, propertyID, r.params.Header, data)
 
 	if nil != err {

--- a/src/scene_server/topo_server/service/inst.go
+++ b/src/scene_server/topo_server/service/inst.go
@@ -78,6 +78,10 @@ func (s *topoService) DeleteInsts(params types.ContextParams, pathParams, queryP
 // DeleteInst delete the inst
 func (s *topoService) DeleteInst(params types.ContextParams, pathParams, queryParams ParamsGetter, data frtypes.MapStr) (interface{}, error) {
 
+	if "batch" == pathParams("inst_id") {
+		return s.DeleteInsts(params, pathParams, queryParams, data)
+	}
+
 	instID, err := strconv.ParseInt(pathParams("inst_id"), 10, 64)
 	if nil != err {
 		blog.Errorf("[api-inst]failed to parse the inst id, error info is %s", err.Error())
@@ -112,7 +116,7 @@ func (s *topoService) UpdateInsts(params types.ContextParams, pathParams, queryP
 	for _, item := range updateCondition.Update {
 
 		cond := condition.CreateCondition()
-		cond.Field(obj.GetInstIDFieldName()).In(item.InstID)
+		cond.Field(obj.GetInstIDFieldName()).Eq(item.InstID)
 		err = s.core.InstOperation().UpdateInst(params, item.InstInfo, obj, cond, item.InstID)
 		if nil != err {
 			blog.Errorf("[api-inst] failed to update the object(%s) inst (%d),the data (%#v), error info is %s", obj.GetID(), item.InstID, data, err.Error())
@@ -128,6 +132,10 @@ func (s *topoService) UpdateInst(params types.ContextParams, pathParams, queryPa
 
 	// /inst/{owner_id}/{obj_id}/{inst_id}
 
+	if "batch" == pathParams("inst_id") {
+		return s.UpdateInsts(params, pathParams, queryParams, data)
+	}
+
 	objID := pathParams("obj_id")
 
 	obj, err := s.core.ObjectOperation().FindSingleObject(params, objID)
@@ -135,6 +143,7 @@ func (s *topoService) UpdateInst(params types.ContextParams, pathParams, queryPa
 		blog.Errorf("[api-inst] failed to find the objects(%s), error info is %s", pathParams("obj_id"), err.Error())
 		return nil, err
 	}
+
 	instID, err := strconv.ParseInt(pathParams("inst_id"), 10, 64)
 	if nil != err {
 		blog.Errorf("[api-inst]failed to parse the inst id, error info is %s", err.Error())

--- a/src/scene_server/topo_server/service/inst.go
+++ b/src/scene_server/topo_server/service/inst.go
@@ -321,7 +321,7 @@ func (s *topoService) SearchInstByInstID(params types.ContextParams, pathParams,
 	cond := condition.CreateCondition()
 	cond.Field(obj.GetInstIDFieldName()).Eq(instID)
 	queryCond := &metadata.QueryInput{}
-	queryCond.Condition = cond
+	queryCond.Condition = cond.ToMapStr()
 
 	cnt, instItems, err := s.core.InstOperation().FindInst(params, obj, queryCond, false)
 	if nil != err {

--- a/src/scene_server/topo_server/service/inst_business.go
+++ b/src/scene_server/topo_server/service/inst_business.go
@@ -155,8 +155,11 @@ func (s *topoService) SearchBusiness(params types.ContextParams, pathParams, que
 	if _, ok := searchCond.Condition[common.BKDataStatusField]; !ok {
 		innerCond.Field(common.BKDataStatusField).NotEq(common.DataStatusDisabled)
 	}
+
 	innerCond.Field(common.BKDefaultField).Eq(0)
 	innerCond.Field(common.BKOwnerIDField).Eq(params.SupplierAccount)
+	innerCond.SetPage(searchCond.Page)
+	innerCond.SetFields(searchCond.Fields)
 
 	cnt, instItems, err := s.core.BusinessOperation().FindBusiness(params, obj, searchCond.Fields, innerCond)
 	if nil != err {

--- a/src/scene_server/topo_server/service/inst_module.go
+++ b/src/scene_server/topo_server/service/inst_module.go
@@ -14,6 +14,7 @@ package service
 
 import (
 	"strconv"
+	"strings"
 
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
@@ -140,6 +141,11 @@ func (s *topoService) SearchModule(params types.ContextParams, pathParams, query
 
 	queryCond := &metadata.QueryInput{}
 	queryCond.Condition = paramsCond.Condition
+	queryCond.Fields = strings.Join(paramsCond.Fields, ",")
+	page := metadata.ParsePage(paramsCond.Page)
+	queryCond.Limit = page.Limit
+	queryCond.Sort = page.Sort
+	queryCond.Start = page.Start
 
 	cnt, instItems, err := s.core.ModuleOperation().FindModule(params, obj, queryCond)
 	if nil != err {

--- a/src/scene_server/topo_server/service/inst_set.go
+++ b/src/scene_server/topo_server/service/inst_set.go
@@ -144,6 +144,10 @@ func (s *topoService) SearchSet(params types.ContextParams, pathParams, queryPar
 	queryCond := &metadata.QueryInput{}
 	queryCond.Condition = paramsCond.Condition
 	queryCond.Fields = strings.Join(paramsCond.Fields, ",")
+	page := metadata.ParsePage(paramsCond.Page)
+	queryCond.Start = page.Start
+	queryCond.Sort = page.Sort
+	queryCond.Limit = page.Limit
 
 	cnt, instItems, err := s.core.SetOperation().FindSet(params, obj, queryCond)
 	if nil != err {

--- a/src/scene_server/topo_server/service/inst_set.go
+++ b/src/scene_server/topo_server/service/inst_set.go
@@ -68,6 +68,10 @@ func (s *topoService) DeleteSets(params types.ContextParams, pathParams, queryPa
 // DeleteSet delete the set
 func (s *topoService) DeleteSet(params types.ContextParams, pathParams, queryParams ParamsGetter, data frtypes.MapStr) (interface{}, error) {
 
+	if "batch" == pathParams("set_id") {
+		return s.DeleteSets(params, pathParams, queryParams, data)
+	}
+
 	bizID, err := strconv.ParseInt(pathParams("app_id"), 10, 64)
 	if nil != err {
 		blog.Errorf("[api-set]failed to parse the biz id, error info is %s", err.Error())


### PR DESCRIPTION
### 修复的问题：
- 导入实例时多关联字段允许为空
- 修改录入操作审计的bug
- 修复批量更新实例失败的bug
- 修改分组排序
- bk_inst_name 字段ispre 设置为true
- 修复查询实例查询条件不生效的bug
- 修复业务列表排序不生效的的问题
- 恢复默认添加集群和模块的 default 字段
- 修复业务角色授权不生效的bug
- 修复用户角色权限绑定的bug
- 解决角色绑定用户失败的bug
- 查询普通模型拓扑时屏蔽主线模型