### PR TITLE
修复 /api/v2/Plat/add 没有数据重复提示

### DIFF
--- a/src/api_server/service/plat.go
+++ b/src/api_server/service/plat.go
@@ -14,6 +14,7 @@ package service
 
 import (
 	"context"
+	"strconv"
 	"strings"
 
 	"configcenter/src/api_server/ccapi/logics/v2/common/converter"
@@ -163,8 +164,12 @@ func (s *Service) createPlats(req *restful.Request, resp *restful.Response) {
 	param, _ = s.Logics.AutoInputV3Field(param, common.BKInnerObjIDPlat, user, pheader)
 
 	result, err := s.CoreAPI.HostServer().CreatePlat(context.Background(), pheader, param)
-	if err != nil {
+	if nil != err {
 		blog.Errorf("createPlats  error:%v", err)
+		if strings.Contains(err.Error(), strconv.Itoa(common.CCErrCommDuplicateItem)) {
+			converter.RespFailV2(common.CCErrCommDuplicateItem, defErr.Error(common.CCErrCommDuplicateItem).Error(), resp)
+			return
+		}
 		converter.RespFailV2(common.CCErrCommHTTPDoRequestFailed, defErr.Error(common.CCErrCommHTTPDoRequestFailed).Error(), resp)
 		return
 	}

--- a/src/scene_server/host_server/service/phpapi.go
+++ b/src/scene_server/host_server/service/phpapi.go
@@ -845,8 +845,13 @@ func (s *Service) CreatePlat(req *restful.Request, resp *restful.Response) {
 
 	valid := validator.NewValidMap(util.GetOwnerID(req.Request.Header), common.BKInnerObjIDPlat, req.Request.Header, s.Engine)
 	validErr := valid.ValidMap(input, common.ValidCreate, 0)
+
 	if nil != validErr {
 		blog.Errorf("CreatePlat error: %v, input:%v", validErr, input)
+		if strings.Contains(defErr.Error(common.CCErrCommDuplicateItem).Error(), validErr.Error()) {
+			resp.WriteError(http.StatusBadRequest, &meta.RespError{Msg: defErr.Error(common.CCErrCommDuplicateItem)})
+			return
+		}
 		resp.WriteError(http.StatusBadGateway, &meta.RespError{Msg: defErr.Error(common.CCErrTopoInstCreateFailed)})
 		return
 	}


### PR DESCRIPTION
### 修复的问题：
- http://{{.apiserver}}/api/v2/Plat/add 新增云区域时如果添加的 platName 重名，返回的报错是“http request failed”，而不是“数据重复”。
