### PR TITLE
Dockerfile中添加WORKDIR

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -8,6 +8,7 @@ docker_file_template_str ='''
 FROM  $base_image
 $run_items
 $copy_items
+WORKDIR $cwd
 ENTRYPOINT $cwd/start.sh
 '''
 


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- Dockerfile中添加WORKDIR
以apiserver为例:
1. Dockerfile中未配置WORKDIR时，当前工作目录并不是/cmdb_apiserver, 可能是/
2. 而Dockerfile中的ENTRYPOIINT为/cmdb_apiserver/start.sh, start.sh中调用了python ip.py获取当前IP, 执行ip.py时使用的是相对路径
3. 所以python进程会从当前路径中查找ip.py, 由于当前路径不是/cmdb_apiserver, 所以docker container在启动时会报出如下错误：

`python: can't open file 'ip.py': [Errno 2] No such file or directory`

解决方法：
在Dockerfile中添加WORKDIR，指定当前路径为$cwd, 即/cmdb_apiserver

