### PR TITLE
批量转移主机模块，操作审计日志只记录了第一个机器的数据

### DIFF
--- a/src/scene_server/host_server/logics/log.go
+++ b/src/scene_server/host_server/logics/log.go
@@ -85,7 +85,7 @@ func (h *HostLog) GetContent(hostID int64) *metadata.Content {
 type HostModuleLog struct {
 	logic     *Logics
 	header    http.Header
-	instID    []int64
+	instIDArr []int64
 	pre       []metadata.ModuleHost
 	cur       []metadata.ModuleHost
 	hostInfos []map[string]interface{}
@@ -94,11 +94,11 @@ type HostModuleLog struct {
 
 func (lgc *Logics) NewHostModuleLog(header http.Header, instID []int64) *HostModuleLog {
 	return &HostModuleLog{
-		logic:  lgc,
-		instID: instID,
-		pre:    make([]metadata.ModuleHost, 0),
-		cur:    make([]metadata.ModuleHost, 0),
-		header: header,
+		logic:     lgc,
+		instIDArr: instID,
+		pre:       make([]metadata.ModuleHost, 0),
+		cur:       make([]metadata.ModuleHost, 0),
+		header:    header,
 	}
 }
 
@@ -257,7 +257,7 @@ func (h *HostModuleLog) SaveAudit(appID, user, desc string) error {
 }
 
 func (h *HostModuleLog) getHostModuleConfig() ([]metadata.ModuleHost, error) {
-	conds := map[string][]int64{common.BKHostIDField: h.instID}
+	conds := map[string][]int64{common.BKHostIDField: h.instIDArr}
 	result, err := h.logic.CoreAPI.HostController().Module().GetModulesHostConfig(context.Background(), h.header, conds)
 	if err != nil || (err == nil && !result.Result) {
 		return nil, fmt.Errorf("%v, %v", err, result.ErrMsg)
@@ -268,9 +268,9 @@ func (h *HostModuleLog) getHostModuleConfig() ([]metadata.ModuleHost, error) {
 func (h *HostModuleLog) getInnerIP() ([]map[string]interface{}, error) {
 	query := &metadata.QueryInput{
 		Start:     0,
-		Limit:     len(h.instID),
+		Limit:     len(h.instIDArr),
 		Sort:      common.BKAppIDField,
-		Condition: common.KvMap{common.BKHostIDField: common.KvMap{common.BKDBIN: h.instID}},
+		Condition: common.KvMap{common.BKHostIDField: common.KvMap{common.BKDBIN: h.instIDArr}},
 		Fields:    fmt.Sprintf("%s,%s", common.BKHostIDField, common.BKHostInnerIPField),
 	}
 

--- a/src/scene_server/host_server/logics/log.go
+++ b/src/scene_server/host_server/logics/log.go
@@ -268,7 +268,7 @@ func (h *HostModuleLog) getHostModuleConfig() ([]metadata.ModuleHost, error) {
 func (h *HostModuleLog) getInnerIP() ([]map[string]interface{}, error) {
 	query := &metadata.QueryInput{
 		Start:     0,
-		Limit:     1,
+		Limit:     len(h.instID),
 		Sort:      common.BKAppIDField,
 		Condition: common.KvMap{common.BKHostIDField: common.KvMap{common.BKDBIN: h.instID}},
 		Fields:    fmt.Sprintf("%s,%s", common.BKHostIDField, common.BKHostInnerIPField),

--- a/src/scene_server/host_server/service/module.go
+++ b/src/scene_server/host_server/service/module.go
@@ -563,13 +563,13 @@ func (s *Service) moveHostToModuleByName(req *restful.Request, resp *restful.Res
 			return
 		}
 
-		user := util.GetUser(pheader)
-		if err := audit.SaveAudit(strconv.FormatInt(conf.ApplicationID, 10), user, "host to "+moduleNameLogKey+" module"); err != nil {
-			blog.Errorf("move host to module %s, save audit log failed, err: %v", moduleName, err)
-			resp.WriteError(http.StatusBadRequest, &metadata.RespError{Msg: defErr.Errorf(common.CCErrCommResourceInitFailed, "audit server")})
-			return
-		}
+	}
 
+	user := util.GetUser(pheader)
+	if err := audit.SaveAudit(strconv.FormatInt(conf.ApplicationID, 10), user, "host to "+moduleNameLogKey+" module"); err != nil {
+		blog.Errorf("move host to module %s, save audit log failed, err: %v", moduleName, err)
+		resp.WriteError(http.StatusBadRequest, &metadata.RespError{Msg: defErr.Errorf(common.CCErrCommResourceInitFailed, "audit server")})
+		return
 	}
 	resp.WriteEntity(metadata.NewSuccessResp(nil))
 }


### PR DESCRIPTION


### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- 批量转移主机模块，操作审计日志只记录了第一个机器的数据


close #979 
