### PR TITLE
LoginPage跳转时使用302而不是301 

### DIFF
--- a/src/web_server/application/controllers/login.go
+++ b/src/web_server/application/controllers/login.go
@@ -33,7 +33,7 @@ func LogOutUser(c *gin.Context) {
 	loginPage := fmt.Sprintf(loginURL, appCode, site)
 	session := sessions.Default(c)
 	session.Clear()
-	c.Redirect(301, loginPage)
+	c.Redirect(302, loginPage)
 }
 
 func init() {

--- a/src/web_server/application/middleware/login.go
+++ b/src/web_server/application/middleware/login.go
@@ -93,7 +93,7 @@ func ValidLogin(params ...string) gin.HandlerFunc {
 				})
 				return
 			} else {
-				c.Redirect(301, loginPage)
+				c.Redirect(302, loginPage)
 			}
 
 		}


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- 跳转到登录页面时， HTTP 状态使用302而不是301 
### 修复的问题：
- xxxx

close #1027 


