### PR TITLE
修复资源池根据云区域查询已分配主机无效 

### DIFF
--- a/src/scene_server/host_server/logics/host.go
+++ b/src/scene_server/host_server/logics/host.go
@@ -434,7 +434,7 @@ func (lgc *Logics) SearchHost(pheader http.Header, data *metadata.HostCommonSear
 		return nil, err
 	}
 
-	if len(appCond.Condition) > 0 || len(setCond.Condition) > 0 || len(moduleCond.Condition) > 0 || -1 != data.AppID {
+	if len(appCond.Condition) > 0 || len(setCond.Condition) > 0 || len(moduleCond.Condition) > 0 || len(objectCondMap) > 0 || -1 != data.AppID {
 		hostCond.Condition = append(hostCond.Condition, metadata.ConditionItem{
 			Field:    common.BKHostIDField,
 			Operator: common.BKDBIN,

--- a/src/scene_server/host_server/logics/object.go
+++ b/src/scene_server/host_server/logics/object.go
@@ -209,7 +209,7 @@ func (lgc *Logics) GetObjectInstByCond(pheader http.Header, objID string, cond [
 	query := &meta.QueryInput{
 		Condition: condc,
 		Start:     0,
-		Limit:     1,
+		Limit:     common.BKNoLimit,
 		Sort:      common.BKAppIDField,
 	}
 	result, err := lgc.CoreAPI.ObjectController().Instance().SearchObjects(context.Background(), objType, pheader, query)


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- 修复资源池根据云区域查询已分配主机无效


 close #1040
