### PR TITLE
解决 后台配置-权限管理-无法单独保存查询权限

### DIFF
--- a/src/common/backbone/configcenter/cc.go
+++ b/src/common/backbone/configcenter/cc.go
@@ -230,12 +230,12 @@ func (c *CC) syncProc() {
 
 	c.Lock()
 	if reflect.DeepEqual(conf, c.previousProc) {
-		blog.V(5).Infof("sync process config, but nothing is changed.")
+		blog.V(4).Infof("sync process config, but nothing is changed.")
 		c.Unlock()
 		return
 	}
-	blog.V(5).Infof("sync process[%s] config, before change is: %+#v", c.procName, *(c.previousProc))
-	blog.V(5).Infof("sync process[%s] config, after change is: %+#v", c.procName, *conf)
+	blog.V(4).Infof("sync process[%s] config, before change is: %+#v", c.procName, *(c.previousProc))
+	blog.V(4).Infof("sync process[%s] config, after change is: %+#v", c.procName, *conf)
 
 	event := &crd.DiscoverEvent{
 		Err:  nil,

--- a/src/scene_server/topo_server/service/privilege.go
+++ b/src/scene_server/topo_server/service/privilege.go
@@ -24,7 +24,6 @@ import (
 func (s *topoService) UpdateUserGroupPrivi(params types.ContextParams, pathParams, queryParams ParamsGetter, data frtypes.MapStr) (interface{}, error) {
 
 	priviData := &metadata.PrivilegeUserGroup{}
-
 	_, err := priviData.Parse(data)
 	if nil != err {
 		blog.Errorf("[api-privilege] failed to parse the input data, error info is %s ", err.Error())

--- a/src/source_controller/objectcontroller/app/server.go
+++ b/src/source_controller/objectcontroller/app/server.go
@@ -73,7 +73,7 @@ func Run(ctx context.Context, op *options.ServerOption) error {
 
 	objCtr := new(ObjectController)
 	objCtr.Core, err = backbone.NewBackbone(ctx, op.ServConf.RegDiscover,
-		types.CC_MODULE_HOSTCONTROLLER,
+		types.CC_MODULE_OBJECTCONTROLLER,
 		op.ServConf.ExConfig,
 		objCtr.onObjectConfigUpdate,
 		bonC)

--- a/src/source_controller/objectcontroller/service/privilege_action.go
+++ b/src/source_controller/objectcontroller/service/privilege_action.go
@@ -27,7 +27,6 @@ import (
 
 //CreateUserGroupPrivi create group privi
 func (cli *Service) CreateUserGroupPrivi(req *restful.Request, resp *restful.Response) {
-	blog.V(3).Infof("create user group privi")
 	// get the language
 	language := util.GetActionLanguage(req)
 	ownerID := util.GetOwnerID(req.Request.Header)
@@ -58,6 +57,30 @@ func (cli *Service) CreateUserGroupPrivi(req *restful.Request, resp *restful.Res
 	data[common.BKUserGroupIDField] = groupID
 	data[common.BKPrivilegeField] = info
 	data = util.SetModOwner(data, ownerID)
+
+	cond := make(map[string]interface{})
+	cond[common.BKOwnerIDField] = ownerID
+	cond[common.BKUserGroupIDField] = groupID
+	cond = util.SetModOwner(cond, ownerID)
+	cnt, err := cli.Instance.GetCntByCondition(common.BKTableNameUserGroupPrivilege, cond)
+	if nil != err && !cli.Instance.IsNotFoundErr(err) {
+		blog.Error("get user group privi error :%v", err)
+		resp.WriteError(http.StatusBadRequest, &meta.RespError{Msg: defErr.New(common.CCErrObjectDBOpErrno, err.Error())})
+		return
+	}
+	if cnt > 0 {
+		blog.V(3).Infof("update user group privi: %+v, by condition %+v ", data, cond)
+		err = cli.Instance.UpdateByCondition(common.BKTableNameUserGroupPrivilege, data, cond)
+		if nil != err {
+			blog.Error("update user group privi error :%v", err)
+			resp.WriteError(http.StatusBadRequest, &meta.RespError{Msg: defErr.New(common.CCErrObjectDBOpErrno, err.Error())})
+			return
+		}
+		resp.WriteEntity(meta.Response{BaseResp: meta.SuccessBaseResp})
+		return
+	}
+
+	blog.V(3).Infof("create user group privi: %+v", data)
 	_, err = cli.Instance.Insert(common.BKTableNameUserGroupPrivilege, data)
 	if nil != err {
 		blog.Error("insert user group privi error :%v", err)
@@ -104,6 +127,7 @@ func (cli *Service) UpdateUserGroupPrivi(req *restful.Request, resp *restful.Res
 	cond[common.BKUserGroupIDField] = groupID
 	data[common.BKPrivilegeField] = info
 	cond = util.SetModOwner(cond, ownerID)
+	blog.V(3).Infof("update user group privi: %+v, by condition %+v ", data, cond)
 	err = cli.Instance.UpdateByCondition(common.BKTableNameUserGroupPrivilege, data, cond)
 	if nil != err {
 		blog.Error("update user group privi error :%v", err)
@@ -115,7 +139,6 @@ func (cli *Service) UpdateUserGroupPrivi(req *restful.Request, resp *restful.Res
 
 //GetUserGroupPrivi get group privi
 func (cli *Service) GetUserGroupPrivi(req *restful.Request, resp *restful.Response) {
-	blog.V(3).Infof("get user group privi")
 	//get the language
 	language := util.GetActionLanguage(req)
 	ownerID := util.GetOwnerID(req.Request.Header)
@@ -130,6 +153,7 @@ func (cli *Service) GetUserGroupPrivi(req *restful.Request, resp *restful.Respon
 	cond[common.BKUserGroupIDField] = groupID
 	cond = util.SetModOwner(cond, ownerID)
 
+	blog.V(3).Infof("get user group privi by condition %+v", cond)
 	cnt, err := cli.Instance.GetCntByCondition(common.BKTableNameUserGroupPrivilege, cond)
 	if nil != err && !cli.Instance.IsNotFoundErr(err) {
 		blog.Error("get user group privi error :%v", err)
@@ -141,6 +165,7 @@ func (cli *Service) GetUserGroupPrivi(req *restful.Request, resp *restful.Respon
 		data[common.BKOwnerIDField] = ownerID
 		data[common.BKUserGroupIDField] = groupID
 		data[common.BKPrivilegeField] = common.KvMap{}
+		blog.V(3).Infof("get user group privi by condition %+v, returns %+v", cond, data)
 		resp.WriteEntity(meta.Response{BaseResp: meta.SuccessBaseResp, Data: data})
 		return
 	}
@@ -153,5 +178,6 @@ func (cli *Service) GetUserGroupPrivi(req *restful.Request, resp *restful.Respon
 		return
 	}
 
+	blog.V(3).Infof("get user group privi by condition %+v, returns %+v", cond, result)
 	resp.WriteEntity(meta.Response{BaseResp: meta.SuccessBaseResp, Data: result})
 }


### PR DESCRIPTION
### 修复的问题：
- 后台配置-权限管理-无法单独保存查询权限
