### PR TITLE
fixbug: 解决保存实例时候 实例关联字段值被清空的bug

### DIFF
--- a/src/scene_server/topo_server/core/operation/inst.go
+++ b/src/scene_server/topo_server/core/operation/inst.go
@@ -768,6 +768,7 @@ func (c *commonInst) FindInstTopo(params types.ContextParams, obj model.Object, 
 		commonInst.ObjID = inst.GetObject().GetID()
 		commonInst.ObjIcon = inst.GetObject().GetIcon()
 		commonInst.InstID = id
+		commonInst.ID = strconv.Itoa(int(id))
 		commonInst.InstName = name
 
 		_, parentInsts, err := c.FindInstParentTopo(params, inst.GetObject(), id, nil)

--- a/src/scene_server/topo_server/core/operation/inst.go
+++ b/src/scene_server/topo_server/core/operation/inst.go
@@ -545,6 +545,7 @@ func (c *commonInst) convertInstIDIntoStruct(params types.ContextParams, asstObj
 
 		if needAsstDetail {
 			instAsstNames = append(instAsstNames, metatype.InstNameAsst{
+				ID:         strconv.Itoa(int(instID)),
 				ObjID:      obj.GetID(),
 				ObjectName: obj.GetName(),
 				ObjIcon:    obj.GetIcon(),
@@ -556,6 +557,7 @@ func (c *commonInst) convertInstIDIntoStruct(params types.ContextParams, asstObj
 		}
 
 		instAsstNames = append(instAsstNames, metatype.InstNameAsst{
+			ID:         strconv.Itoa(int(instID)),
 			ObjID:      obj.GetID(),
 			ObjectName: obj.GetName(),
 			ObjIcon:    obj.GetIcon(),


### PR DESCRIPTION

### 修复的问题：
- 实例关联字段，组织数据时补充 id 取值为 bk_inst_id 值一样
