### PR TITLE
cherry-pick 3.1.1

### DIFF
--- a/src/scene_server/admin_server/command/import.go
+++ b/src/scene_server/admin_server/command/import.go
@@ -215,6 +215,7 @@ func importProcess(db storage.DI, opt *option, cur, tar *ProcessTopo, bizID int6
 				procmod.ModuleName = modulename
 				procmod.BizID = bizID
 				procmod.ProcessID = procID
+				procmod.OwnerID = opt.OwnerID
 				fmt.Printf("--- \033[34minsert process module data: %+v\033[0m\n", procmod)
 				if !opt.dryrun {
 					_, err = db.Insert(common.BKTableNameProcModule, &procmod)
@@ -259,6 +260,7 @@ func importProcess(db storage.DI, opt *option, cur, tar *ProcessTopo, bizID int6
 				procmod.ModuleName = modulename
 				procmod.BizID = bizID
 				procmod.ProcessID = nid
+				procmod.OwnerID = opt.OwnerID
 				fmt.Printf("--- \033[34minsert process module data: %+v\033[0m\n", topo.Data)
 				if !opt.dryrun {
 					_, err = db.Insert(common.BKTableNameProcModule, &procmod)

--- a/src/scene_server/admin_server/command/types.go
+++ b/src/scene_server/admin_server/command/types.go
@@ -131,6 +131,7 @@ type ProModule struct {
 	ProcessID  int64  `json:"bk_process_id" bson:"bk_process_id,omitempty"`
 	ModuleName string `json:"bk_module_name" bson:"bk_module_name,omitempty"`
 	BizID      int64  `json:"bk_biz_id" bson:"bk_biz_id,omitempty"`
+	OwnerID    string `json:"bk_supplier_account" bson:"bk_supplier_account"`
 }
 
 type Process struct {


### PR DESCRIPTION
### 修复的问题：
- 解决推送主机身份缺少进程信息问题
- 解决导入拓扑进程模块映射表缺少开发商字段问题
