### PR TITLE
fix: drop outdate columns after upgrade to v3.2

### DIFF
--- a/src/common/metadata/association.go
+++ b/src/common/metadata/association.go
@@ -13,8 +13,9 @@
 package metadata
 
 import (
-	"configcenter/src/common/mapstr"
 	"time"
+
+	"configcenter/src/common/mapstr"
 )
 
 const (
@@ -249,7 +250,7 @@ func (a *Association) CanUpdate() (field string, can bool) {
 	}
 
 	if a.IsPre != nil {
-		return "is_pre", false
+		return "ispre", false
 	}
 
 	// only on delete, association kind id, alias name can be update.

--- a/src/scene_server/admin_server/upgrader/x18.10.30.01/association.go
+++ b/src/scene_server/admin_server/upgrader/x18.10.30.01/association.go
@@ -171,6 +171,13 @@ func reconcilAsstData(ctx context.Context, db dal.RDB, conf *upgrader.Config) er
 	if err != nil {
 		return err
 	}
+
+	outdateColumns := []string{"bk_object_att_id", "bk_asst_forward"}
+	for _, column := range outdateColumns {
+		if err = db.Table(common.BKTableNameObjAttDes).DropColumn(ctx, column); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
### 修复的问题：
- 升级完成后移除过时的字段
