### PR TITLE
POST method in createobject should put obj in body

### DIFF
--- a/src/apimachinery/toposerver/object/obj.go
+++ b/src/apimachinery/toposerver/object/obj.go
@@ -52,7 +52,7 @@ func (t *object) CreateObject(ctx context.Context, h http.Header, obj metadata.O
 
 	err = t.client.Post().
 		WithContext(ctx).
-		Body(nil).
+		Body(obj).
 		SubResource(subPath).
 		WithHeaders(h).
 		Do().


### PR DESCRIPTION
POST method in createobject should put obj in body, otherwise method
call in handler.go in datacollection will get error invalid
classification() for the object() when create model from discover

### 修复的问题：
when use datacollection discover func, it will call createobject to create model, and in 
cmdb_datacollection log will find error "invalid classification() for the object()" and can
not create model
