### PR TITLE
修复主机筛选operator参数丢失的问题

### DIFF
--- a/src/ui/src/components/hosts/filter/_filter.vue
+++ b/src/ui/src/components/hosts/filter/_filter.vue
@@ -25,7 +25,7 @@
             </div>
             <div class="filter-group"
                 v-for="(property, index) in customFieldProperties"
-                :key="index">
+                :key="property['bk_property_id']">
                 <label class="filter-label">{{getFilterLabel(property)}}</label>
                 <div class="filter-field clearfix">
                     <filter-field-operator class="filter-field-operator fl"

--- a/src/ui/src/views/topology/index.vue
+++ b/src/ui/src/views/topology/index.vue
@@ -421,7 +421,7 @@
                         ...instTopo[0],
                         child: [...internalModule, ...instTopo[0].child]
                     }]
-                    this.setSimplifyAvailable()
+                    // this.setSimplifyAvailable()
                 })
             },
             setSimplifyAvailable () {


### PR DESCRIPTION
### 修复的问题：
- 修复主机筛选切换属性时部分情况下会丢失operator参数的问题
