### PR TITLE
V3.2.x  关联关系导入调整

### DIFF
--- a/src/web_server/middleware/login.go
+++ b/src/web_server/middleware/login.go
@@ -59,6 +59,7 @@ func ValidLogin(config options.Config, disc discovery.DiscoveryInterface) gin.Ha
 				c.JSON(403, gin.H{
 					"status": "access forbidden",
 				})
+				c.Abort()
 				return
 			}
 			//http request header add user
@@ -77,6 +78,7 @@ func ValidLogin(config options.Config, disc discovery.DiscoveryInterface) gin.Ha
 				}
 				url := servers[0]
 				httpclient.ProxyHttp(c, url)
+
 			} else {
 				c.Next()
 			}
@@ -85,11 +87,13 @@ func ValidLogin(config options.Config, disc discovery.DiscoveryInterface) gin.Ha
 				c.JSON(401, gin.H{
 					"status": "log out",
 				})
+				c.Abort()
 				return
 			} else {
 				user := user.NewUser(config, Engine, CacheCli, LoginPlg)
 				url := user.GetLoginUrl(c)
 				c.Redirect(302, url)
+				c.Abort()
 			}
 
 		}


### PR DESCRIPTION
### 新加的功能:
- 导入实例，源-目标约束1:1的时候，如果已经存在关联关系，不可在进行关联操作
### 优化的功能:
- xxxx
### 修复的问题：
-  修复用户没有权限，返回两段JSON格式数据给前端的问题



close #1460  #1458 


@breezelxp 