### PR TITLE
fix: getInstDataByID  should return not found error if the id not exists

### DIFF
--- a/src/scene_server/validator/valid_unique.go
+++ b/src/scene_server/validator/valid_unique.go
@@ -193,7 +193,7 @@ func (valid *ValidMap) getInstDataByID(instID int64) (map[string]interface{}, er
 		return nil, valid.errif.Error(result.Code)
 	}
 	if len(result.Data.Info) == 0 {
-		return nil, nil
+		return nil, valid.errif.Error(common.CCErrCommNotFound)
 	}
 
 	if len(result.Data.Info[0]) > 0 {


### PR DESCRIPTION
### 修复的问题：
- 修复更新实例时的唯一性检查当ID不存在的会panic的问题
