### PR TITLE
fix: 新建主线模型时，主线拓扑实例中缺少默认的实例字段属性 #1562

### DIFF
--- a/src/scene_server/topo_server/core/operation/association_mainline_object.go
+++ b/src/scene_server/topo_server/core/operation/association_mainline_object.go
@@ -13,6 +13,7 @@
 package operation
 
 import (
+	"context"
 	"io"
 
 	"configcenter/src/common"
@@ -202,6 +203,32 @@ func (a *association) CreateMainlineAssociation(params types.ContextParams, data
 	if err = childObj.UpdateMainlineObjectAssociationTo(parentObj.GetID(), currentObj.GetID()); err != nil {
 		blog.Errorf("[operation-asst] update mainline current object's[%s] child object[%s] association to current failed, err: %v",
 			currentObj.GetID(), childObj.GetID(), err)
+		return nil, err
+	}
+
+	attr := &metadata.Attribute{
+		OwnerID:       params.SupplierAccount,
+		ObjectID:      currentObj.GetID(),
+		PropertyID:    common.BKInstNameField,
+		PropertyName:  "名称",
+		PropertyGroup: "default",
+		PropertyIndex: 0,
+		IsSystem:      false,
+		IsAPI:         false,
+		IsRequired:    true,
+		IsPre:         true,
+		PropertyType:  "singlechar",
+		Creator:       "cc_system",
+		IsEditable:    true,
+	}
+
+	rsp, err := a.clientSet.ObjectController().Meta().CreateObjectAtt(context.Background(), params.Header, attr)
+	if nil != err {
+		blog.Errorf("create mainline object, but create default attribute bk_inst_name failed, err: %v", err)
+		return nil, params.Err.Error(common.CCErrCommHTTPDoRequestFailed)
+	}
+
+	if !rsp.Result {
 		return nil, err
 	}
 


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
close #1562 
