### PR TITLE
optimize: optimize the search object instance association api.

### DIFF
--- a/src/scene_server/topo_server/core/inst/association.go
+++ b/src/scene_server/topo_server/core/inst/association.go
@@ -68,7 +68,13 @@ func (cli *inst) setCommonInstAssociation(child Inst, parent Inst) error {
 		return err
 	}
 
-	asstItems, err := cli.searchInstAssociation(childID, parentID, child.GetObject().GetID(), parent.GetObject().GetID())
+	cond := condition.CreateCondition()
+	cond.Field(common.BKInstIDField).Eq(childID)
+	cond.Field(common.BKAsstInstIDField).Eq(parentID)
+	cond.Field(common.BKObjIDField).Eq(child.GetObject().GetID())
+	cond.Field(common.BKAsstObjIDField).Eq(parent.GetObject().GetID())
+
+	asstItems, err := cli.searchInstAssociation(cond)
 	if nil != err {
 		return err
 	}
@@ -128,22 +134,7 @@ func (cli *inst) setCommonInstAssociation(child Inst, parent Inst) error {
 	return nil
 }
 
-func (cli *inst) searchInstAssociation(instID, asstInstID int64, objID, asstObjID string) ([]frtypes.MapStr, error) {
-
-	cond := condition.CreateCondition()
-
-	if 0 < instID {
-		cond.Field(common.BKInstIDField).Eq(instID)
-	}
-	if 0 < asstInstID {
-		cond.Field(common.BKAsstInstIDField).Eq(asstInstID)
-	}
-	if 0 != len(objID) {
-		cond.Field(common.BKObjIDField).Eq(objID)
-	}
-	if 0 != len(asstObjID) {
-		cond.Field(common.BKAsstObjIDField).Eq(asstObjID)
-	}
+func (cli *inst) searchInstAssociation(cond condition.Condition) ([]frtypes.MapStr, error) {
 
 	queryInput := &metatype.QueryInput{}
 	queryInput.Condition = cond.ToMapStr()
@@ -249,7 +240,7 @@ func (cli *inst) GetMainlineChildInst() ([]Inst, error) {
 func (cli *inst) GetParentObjectWithInsts() ([]*ObjectWithInsts, error) {
 
 	result := make([]*ObjectWithInsts, 0)
-	parentObjs, err := cli.target.GetParentObject()
+	objPairs, err := cli.target.GetParentObject()
 	if nil != err {
 		blog.Errorf("[inst-inst] failed to get the object(%s)'s parent, error info is %s", cli.target.GetID(), err.Error())
 		return result, err
@@ -261,17 +252,28 @@ func (cli *inst) GetParentObjectWithInsts() ([]*ObjectWithInsts, error) {
 		return result, err
 	}
 
-	for _, parentObj := range parentObjs {
+	for _, objPair := range objPairs {
 
-		rstObj := &ObjectWithInsts{Object: parentObj}
-		asstItems, err := cli.searchInstAssociation(-1, currInstID, parentObj.GetID(), cli.target.GetID())
+		rstObj := &ObjectWithInsts{Object: objPair.Object}
+		cond := condition.CreateCondition()
+		cond.Field(common.BKAsstInstIDField).Eq(currInstID)
+		cond.Field(common.BKObjIDField).Eq(objPair.Object.GetID())
+		cond.Field(common.BKAsstObjIDField).Eq(cli.target.GetID())
+		cond.Field(common.AssociationObjAsstIDField).Eq(objPair.Association.AssociationName)
+
+		asstItems, err := cli.searchInstAssociation(cond)
 		if nil != err {
 			blog.Errorf("[inst-inst] failed to search the inst association, the error info is %s", err.Error())
 			return result, err
 		}
 
-		relation := make(map[int64]int64)
+		// found no noe inst association with this object and association info.
+		// which means that, this object association has not been instantiated.
+		if len(asstItems) == 0 {
+			continue
+		}
 
+		relation := make(map[int64]int64)
 		parentInstIDS := []int64{}
 		for _, item := range asstItems {
 
@@ -292,12 +294,12 @@ func (cli *inst) GetParentObjectWithInsts() ([]*ObjectWithInsts, error) {
 		innerCond := condition.CreateCondition()
 
 		innerCond.Field(metatype.ModelFieldOwnerID).Eq(cli.params.SupplierAccount)
-		innerCond.Field(parentObj.GetInstIDFieldName()).In(parentInstIDS)
-		if parentObj.IsCommon() {
-			innerCond.Field(metatype.ModelFieldObjectID).Eq(parentObj.GetID())
+		innerCond.Field(objPair.Object.GetInstIDFieldName()).In(parentInstIDS)
+		if objPair.Object.IsCommon() {
+			innerCond.Field(metatype.ModelFieldObjectID).Eq(objPair.Object.GetID())
 		}
 
-		rspItems, err := cli.searchInsts(parentObj, innerCond)
+		rspItems, err := cli.searchInsts(objPair.Object, innerCond)
 		if nil != err {
 			blog.Errorf("[inst-inst] failed to search the insts by the condition(%#v), error info is %s", innerCond, err.Error())
 			return result, err
@@ -320,66 +322,11 @@ func (cli *inst) GetParentObjectWithInsts() ([]*ObjectWithInsts, error) {
 	return result, nil
 }
 
-func (cli *inst) GetParentInst() ([]Inst, error) {
-
-	parentObjs, err := cli.target.GetParentObject()
-	if nil != err {
-		blog.Errorf("[inst-inst] failed to get the object(%s)'s parent, error info is %s", cli.target.GetID(), err.Error())
-		return nil, err
-	}
-
-	currInstID, err := cli.GetInstID()
-	if nil != err {
-		blog.Errorf("[inst-inst] failed to get the inst id, error info is %s", err.Error())
-		return nil, err
-	}
-
-	result := make([]Inst, 0)
-
-	for _, parentObj := range parentObjs {
-		asstItems, err := cli.searchInstAssociation(-1, currInstID, parentObj.GetID(), cli.target.GetID())
-		if nil != err {
-			blog.Errorf("[inst-inst] failed to search the inst association, the error info is %s", err.Error())
-			return nil, err
-		}
-
-		parentInstIDS := []int64{}
-		for _, item := range asstItems {
-
-			parentInstID, err := item.Int64(common.BKInstIDField)
-			if nil != err {
-				blog.Errorf("[inst-inst] failed to parse the asst inst id, error info is %s", err.Error())
-				return nil, err
-			}
-
-			parentInstIDS = append(parentInstIDS, parentInstID)
-		}
-
-		innerCond := condition.CreateCondition()
-		innerCond.Field(metatype.ModelFieldOwnerID).Eq(cli.params.SupplierAccount)
-		innerCond.Field(parentObj.GetInstIDFieldName()).In(parentInstIDS)
-		if parentObj.IsCommon() {
-			innerCond.Field(metatype.ModelFieldObjectID).Eq(parentObj.GetID())
-		}
-
-		rspItems, err := cli.searchInsts(parentObj, innerCond)
-		if nil != err {
-			blog.Errorf("[inst-asst] failed to search the insts by the condition(%#v), error info is %s", innerCond, err.Error())
-			return nil, err
-		}
-
-		result = append(result, rspItems...)
-
-	}
-
-	return result, nil
-}
-
 func (cli *inst) GetChildObjectWithInsts() ([]*ObjectWithInsts, error) {
 
 	result := make([]*ObjectWithInsts, 0)
 
-	childObjs, err := cli.target.GetChildObject()
+	objPairs, err := cli.target.GetChildObject()
 	if nil != err {
 		blog.Errorf("[inst-inst] failed to get the object(%s)'s child, error info is %s", cli.target.GetID(), err.Error())
 		return result, err
@@ -391,13 +338,25 @@ func (cli *inst) GetChildObjectWithInsts() ([]*ObjectWithInsts, error) {
 		return result, err
 	}
 
-	for _, childObj := range childObjs {
+	for _, objPair := range objPairs {
 
-		rstObj := &ObjectWithInsts{Object: childObj}
-		asstItems, err := cli.searchInstAssociation(currInstID, -1, cli.target.GetID(), childObj.GetID())
+		rstObj := &ObjectWithInsts{Object: objPair.Object}
+		cond := condition.CreateCondition()
+		cond.Field(common.BKInstIDField).Eq(currInstID)
+		cond.Field(common.BKObjIDField).Eq(cli.target.GetID())
+		cond.Field(common.BKAsstObjIDField).Eq(objPair.Object.GetID())
+		cond.Field(common.AssociationObjAsstIDField).Eq(objPair.Association.AssociationName)
+
+		asstItems, err := cli.searchInstAssociation(cond)
 		if nil != err {
 			blog.Errorf("[inst-inst] failed to search the inst association,  the error info is %s", err.Error())
 			return result, err
+		}
+
+		// found no noe inst association with this object and association info.
+		// which means that, this object association has not been instantiated.
+		if len(asstItems) == 0 {
+			continue
 		}
 
 		relations := make(map[int64]int64, 0)
@@ -421,12 +380,12 @@ func (cli *inst) GetChildObjectWithInsts() ([]*ObjectWithInsts, error) {
 
 		innerCond := condition.CreateCondition()
 		innerCond.Field(metatype.ModelFieldOwnerID).Eq(cli.params.SupplierAccount)
-		innerCond.Field(childObj.GetInstIDFieldName()).In(childInstIDS)
-		if childObj.IsCommon() {
-			innerCond.Field(metatype.ModelFieldObjectID).Eq(childObj.GetID())
+		innerCond.Field(objPair.Object.GetInstIDFieldName()).In(childInstIDS)
+		if objPair.Object.IsCommon() {
+			innerCond.Field(metatype.ModelFieldObjectID).Eq(objPair.Object.GetID())
 		}
 
-		rspItems, err := cli.searchInsts(childObj, innerCond)
+		rspItems, err := cli.searchInsts(objPair.Object, innerCond)
 		if nil != err {
 			blog.Errorf("[inst-inst] failed to search the insts by the condition(%#v), error info is %s", innerCond, err.Error())
 			return result, err
@@ -444,59 +403,6 @@ func (cli *inst) GetChildObjectWithInsts() ([]*ObjectWithInsts, error) {
 
 		rstObj.Insts = rspItems
 		result = append(result, rstObj)
-	}
-
-	return result, nil
-}
-func (cli *inst) GetChildInst() ([]Inst, error) {
-
-	childObjs, err := cli.target.GetChildObject()
-	if nil != err {
-		blog.Errorf("[inst-inst] failed to get the object(%s)'s child, error info is %s", cli.target.GetID(), err.Error())
-		return nil, err
-	}
-
-	currInstID, err := cli.GetInstID()
-	if nil != err {
-		blog.Errorf("[inst-inst] failed to get the inst id, error info is %s", err.Error())
-		return nil, err
-	}
-
-	result := make([]Inst, 0)
-
-	for _, childObj := range childObjs {
-
-		asstItems, err := cli.searchInstAssociation(currInstID, -1, cli.target.GetID(), childObj.GetID())
-		if nil != err {
-			blog.Errorf("[inst-inst] failed to search the inst association,  the error info is %s", err.Error())
-			return nil, err
-		}
-
-		childInstIDS := []int64{}
-		for _, item := range asstItems {
-
-			childInstID, err := item.Int64(common.BKInstIDField)
-			if nil != err {
-				blog.Errorf("[inst-inst] failed to parse the asst inst id, error info is %s", err.Error())
-				return nil, err
-			}
-			childInstIDS = append(childInstIDS, childInstID)
-		}
-
-		innerCond := condition.CreateCondition()
-		innerCond.Field(metatype.ModelFieldOwnerID).Eq(cli.params.SupplierAccount)
-		innerCond.Field(childObj.GetInstIDFieldName()).In(childInstIDS)
-		if childObj.IsCommon() {
-			innerCond.Field(metatype.ModelFieldObjectID).Eq(childObj.GetID())
-		}
-
-		rspItems, err := cli.searchInsts(childObj, innerCond)
-		if nil != err {
-			blog.Errorf("[inst-inst] failed to search the insts by the condition(%#v), error info is %s", innerCond, err.Error())
-			return nil, err
-		}
-
-		result = append(result, rspItems...)
 	}
 
 	return result, nil

--- a/src/scene_server/topo_server/core/inst/inst.go
+++ b/src/scene_server/topo_server/core/inst/inst.go
@@ -37,9 +37,7 @@ type Inst interface {
 	GetMainlineChildInst() ([]Inst, error)
 
 	GetParentObjectWithInsts() ([]*ObjectWithInsts, error)
-	GetParentInst() ([]Inst, error)
 	GetChildObjectWithInsts() ([]*ObjectWithInsts, error)
-	GetChildInst() ([]Inst, error)
 
 	SetParentInst(targetInst Inst) error
 	SetChildInst(targetInst Inst) error

--- a/src/scene_server/topo_server/core/model/object.go
+++ b/src/scene_server/topo_server/core/model/object.go
@@ -43,9 +43,9 @@ type Object interface {
 	GetMainlineParentObject() (Object, error)
 	GetMainlineChildObject() (Object, error)
 
-	GetChildObjectByFieldID(fieldID string) ([]Object, error)
-	GetParentObject() ([]Object, error)
-	GetChildObject() ([]Object, error)
+	// GetChildObjectByFieldID(fieldID string) ([]Object, error)
+	GetParentObject() ([]ObjectAssoPair, error)
+	GetChildObject() ([]ObjectAssoPair, error)
 
 	SetMainlineParentObject(objID string) error
 	// SetMainlineChildObject(objID string) error
@@ -279,14 +279,14 @@ func (o *object) GetMainlineChildObject() (Object, error) {
 	return nil, io.EOF
 }
 
-func (o *object) searchObjects(isNeedChild bool, cond condition.Condition) ([]Object, error) {
+func (o *object) searchAssoObjects(isNeedChild bool, cond condition.Condition) ([]ObjectAssoPair, error) {
 	rsp, err := o.clientSet.ObjectController().Meta().SelectObjectAssociations(context.Background(), o.params.Header, cond.ToMapStr())
 	if nil != err {
 		blog.Errorf("[model-obj] failed to request the object controller, error info is %s", err.Error())
 		return nil, err
 	}
 
-	objItems := make([]Object, 0)
+	pair := make([]ObjectAssoPair, 0)
 	for _, asst := range rsp.Data {
 		cond := condition.CreateCondition()
 		cond.Field(common.BKOwnerIDField).Eq(o.params.SupplierAccount)
@@ -301,37 +301,44 @@ func (o *object) searchObjects(isNeedChild bool, cond condition.Condition) ([]Ob
 			return nil, err
 		}
 
-		objItems = append(objItems, CreateObject(o.params, o.clientSet, rspRst)...)
+		if len(rspRst) == 0 {
+			blog.Errorf("search asso object, but can not found object with cond: %v", cond.ToMapStr())
+			return nil, fmt.Errorf("can not found object %v", cond.ToMapStr())
+		}
+
+		pair = append(pair, ObjectAssoPair{
+			Object:      CreateObject(o.params, o.clientSet, rspRst)[0],
+			Association: asst,
+		})
 
 	}
 
-	return objItems, nil
+	return pair, nil
 }
-func (o *object) GetChildObjectByFieldID(fieldID string) ([]Object, error) {
-	cond := condition.CreateCondition()
-	cond.Field(meta.AssociationFieldSupplierAccount).Eq(o.params.SupplierAccount)
-	cond.Field(meta.AssociationFieldObjectID).Eq(o.obj.ObjectID)
-	// cond.Field(meta.AssociationFieldAssociationName).Eq(fieldID)
 
-	return o.searchObjects(true, cond)
-}
-func (o *object) GetParentObject() ([]Object, error) {
+// func (o *object) GetChildObjectByFieldID(fieldID string) ([]Object, error) {
+// 	cond := condition.CreateCondition()
+// 	cond.Field(meta.AssociationFieldSupplierAccount).Eq(o.params.SupplierAccount)
+// 	cond.Field(meta.AssociationFieldObjectID).Eq(o.obj.ObjectID)
+// 	// cond.Field(meta.AssociationFieldAssociationName).Eq(fieldID)
+//
+// 	return o.searchObjects(true, cond)
+// }
+func (o *object) GetParentObject() ([]ObjectAssoPair, error) {
 
 	cond := condition.CreateCondition()
 	cond.Field(meta.AssociationFieldSupplierAccount).Eq(o.params.SupplierAccount)
 	cond.Field(meta.AssociationFieldAssociationObjectID).Eq(o.obj.ObjectID)
-	// cond.Field(meta.AssociationFieldAssociationName).NotEq(common.BKChildStr)
 
-	return o.searchObjects(false, cond)
+	return o.searchAssoObjects(false, cond)
 }
 
-func (o *object) GetChildObject() ([]Object, error) {
+func (o *object) GetChildObject() ([]ObjectAssoPair, error) {
 	cond := condition.CreateCondition()
 	cond.Field(meta.AssociationFieldSupplierAccount).Eq(o.params.SupplierAccount)
 	cond.Field(meta.AssociationFieldObjectID).Eq(o.obj.ObjectID)
-	// cond.Field(meta.AssociationFieldAssociationName).NotEq(common.BKChildStr)
 
-	return o.searchObjects(true, cond)
+	return o.searchAssoObjects(true, cond)
 }
 
 func (o *object) SetMainlineParentObject(objID string) error {

--- a/src/scene_server/topo_server/core/model/types.go
+++ b/src/scene_server/topo_server/core/model/types.go
@@ -64,3 +64,8 @@ type Factory interface {
 	CreateCommonAssociation(params types.ContextParams, obj Object, asstKey string, asstObj Object) Association
 	CreateMainLineAssociatin(params types.ContextParams, obj Object, asstKey string, asstObj Object) Association
 }
+
+type ObjectAssoPair struct {
+	Object      Object
+	Association metadata.Association
+}


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- when the two objects associated with different object kind if a object instance is associated with only one another object, the search instance topo api should return only one instance.

### 修复的问题：
- xxxx

close #1592