### PR TITLE
3.2.x bugfix

### DIFF
--- a/src/ui/src/components/relation/_topology.vue
+++ b/src/ui/src/components/relation/_topology.vue
@@ -382,7 +382,7 @@
             handleToggleNodeVisibility (legend) {
                 ['prev', 'next'].forEach(type => {
                     legend.node[type].forEach(node => {
-                        const level = legend.node.level === 0 ? [-1, 1] : [legend.node.level]
+                        const level = legend.node.level === 0 ? [-1, 1] : [legend.node.level + 1]
                         if (level.includes(node.level) && node.data['bk_obj_id'] === legend.id) {
                             node.hidden = legend.active
                         }

--- a/src/ui/src/components/relation/_update.vue
+++ b/src/ui/src/components/relation/_update.vue
@@ -295,7 +295,8 @@
                             'bk_asst_id': option['bk_asst_id'],
                             'bk_obj_asst_id': option['bk_obj_asst_id'],
                             'bk_obj_id': this.objId,
-                            'bk_asst_obj_id': option['bk_asst_obj_id']
+                            'bk_asst_obj_id': option['bk_asst_obj_id'],
+                            'bk_inst_id': this.instId
                         }
                     }
                 }).then(data => {

--- a/src/ui/src/components/relation/_update.vue
+++ b/src/ui/src/components/relation/_update.vue
@@ -260,6 +260,10 @@
                             condition: {
                                 'bk_obj_id': this.objId
                             }
+                        },
+                        config: {
+                            requestId: 'getSourceAssocaition',
+                            fromCache: true
                         }
                     }),
                     this.searchObjectAssociation({
@@ -267,6 +271,10 @@
                             condition: {
                                 'bk_asst_obj_id': this.objId
                             }
+                        },
+                        config: {
+                            requestId: 'getTargetAssocaition',
+                            fromCache: true
                         }
                     })
                 ]).then(([dataAsSource, dataAsTarget]) => {

--- a/src/ui/src/components/relation/index.vue
+++ b/src/ui/src/components/relation/index.vue
@@ -97,8 +97,8 @@
             async getRelation () {
                 try {
                     const [dataAsSource, dataAsTarget] = await Promise.all([
-                        this.getObjectAssociation({'bk_obj_id': this.objId}),
-                        this.getObjectAssociation({'bk_asst_obj_id': this.objId})
+                        this.getObjectAssociation({'bk_obj_id': this.objId}, {requestId: 'getSourceAssocaition'}),
+                        this.getObjectAssociation({'bk_asst_obj_id': this.objId}, {requestId: 'getTargetAssocaition'})
                     ])
                     if (dataAsSource.length || dataAsTarget.length) {
                         this.hasRelation = true
@@ -107,9 +107,10 @@
                     this.hasRelation = false
                 }
             },
-            getObjectAssociation (condition) {
+            getObjectAssociation (condition, config) {
                 return this.$store.dispatch('objectAssociation/searchObjectAssociation', {
-                    params: {condition}
+                    params: {condition},
+                    config
                 })
             },
             handleShowUpdate () {

--- a/src/ui/src/components/relation/index.vue
+++ b/src/ui/src/components/relation/index.vue
@@ -96,19 +96,21 @@
         methods: {
             async getRelation () {
                 try {
-                    const data = await this.$store.dispatch('objectAssociation/searchObjectAssociation', {
-                        params: {
-                            condition: {
-                                'bk_obj_id': this.objId
-                            }
-                        }
-                    })
-                    if (data.length) {
+                    const [dataAsSource, dataAsTarget] = await Promise.all([
+                        this.getObjectAssociation({'bk_obj_id': this.objId}),
+                        this.getObjectAssociation({'bk_asst_obj_id': this.objId})
+                    ])
+                    if (dataAsSource.length || dataAsTarget.length) {
                         this.hasRelation = true
                     }
                 } catch (e) {
                     this.hasRelation = false
                 }
+            },
+            getObjectAssociation (condition) {
+                return this.$store.dispatch('objectAssociation/searchObjectAssociation', {
+                    params: {condition}
+                })
             },
             handleShowUpdate () {
                 if (this.activeComponent === 'cmdbRelationUpdate') {

--- a/src/ui/src/components/ui/form/date.vue
+++ b/src/ui/src/components/ui/form/date.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="form-date">
         <bk-date-picker class="form-date-picker"
-            :init-date="initDate"
+            :init-date="initDate || ''"
             :start-date="startDate"
             :end-date="endDate"
             :disabled="disabled"

--- a/src/ui/src/components/ui/form/time.vue
+++ b/src/ui/src/components/ui/form/time.vue
@@ -2,7 +2,7 @@
     <div class="form-time">
         <bk-date-picker class="form-date-picker"
             :timer="true"
-            :init-date="initDate"
+            :init-date="initDate || ''"
             :start-date="startDate"
             :end-date="endDate"
             :disabled="disabled"

--- a/src/ui/src/utils/tools.js
+++ b/src/ui/src/utils/tools.js
@@ -119,7 +119,8 @@ export function getInstFormValues (properties, inst = {}) {
             // const validAsst = (inst[propertyId] || []).filter(asstInst => asstInst.id !== '')
             // values[propertyId] = validAsst.map(asstInst => asstInst['bk_inst_id']).join(',')
         } else if (['date', 'time'].includes(propertyType)) {
-            values[propertyId] = formatTime(inst[propertyId], propertyType === 'date' ? 'YYYY-MM-DD' : 'YYYY-MM-DD HH:mm:ss')
+            const formatedTime = formatTime(inst[propertyId], propertyType === 'date' ? 'YYYY-MM-DD' : 'YYYY-MM-DD HH:mm:ss')
+            values[propertyId] = formatedTime || null
         } else if (['int'].includes(propertyType)) {
             values[propertyId] = ['', undefined].includes(inst[propertyId]) ? null : inst[propertyId]
         } else if (['bool'].includes(propertyType)) {

--- a/src/ui/src/views/custom-query/preview.vue
+++ b/src/ui/src/views/custom-query/preview.vue
@@ -13,7 +13,7 @@
                 @handleSizeChange="handleSizeChange"
                 @handleSortChange="handleSortChange">
                 <template v-for="({id,name, property}, index) in table.header" :slot="id" slot-scope="{ item }">
-                    <template>{{getCellValue(property, item)}}</template>
+                    <template>{{getHostCellText(property, item)}}</template>
                 </template>
             </cmdb-table>
         </div>
@@ -84,56 +84,15 @@
             ...mapActions('hostSearch', [
                 'searchHost'
             ]),
-            getCellValue (property, item) {
-                if (property) {
-                    let bkObjId = property['bk_obj_id']
-                    let value = item[bkObjId][property['bk_property_id']]
-                    if (property['bk_property_id'] === 'bk_module_name') {
-                        let moduleName = []
-                        item.module.map(({bk_module_name: bkModuleName}) => {
-                            moduleName.push(bkModuleName)
-                        })
-                        return moduleName.join(',')
-                    }
-                    if (property['bk_property_id'] === 'bk_set_name') {
-                        let setName = []
-                        item.set.map(({bk_set_name: bksetName}) => {
-                            setName.push(bksetName)
-                        })
-                        return setName.join(',')
-                    }
-                    if (property['bk_property_id'] === 'bk_biz_name') {
-                        let bizName = []
-                        item.biz.map(({bk_biz_name: bkbizName}) => {
-                            bizName.push(bkbizName)
-                        })
-                        return bizName.join(',')
-                    }
-                    if (property['bk_asst_obj_id'] && Array.isArray(value)) {
-                        let tempValue = []
-                        value.map(({bk_inst_name: bkInstName}) => {
-                            if (bkInstName) {
-                                tempValue.push(bkInstName)
-                            }
-                        })
-                        value = tempValue.join(',')
-                    } else if (property['bk_property_type'] === 'date') {
-                        value = this.$tools.formatTime(value, 'YYYY-MM-DD')
-                    } else if (property['bk_property_type'] === 'time') {
-                        value = this.$tools.formatTime(value)
-                    } else if (property['bk_property_type'] === 'enum') {
-                        let option = property.option.find(({id}) => {
-                            return id === value
-                        })
-                        if (option) {
-                            value = option.name
-                        } else {
-                            value = ''
-                        }
-                    }
-                    return value
-                }
-                return ''
+            getHostCellText (property, item) {
+                const objId = property['bk_obj_id']
+                const originalValues = item[objId] instanceof Array ? item[objId] : [item[objId]]
+                let text = []
+                originalValues.forEach(value => {
+                    const flatternedText = this.$tools.getPropertyText(property, value)
+                    flatternedText ? text.push(flatternedText) : void (0)
+                })
+                return text.join(',') || '--'
             },
             getColumnProperty (propertyId, objId) {
                 return this.allProperties.find(property => {

--- a/src/ui/src/views/model-manage/children/field.vue
+++ b/src/ui/src/views/model-manage/children/field.vue
@@ -21,7 +21,7 @@
                         {{fieldTypeMap[item['bk_property_type']]}}
                     </template>
                     <template v-else-if="header.id==='isrequired'">
-                        <i class="bk-icon icon-check-1"></i>
+                        <i class="bk-icon icon-check-1" v-if="item.isrequired"></i>
                     </template>
                     <template v-else-if="header.id==='create_time'">
                         {{$tools.formatTime(item['create_time'])}}

--- a/src/ui/src/views/model-manage/children/field.vue
+++ b/src/ui/src/views/model-manage/children/field.vue
@@ -217,7 +217,7 @@
     }
     .field-table {
         .disabled {
-            color: #ccc;
+            color: #bfc7d2;
         }
     }
 </style>

--- a/src/ui/src/views/model-manage/children/index.vue
+++ b/src/ui/src/views/model-manage/children/index.vue
@@ -85,7 +85,7 @@
         </div>
         <bk-tab class="model-details-tab" :active-name.sync="tab.active">
             <bk-tabpanel name="field" :title="$t('ModelManagement[\'模型字段\']')">
-                <the-field ref="field"></the-field>
+                <the-field ref="field" v-if="tab.active === 'field'"></the-field>
             </bk-tabpanel>
             <bk-tabpanel name="relation" :title="$t('ModelManagement[\'模型关联\']')" :show="activeModel && !specialModel.includes(activeModel['bk_obj_id'])">
                 <the-relation v-if="tab.active === 'relation'"></the-relation>

--- a/src/ui/src/views/model-manage/index.vue
+++ b/src/ui/src/views/model-manage/index.vue
@@ -38,8 +38,8 @@
                             <i class="icon" :class="model['bk_obj_icon']"></i>
                         </div>
                         <div class="model-details">
-                            <p class="model-name">{{model['bk_obj_name']}}</p>
-                            <p class="model-id">{{model['bk_obj_id']}}</p>
+                            <p class="model-name" :title="model['bk_obj_name']">{{model['bk_obj_name']}}</p>
+                            <p class="model-id" :title="model['bk_obj_id']">{{model['bk_obj_id']}}</p>
                         </div>
                         <span class="paused-info" v-if="model['bk_ispaused']">
                             {{$t('ModelManagement["已停用"]')}}
@@ -439,6 +439,7 @@
             }
             .icon-box {
                 float: left;
+                width: 50px;
                 .icon {
                     padding-left: 18px;
                     font-size: 32px;
@@ -448,16 +449,19 @@
             }
             .model-details {
                 float: left;
+                width: 208px;
                 line-height: 16px;
                 margin-top: 20px;
-                padding-left: 10px;
+                padding: 0 10px;
             }
             .model-name {
                 font-size: 14px;
+                @include ellipsis;
             }
             .model-id {
                 font-size: 12px;
                 color: $cmdbBorderColor;
+                @include ellipsis;
             }
         }
     }

--- a/src/ui/src/views/model-manage/index.vue
+++ b/src/ui/src/views/model-manage/index.vue
@@ -46,11 +46,6 @@
                         </span>
                     </li>
                 </ul>
-                <i class="bk-icon icon-angle-double-down"
-                    v-if="classification['bk_objects'].length > 8"
-                    :class="{'rotate': classification.isModelShow}"
-                    @click="toggleModelList(classification)"
-                ></i>
             </li>
         </ul>
         <bk-dialog
@@ -251,9 +246,6 @@
             ...mapActions('objectModel', [
                 'createObject'
             ]),
-            toggleModelList (classification) {
-                classification.isModelShow = !classification.isModelShow
-            },
             showGroupDialog (isEdit, group) {
                 if (isEdit) {
                     this.groupDialog.data.id = group.id

--- a/src/ui/src/views/model-manage/index.vue
+++ b/src/ui/src/views/model-manage/index.vue
@@ -370,7 +370,7 @@
             margin-right: 10px;
         }
         &.sticky {
-            box-shadow: 0 0 8px 1px rgba(0, 0, 0, 0.1);
+            box-shadow: 0 0 8px 1px rgba(0, 0, 0, 0.03);
         }
     }
     .group-list {

--- a/src/ui/src/views/model-manage/index.vue
+++ b/src/ui/src/views/model-manage/index.vue
@@ -1,6 +1,6 @@
 <template>
-    <div class="group-wrapper">
-        <p class="btn-group">
+    <div class="group-wrapper" @scroll="handleWrapperScroll">
+        <p class="btn-group" :class="{sticky: wrapperScroll}">
             <bk-button type="primary"
                 :disabled="!authority.includes('update')"
                 @click="showModelDialog(false)">
@@ -185,6 +185,7 @@
         },
         data () {
             return {
+                wrapperScroll: 0,
                 groupDialog: {
                     isShow: false,
                     isEdit: false,
@@ -246,6 +247,9 @@
             ...mapActions('objectModel', [
                 'createObject'
             ]),
+            handleWrapperScroll () {
+                this.wrapperScroll = this.$el.scrollTop
+            },
             showGroupDialog (isEdit, group) {
                 if (isEdit) {
                     this.groupDialog.data.id = group.id
@@ -348,14 +352,29 @@
 </script>
 
 <style lang="scss" scoped>
+    .group-wrapper {
+        position: relative;
+        height: 100%;
+        padding: 0;
+        overflow-y: auto;
+    }
     .btn-group {
-        margin: 0 0 20px 0;
+        position: sticky;
+        top: 0;
+        left: 0;
+        padding: 20px;
         font-size: 0;
+        z-index: 2;
+        background-color: #fff;
         .bk-primary {
             margin-right: 10px;
         }
+        &.sticky {
+            box-shadow: 0 0 8px 1px rgba(0, 0, 0, 0.1);
+        }
     }
     .group-list {
+        padding: 0 20px 20px;
         .group-item {
             position: relative;
             padding: 10px 0 20px;

--- a/src/ui/src/views/model-manage/index.vue
+++ b/src/ui/src/views/model-manage/index.vue
@@ -479,7 +479,7 @@
             }
             .model-id {
                 font-size: 12px;
-                color: $cmdbBorderColor;
+                color: #bfc7d2;
                 @include ellipsis;
             }
         }


### PR DESCRIPTION
### 优化的功能:
- 调整模型下的部分字体颜色
- 模型过多时，滚动悬浮顶部按钮
- 实例关联管理放开源模型限制
### 修复的问题：
- 修复实例拓扑图例操作UI显示异常的问题
- 修复模型字段是否必填UI显示错误的问题
- 修复实例已有的关联状态显示错误的问题
- 修复创建拓扑节点时间、日期类型传参错误的问题
- 修复模型名称太长时UI异常的问题
- 修复模型分组出现多余的箭头的问题
- 修复动态分组预览云区域显示不正确的问题