### PR TITLE
fix: solve init.py for coreservice

### DIFF
--- a/scripts/init.py
+++ b/scripts/init.py
@@ -367,7 +367,7 @@ def main(argv):
     server_ports={"cmdb_adminserver":60004,"cmdb_apiserver":8080,\
     "cmdb_auditcontroller":50005,"cmdb_datacollection":60005,\
     "cmdb_eventserver":60009,"cmdb_hostcontroller":50002,\
-    "cmdb_hostserver":60001,"cmdb_objectcontroller":50001,\
+    "cmdb_hostserver":60001,"cmdb_objectcontroller":50001,"cmdb_coreservice":50009,\
     "cmdb_proccontroller":50003,"cmdb_procserver":60003,\
     "cmdb_toposerver":60002,"cmdb_webserver":8083}
     try:

--- a/src/scene_server/admin_server/upgrader/x18.12.05.01/addswitchAssociation.go
+++ b/src/scene_server/admin_server/upgrader/x18.12.05.01/addswitchAssociation.go
@@ -14,6 +14,7 @@ package x18_12_05_01
 
 import (
 	"context"
+	"strings"
 
 	"configcenter/src/common"
 	"configcenter/src/common/metadata"
@@ -45,11 +46,11 @@ func addswitchAssociation(ctx context.Context, db dal.RDB, conf *upgrader.Config
 
 func changeNetDeviceTableName(ctx context.Context, db dal.RDB, conf *upgrader.Config) error {
 	err := db.DropTable("cc_Netcollect_Device")
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "ns not found") {
 		return err
 	}
 	err = db.DropTable("cc_Netcollect_Property")
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "ns not found") {
 		return err
 	}
 

--- a/src/scene_server/admin_server/upgrader/x18.12.05.01/pkg.go
+++ b/src/scene_server/admin_server/upgrader/x18.12.05.01/pkg.go
@@ -9,6 +9,7 @@
  * either express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package x18_12_05_01
 
 import (
@@ -20,17 +21,17 @@ import (
 )
 
 func init() {
-	upgrader.RegistUpgrader("x18.12.09.01", upgrade)
+	upgrader.RegistUpgrader("x18.12.05.01", upgrade)
 }
 func upgrade(ctx context.Context, db dal.RDB, conf *upgrader.Config) (err error) {
 	err = addswitchAssociation(ctx, db, conf)
 	if err != nil {
-		blog.Errorf("[upgrade x18.12.09.01] addswitchAssociation error  %s", err.Error())
+		blog.Errorf("[upgrade x18.12.05.01] addswitchAssociation error  %s", err.Error())
 		return err
 	}
 	err = changeNetDeviceTableName(ctx, db, conf)
 	if err != nil {
-		blog.Errorf("[upgrade x18.12.09.01] changeNetDeviceTableName error  %s", err.Error())
+		blog.Errorf("[upgrade x18.12.05.01] changeNetDeviceTableName error  %s", err.Error())
 		return err
 	}
 


### PR DESCRIPTION
### 修复的问题：
- fix: solve init.py for coreservice
- fix: should ignore "ns not found" error when drop table