### PR TITLE
V3.2.x 修复新建模型icon可以为空问题， 优化新加拓扑层级，失败错误提示

### DIFF
--- a/src/scene_server/topo_server/core/model/object.go
+++ b/src/scene_server/topo_server/core/model/object.go
@@ -575,6 +575,9 @@ func (o *object) Create() error {
 		return o.params.Err.Error(common.CCErrCommDuplicateItem)
 	}
 
+	if o.obj.ObjIcon == "" {
+		return o.params.Err.Errorf(common.CCErrCommParamsNeedSet, common.BKObjIconField)
+	}
 	rsp, err := o.clientSet.ObjectController().Meta().CreateObject(context.Background(), o.params.Header, &o.obj)
 
 	if nil != err {

--- a/src/scene_server/topo_server/core/operation/association_mainline_object.go
+++ b/src/scene_server/topo_server/core/operation/association_mainline_object.go
@@ -21,6 +21,7 @@ import (
 	"configcenter/src/common/errors"
 	"configcenter/src/common/mapstr"
 	"configcenter/src/common/metadata"
+	"configcenter/src/common/util"
 	"configcenter/src/scene_server/topo_server/core/model"
 	"configcenter/src/scene_server/topo_server/core/types"
 )
@@ -119,6 +120,11 @@ func (a *association) CreateMainlineAssociation(params types.ContextParams, data
 	if nil != err {
 		blog.Errorf("[operation-asst] failed to check the mainline topo level, error info is %s", err.Error())
 		return nil, err
+	}
+
+	if data.AsstObjID == "" {
+		blog.Errorf("[operation-asst] bk_asst_obj_id empty,rid:%s", util.GetHTTPCCRequestID(params.Header))
+		return nil, params.Err.Errorf(common.CCErrCommParamsNeedSet, common.BKAsstObjIDField)
 	}
 
 	items, err := a.SearchMainlineAssociationTopo(params, bizObj)


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- 优化新加拓扑层级，失败错误提示
### 修复的问题：
- 修复新建模型icon可以为空问题

close #1716  close #1715 

@breezelxp 
