### PR TITLE
 fix:if the value is nil in mapstr, then return the origin by $eq

### DIFF
--- a/src/common/universalsql/mongo/condition_private.go
+++ b/src/common/universalsql/mongo/condition_private.go
@@ -45,7 +45,9 @@ func parseConditionFromMapStr(inputCond *mongoCondition, inputKey string, inputC
 				return err
 			}
 
-		case universalsql.EQ, universalsql.NEQ, universalsql.GT, universalsql.GTE, universalsql.LTE, universalsql.LT, universalsql.IN, universalsql.NIN, universalsql.REGEX, universalsql.EXISTS:
+		case universalsql.EQ, universalsql.NEQ,
+			universalsql.GT, universalsql.GTE, universalsql.LTE, universalsql.LT,
+			universalsql.IN, universalsql.NIN, universalsql.REGEX, universalsql.EXISTS:
 			ele, err := convertToElement(inputKey, operatorKey, val, outputCond, inputCondMapStr)
 			if nil != err {
 				return err
@@ -55,7 +57,9 @@ func parseConditionFromMapStr(inputCond *mongoCondition, inputKey string, inputC
 
 			tmpType := reflect.TypeOf(val)
 			if nil == tmpType {
-				return nil // val is nil , ignore this operation
+				// val is nil , return origin by $eq
+				outputCond.Element(&Eq{Key: operatorKey, Val: val})
+				return nil
 			}
 
 			switch tmpType.Kind() {

--- a/src/common/universalsql/mongo/condition_test.go
+++ b/src/common/universalsql/mongo/condition_test.go
@@ -117,3 +117,29 @@ func TestIssue1708(t *testing.T) {
 	t.Logf("t:%#v", cond.ToMapStr())
 
 }
+
+func TestIssue1738(t *testing.T) {
+	cond := mongo.NewCondition()
+	cond.Element(&mongo.Eq{Key: "bk_set_name", Val: nil})
+	cond.Element(&mongo.Eq{Key: "bk_set_id", Val: nil})
+	cond.Element(&mongo.Eq{Key: "bk_biz_id", Val: nil})
+	cond.Element(&mongo.Eq{Key: "bk_parent_id", Val: 2})
+	cond.Element(&mongo.In{Key: "bk_parent_in_nil", Val: nil})
+	cond.Element(&mongo.Neq{Key: "bk_data_status", Val: "disabled"})
+
+	result, err := cond.ToSQL()
+	require.NoError(t, err)
+	t.Logf("sql:%s", result)
+
+	inputMapStr := cond.ToMapStr()
+
+	outCond := mongo.NewCondition()
+	for i := 0; i <= 1; i++ {
+		outCond, err = mongo.NewConditionFromMapStr(inputMapStr)
+		require.NoError(t, err)
+	}
+
+	result, err = outCond.ToSQL()
+	require.NoError(t, err)
+	t.Logf("sql_1738:%s", result)
+}


### PR DESCRIPTION

### 修复的问题：
-  fix:if the value is nil in mapstr, then return the origin by $eq
