### PR TITLE
create mainline测试用例运行失败处理：新增 bk_classification_id 为空的校验

### DIFF
--- a/src/scene_server/topo_server/core/operation/association_mainline_object.go
+++ b/src/scene_server/topo_server/core/operation/association_mainline_object.go
@@ -127,6 +127,11 @@ func (a *association) CreateMainlineAssociation(params types.ContextParams, data
 		return nil, params.Err.Errorf(common.CCErrCommParamsNeedSet, common.BKAsstObjIDField)
 	}
 
+	if data.ClassificationID == "" {
+		blog.Errorf("[operation-asst] bk_classification_id empty,rid:%s", util.GetHTTPCCRequestID(params.Header))
+		return nil, params.Err.Errorf(common.CCErrCommParamsNeedSet, common.BKClassificationIDField)
+	}
+
 	items, err := a.SearchMainlineAssociationTopo(params, bizObj)
 	if nil != err {
 		blog.Errorf("[operation-asst] failed to check the mainline topo level, error info is %s", err.Error())


### PR DESCRIPTION
### 修复的问题：
- create mainline object 测试用例运行失败，增加 ClassificationID 为空的校验
