### PR TITLE
fix: ignore duplicated error

### DIFF
--- a/src/scene_server/admin_server/upgrader/x18.10.30.01/association.go
+++ b/src/scene_server/admin_server/upgrader/x18.10.30.01/association.go
@@ -175,7 +175,7 @@ func reconcilAsstData(ctx context.Context, db dal.RDB, conf *upgrader.Config) er
 
 		updateInstCond := condition.CreateCondition()
 		updateInstCond.Field("bk_obj_id").Eq(asst.ObjectID)
-		updateInstCond.Field("bk_asst_id").Eq(asst.AsstObjID)
+		updateInstCond.Field("bk_asst_obj_id").Eq(asst.AsstObjID)
 		err = db.Table(common.BKTableNameInstAsst).Update(ctx, updateInstCond.ToMapStr(), updateInst)
 		if err != nil {
 			return err

--- a/src/scene_server/event_server/distribution/start.go
+++ b/src/scene_server/event_server/distribution/start.go
@@ -88,7 +88,7 @@ func migrateIDToMongo(ctx context.Context, cache *redis.Client, db dal.RDB) erro
 	}
 
 	err = db.Table(common.BKTableNameIDgenerator).Insert(ctx, docs)
-	if err != nil {
+	if err != nil && !db.IsDuplicatedError(err) {
 		return err
 	}
 


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- fix: 迁移事件ID到mongoDB时，忽略重复提示的错误
