### PR TITLE
add restrict for instance batch update interface, which will update a…

### DIFF
--- a/src/scene_server/topo_server/service/inst.go
+++ b/src/scene_server/topo_server/service/inst.go
@@ -13,6 +13,7 @@
 package service
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -59,6 +60,7 @@ func (s *topoService) CreateInst(params types.ContextParams, pathParams, queryPa
 
 	return setInst.ToMapStr(), nil
 }
+
 func (s *topoService) DeleteInsts(params types.ContextParams, pathParams, queryParams ParamsGetter, data frtypes.MapStr) (interface{}, error) {
 
 	obj, err := s.core.ObjectOperation().FindSingleObject(params, pathParams("obj_id"))
@@ -105,6 +107,18 @@ func (s *topoService) UpdateInsts(params types.ContextParams, pathParams, queryP
 	if err := data.MarshalJSONInto(updateCondition); nil != err {
 		blog.Errorf("[api-inst] failed to parse the input data(%v), error info is %s", data, err.Error())
 		return nil, err
+	}
+
+	// check inst_id field to be not empty, is dangerous for empty inst_id field, which will update or delete all instance
+	for idx, item := range updateCondition.Update {
+		if item.InstID == 0 {
+			return nil, fmt.Errorf("%d's update item's field `inst_id` emtpy", idx)
+		}
+	}
+	for idx, instID := range updateCondition.Delete.InstID {
+		if instID == 0 {
+			return nil, fmt.Errorf("%d's delete item's field `inst_id` emtpy", idx)
+		}
 	}
 
 	obj, err := s.core.ObjectOperation().FindSingleObject(params, objID)

--- a/src/scene_server/topo_server/service/inst.go
+++ b/src/scene_server/topo_server/service/inst.go
@@ -49,6 +49,7 @@ func (s *topoService) CreateInst(params types.ContextParams, pathParams, queryPa
 			blog.Errorf("failed to create a new %s, %s", objID, err.Error())
 			return nil, err
 		}
+		blog.V(5).Infof("create instances with batch method, result: %+v", setInst)
 		return setInst, nil
 	}
 
@@ -99,6 +100,7 @@ func (s *topoService) DeleteInst(params types.ContextParams, pathParams, queryPa
 	err = s.core.InstOperation().DeleteInstByInstID(params, obj, []int64{instID}, true)
 	return nil, err
 }
+
 func (s *topoService) UpdateInsts(params types.ContextParams, pathParams, queryParams ParamsGetter, data frtypes.MapStr) (interface{}, error) {
 
 	objID := pathParams("obj_id")


### PR DESCRIPTION
### 优化的功能:
- 接口设计上，3.1 中的批量更新实例接口，如果用户不小心把 bk_inst_id 字段传错了，那么这个接口的操作就是对所有实例的更新
