### PR TITLE
fix:host transfer default module ,can has other module issue #1978

### DIFF
--- a/src/source_controller/hostcontroller/logics/logics.go
+++ b/src/source_controller/hostcontroller/logics/logics.go
@@ -19,7 +19,6 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/redis.v5"
 	"net/http"
-	
 
 	"configcenter/src/common"
 	"configcenter/src/common/backbone"
@@ -225,9 +224,9 @@ func (lgc *Logics) GetModuleIDsByHostID(ctx context.Context, moduleCond interfac
 }
 
 //GetHostIDModuleIDMapsByHostID get hsot id and module id by hostid return map[hostid]moduleid
-func (lgc *Logics) GetHostIDModuleIDMapsByHostID(ctx context.Context, moduleCond interface{}, header http.Header) (map[int64]int64, error) {
+func (lgc *Logics) GetHostIDModuleIDMapsByHostID(ctx context.Context, moduleCond interface{}, header http.Header) (map[int64][]int64, error) {
 	result := make([]metadata.ModuleHost, 0)
-	ret := make(map[int64]int64, 0)
+	ret := make(map[int64][]int64, 0)
 	rid := util.GetHTTPCCRequestID(header)
 	defErr := lgc.CCErr.CreateDefaultCCErrorIf(util.GetLanguage(header))
 	fileds := []string{common.BKModuleIDField, common.BKSetIDField, common.BKAppIDField, common.BKHostIDField}
@@ -238,7 +237,7 @@ func (lgc *Logics) GetHostIDModuleIDMapsByHostID(ctx context.Context, moduleCond
 	}
 
 	for _, r := range result {
-		ret[r.HostID] = r.ModuleID
+		ret[r.HostID] = append(ret[r.HostID], r.ModuleID)
 	}
 	return ret, nil
 }
@@ -355,11 +354,13 @@ func (lgc *Logics) TransferHostToDefaultModuleConfig(ctx context.Context, input 
 		return err
 	}
 
-	for hostID, moduleID := range hostIDModuleIDMap {
-		_, err := lgc.DelSingleHostModuleRelation(ctx, header, hostID, moduleID, input.ApplicationID, ownerID)
-		if nil != err {
-			blog.Errorf("TransferHostToDefaultModuleConfig  DelSingleHostModuleRelation , input:%#v, hostID:%v,moduleID:%v, err: %v,rid:%s", input, hostID, moduleID, err, rid)
-			return err
+	for hostID, moduleIDArr := range hostIDModuleIDMap {
+		for _, moduleID := range moduleIDArr {
+			_, err := lgc.DelSingleHostModuleRelation(ctx, header, hostID, moduleID, input.ApplicationID, ownerID)
+			if nil != err {
+				blog.Errorf("TransferHostToDefaultModuleConfig  DelSingleHostModuleRelation , input:%#v, hostID:%v,moduleID:%v, err: %v,rid:%s", input, hostID, moduleID, err, rid)
+				return err
+			}
 		}
 	}
 	for _, hostID := range input.HostID {


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- 修复主机转移到空闲机/故障机模块。当主机属于多个模块的时候，主机的模块没有清除掉


@hoffermei 
