### PR TITLE
进程保存按钮和模型删除按钮鉴权修改，模型页面数据刷新

### DIFF
--- a/src/ui/src/views/model-manage/children/index.vue
+++ b/src/ui/src/views/model-manage/children/index.vue
@@ -75,6 +75,7 @@
                             </span>
                         </label>
                         <label class="label-btn"
+                            v-if="$isAuthorized(OPERATION.D_MODEL)"
                             v-tooltip="$t('ModelManagement[\'删除模型和其下所有实例，此动作不可逆，请谨慎操作\']')"
                             @click="dialogConfirm('delete')">
                             <i class="icon-cc-del"></i>

--- a/src/ui/src/views/model-manage/index.vue
+++ b/src/ui/src/views/model-manage/index.vue
@@ -8,14 +8,14 @@
                     v-if="isAdminView"
                     :disabled="!$isAuthorized(OPERATION.C_MODEL) || modelType === 'disabled'"
                     @click="showModelDialog(false)">
-                    {{$t('ModelManagement["新增模型"]')}}
+                    {{$t('ModelManagement["新建模型"]')}}
                 </bk-button>
                 <bk-button type="primary"
                     v-else
                     v-tooltip="$t('ModelManagement[\'新增模型提示\']')"
                     :disabled="!$isAuthorized(OPERATION.C_MODEL) || modelType === 'disabled'"
                     @click="showModelDialog(false)">
-                    {{$t('ModelManagement["新增模型"]')}}
+                    {{$t('ModelManagement["新建模型"]')}}
                 </bk-button>
                 <bk-button type="default"
                     :disabled="!$isAuthorized(OPERATION.C_MODEL_GROUP) || modelType === 'disabled'"
@@ -127,7 +127,7 @@
         </bk-dialog>
         <the-create-model
             :is-show.sync="modelDialog.isShow"
-            :title="$t('ModelManagement[\'新增模型\']')"
+            :title="$t('ModelManagement[\'新建模型\']')"
             @confirm="saveModel">
         </the-create-model>
     </div>
@@ -212,6 +212,7 @@
                 this.scrollTop = event.target.scrollTop
             }
             addMainScrollListener(this.scrollHandler)
+            this.searchClassificationsObjects({})
         },
         beforeDestroy () {
             removeMainScrollListener(this.scrollHandler)

--- a/src/ui/src/views/process/index.vue
+++ b/src/ui/src/views/process/index.vue
@@ -50,7 +50,7 @@
                         :property-groups="propertyGroups"
                         :inst="attribute.inst.edit"
                         :type="attribute.type"
-                        :save-disabled="!$isAuthorized(OPERATION[attribute.type === 'update'] ? 'U_PROCESS' : 'C_PROCESS')"
+                        :save-disabled="!$isAuthorized(OPERATION[attribute.type === 'update' ? 'U_PROCESS' : 'C_PROCESS'])"
                         @on-submit="handleSave"
                         @on-cancel="handleCancel">
                     </cmdb-form>


### PR DESCRIPTION
### 修复的问题：
- 进程保存按钮权限
- 返回模型页面重新拉取数据
- 模型删除按钮鉴权
