### PR TITLE
search_host接口无法使用"^"符号正则搜索数据 

### DIFF
--- a/src/common/paraparse/app.go
+++ b/src/common/paraparse/app.go
@@ -47,6 +47,10 @@ func ParseCommonParams(input []metadata.ConditionItem, output map[string]interfa
 			} else {
 				output[i.Field] = i.Value
 			}
+		case common.BKDBLIKE:
+			regex := make(map[string]interface{})
+			regex[common.BKDBLIKE] = i.Value
+			output[i.Field] = regex
 
 		default:
 			d := make(map[string]interface{})

--- a/src/common/paraparse/host.go
+++ b/src/common/paraparse/host.go
@@ -66,18 +66,9 @@ func ParseHostParams(input []metadata.ConditionItem, output map[string]interface
 			queryCondItem[i.Operator] = i.Value
 			output[i.Field] = queryCondItem
 		case common.BKDBLIKE:
-			//d := make(map[string]interface{})
-			queryCondItem, ok := output[i.Field].(map[string]interface{})
-			if !ok {
-				queryCondItem = make(map[string]interface{})
-			}
-			valStr, ok := i.Value.(string)
-			if ok {
-				queryCondItem[i.Operator] = SpeceialCharChange(valStr)
-			} else {
-				queryCondItem[i.Operator] = i.Value
-			}
-			output[i.Field] = queryCondItem
+			regex := make(map[string]interface{})
+			regex[common.BKDBLIKE] = i.Value
+			output[i.Field] = regex
 		default:
 			queryCondItem, ok := output[i.Field].(map[string]interface{})
 			if !ok {


### PR DESCRIPTION
修复的问题：
- search_host接口无法使用"^"符号正则搜索数据 

issue:
#2111 
