### PR TITLE
修复3.2关联问题

### DIFF
--- a/src/scene_server/admin_server/imports.go
+++ b/src/scene_server/admin_server/imports.go
@@ -28,6 +28,7 @@ import (
 	_ "configcenter/src/scene_server/admin_server/upgrader/x18.10.30.01"
 	_ "configcenter/src/scene_server/admin_server/upgrader/x18.10.30.02"
 	_ "configcenter/src/scene_server/admin_server/upgrader/x18.11.19.01"
+	_ "configcenter/src/scene_server/admin_server/upgrader/x18.12.12.01"
 	_ "configcenter/src/scene_server/admin_server/upgrader/x18.12.12.02"
 	_ "configcenter/src/scene_server/admin_server/upgrader/x18.12.12.03"
 	_ "configcenter/src/scene_server/admin_server/upgrader/x18.12.12.04"

--- a/src/scene_server/admin_server/imports.go
+++ b/src/scene_server/admin_server/imports.go
@@ -28,7 +28,8 @@ import (
 	_ "configcenter/src/scene_server/admin_server/upgrader/x18.10.30.01"
 	_ "configcenter/src/scene_server/admin_server/upgrader/x18.10.30.02"
 	_ "configcenter/src/scene_server/admin_server/upgrader/x18.11.19.01"
-	_ "configcenter/src/scene_server/admin_server/upgrader/x18.12.12.01"
 	_ "configcenter/src/scene_server/admin_server/upgrader/x18.12.12.02"
 	_ "configcenter/src/scene_server/admin_server/upgrader/x18.12.12.03"
+	_ "configcenter/src/scene_server/admin_server/upgrader/x18.12.12.04"
+	_ "configcenter/src/scene_server/admin_server/upgrader/x18.12.12.05"
 )

--- a/src/scene_server/admin_server/upgrader/x18.10.30.01/association.go
+++ b/src/scene_server/admin_server/upgrader/x18.10.30.01/association.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"configcenter/src/common"
-	"configcenter/src/common/blog"
 	"configcenter/src/common/condition"
 	"configcenter/src/common/mapstr"
 	"configcenter/src/common/metadata"
@@ -131,13 +130,6 @@ func reconcilAsstData(ctx context.Context, db dal.RDB, conf *upgrader.Config) er
 		return err
 	}
 
-	properyMap := map[string]metadata.ObjAttDes{}
-	buildObjPropertyMapKey := func(objID string, propertyID string) string { return fmt.Sprintf("%s:%s", objID, propertyID) }
-	for _, property := range propertys {
-		properyMap[buildObjPropertyMapKey(property.ObjectID, property.PropertyID)] = property
-		blog.Infof("key %s: %+v", buildObjPropertyMapKey(property.ObjectID, property.PropertyID), property)
-	}
-
 	for _, asst := range assts {
 		if asst.ObjectAttID == common.BKChildStr {
 			asst.AsstKindID = common.AssociationKindMainline
@@ -153,16 +145,7 @@ func reconcilAsstData(ctx context.Context, db dal.RDB, conf *upgrader.Config) er
 		} else {
 			asst.AsstKindID = common.AssociationTypeDefault
 			asst.AssociationName = buildObjAsstID(asst)
-			property := properyMap[buildObjPropertyMapKey(asst.ObjectID, asst.ObjectAttID)]
-			switch property.PropertyType {
-			case common.FieldTypeSingleAsst:
-				asst.Mapping = metadata.OneToOneMapping
-			case common.FieldTypeMultiAsst:
-				asst.Mapping = metadata.OneToManyMapping
-			default:
-				blog.Infof("property: %+v, asst: %+v, for key: %v", property, asst, buildObjPropertyMapKey(asst.ObjectID, asst.ObjectAttID))
-				asst.Mapping = metadata.OneToOneMapping
-			}
+			asst.Mapping = metadata.OneToManyMapping
 			asst.OnDelete = metadata.NoAction
 			asst.IsPre = pfalse()
 		}

--- a/src/scene_server/admin_server/upgrader/x18.12.12.04/fix_bk_obj_asst_id.go
+++ b/src/scene_server/admin_server/upgrader/x18.12.12.04/fix_bk_obj_asst_id.go
@@ -22,8 +22,6 @@ import (
 	"configcenter/src/common/metadata"
 	"configcenter/src/scene_server/admin_server/upgrader"
 	"configcenter/src/storage/dal"
-
-	"github.com/rs/xid"
 )
 
 func fixBKObjAsstID(ctx context.Context, db dal.RDB, conf *upgrader.Config) error {
@@ -37,8 +35,8 @@ func fixBKObjAsstID(ctx context.Context, db dal.RDB, conf *upgrader.Config) erro
 	}
 
 	for _, objasst := range objassts {
-		if strings.objasst.AssociationName {
-
+		if countCharacter(objasst.AssociationName, '_') > 1 {
+			continue
 		}
 
 		cond := condition.CreateCondition()
@@ -72,7 +70,7 @@ func buildObjAsstID(asst metadata.Association) string {
 	return fmt.Sprintf("%s_%s_%s", asst.ObjectID, asst.AsstKindID, asst.AsstObjID)
 }
 
-func countSubString(src, sub string) int {
+func countCharacter(src string, sub rune) int {
 	count := 0
 	for _, s := range src {
 		if s == sub {

--- a/src/scene_server/admin_server/upgrader/x18.12.12.04/fix_bk_obj_asst_id.go
+++ b/src/scene_server/admin_server/upgrader/x18.12.12.04/fix_bk_obj_asst_id.go
@@ -1,0 +1,83 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package x18_12_12_04
+
+import (
+	"context"
+	"fmt"
+
+	"configcenter/src/common"
+	"configcenter/src/common/condition"
+	"configcenter/src/common/mapstr"
+	"configcenter/src/common/metadata"
+	"configcenter/src/scene_server/admin_server/upgrader"
+	"configcenter/src/storage/dal"
+
+	"github.com/rs/xid"
+)
+
+func fixBKObjAsstID(ctx context.Context, db dal.RDB, conf *upgrader.Config) error {
+
+	findCond := condition.CreateCondition()
+	findCond.Field(common.AssociationKindIDField).NotEq(common.AssociationKindMainline)
+	objassts := []metadata.Association{}
+	err := db.Table(common.BKTableNameObjAsst).Find(findCond.ToMapStr()).All(ctx, &objassts)
+	if err != nil {
+		return err
+	}
+
+	for _, objasst := range objassts {
+		if strings.objasst.AssociationName {
+
+		}
+
+		cond := condition.CreateCondition()
+		cond.Field(common.BKFieldID).Eq(objasst.ID)
+
+		newObjAsstID := buildObjAsstID(objasst)
+		data := mapstr.MapStr{
+			common.AssociationObjAsstIDField: newObjAsstID,
+		}
+		err := db.Table(common.BKTableNameObjAsst).Update(ctx, mapstr.MapStr{common.BKFieldID: objasst.ID}, data)
+		if err != nil {
+			return err
+		}
+
+		err = db.Table(common.BKTableNameInstAsst).Update(
+			ctx,
+			mapstr.MapStr{
+				common.BKObjIDField:     objasst.ObjectID,
+				common.BKAsstObjIDField: objasst.AsstObjID,
+			},
+			data)
+		if err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func buildObjAsstID(asst metadata.Association) string {
+	return fmt.Sprintf("%s_%s_%s", asst.ObjectID, asst.AsstKindID, asst.AsstObjID)
+}
+
+func countSubString(src, sub string) int {
+	count := 0
+	for _, s := range src {
+		if s == sub {
+			count++
+		}
+	}
+	return count
+}

--- a/src/scene_server/admin_server/upgrader/x18.12.12.04/fix_bk_obj_asst_id.go
+++ b/src/scene_server/admin_server/upgrader/x18.12.12.04/fix_bk_obj_asst_id.go
@@ -15,6 +15,7 @@ package x18_12_12_04
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"configcenter/src/common"
 	"configcenter/src/common/condition"
@@ -35,7 +36,11 @@ func fixBKObjAsstID(ctx context.Context, db dal.RDB, conf *upgrader.Config) erro
 	}
 
 	for _, objasst := range objassts {
-		if countCharacter(objasst.AssociationName, '_') > 1 {
+		name := objasst.AssociationName
+		if common.GetObjByType(objasst.AsstObjID) == common.BKInnerObjIDObject {
+			name = strings.TrimPrefix(name, "bk_")
+		}
+		if countCharacter(name, '_') > 1 {
 			continue
 		}
 

--- a/src/scene_server/admin_server/upgrader/x18.12.12.04/pkg.go
+++ b/src/scene_server/admin_server/upgrader/x18.12.12.04/pkg.go
@@ -1,0 +1,33 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package x18_12_12_04
+
+import (
+	"context"
+
+	"configcenter/src/common/blog"
+	"configcenter/src/scene_server/admin_server/upgrader"
+	"configcenter/src/storage/dal"
+)
+
+func init() {
+	upgrader.RegistUpgrader("x18.12.12.04", upgrade)
+}
+
+func upgrade(ctx context.Context, db dal.RDB, conf *upgrader.Config) (err error) {
+	err = fixBKObjAsstID(ctx, db, conf)
+	if err != nil {
+		blog.Errorf("[upgrade x18.12.12.04] fixBKObjAsstID error  %s", err.Error())
+		return err
+	}
+	return
+}

--- a/src/scene_server/admin_server/upgrader/x18.12.12.05/pkg.go
+++ b/src/scene_server/admin_server/upgrader/x18.12.12.05/pkg.go
@@ -1,0 +1,33 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package x18_12_12_05
+
+import (
+	"context"
+
+	"configcenter/src/common/blog"
+	"configcenter/src/scene_server/admin_server/upgrader"
+	"configcenter/src/storage/dal"
+)
+
+func init() {
+	upgrader.RegistUpgrader("x18.12.12.05", upgrade)
+}
+
+func upgrade(ctx context.Context, db dal.RDB, conf *upgrader.Config) (err error) {
+	err = removeDeletedInstAsst(ctx, db, conf)
+	if err != nil {
+		blog.Errorf("[upgrade x18.12.12.05] fixBKObjAsstID error  %s", err.Error())
+		return err
+	}
+	return
+}

--- a/src/scene_server/admin_server/upgrader/x18.12.12.05/remove_deleted_inst_asst.go
+++ b/src/scene_server/admin_server/upgrader/x18.12.12.05/remove_deleted_inst_asst.go
@@ -1,0 +1,71 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package x18_12_12_05
+
+import (
+	"context"
+
+	"configcenter/src/common"
+	"configcenter/src/common/condition"
+	"configcenter/src/common/mapstr"
+	"configcenter/src/common/metadata"
+	"configcenter/src/scene_server/admin_server/upgrader"
+	"configcenter/src/storage/dal"
+)
+
+func removeDeletedInstAsst(ctx context.Context, db dal.RDB, conf *upgrader.Config) error {
+
+	assts := []metadata.InstAsst{}
+	err := db.Table(common.BKTableNameInstAsst).Find(nil).All(ctx, &assts)
+	if err != nil {
+		return err
+	}
+
+	for _, asst := range assts {
+		count, err := getInst(ctx, db, asst.ObjectID, asst.InstID, asst.OwnerID)
+		if err != nil {
+			return err
+		}
+		if count <= 0 {
+			err := db.Table(common.BKTableNameInstAsst).Delete(ctx, mapstr.MapStr{common.BKFieldID: asst.ID})
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		count, err = getInst(ctx, db, asst.AsstObjectID, asst.AsstInstID, asst.OwnerID)
+		if err != nil {
+			return err
+		}
+		if count <= 0 {
+			err := db.Table(common.BKTableNameInstAsst).Delete(ctx, mapstr.MapStr{common.BKFieldID: asst.ID})
+			if err != nil {
+				return err
+			}
+		}
+
+	}
+	return nil
+}
+
+func getInst(ctx context.Context, db dal.RDB, objID string, instID int64, ownerID string) (uint64, error) {
+	insttable := common.GetInstTableName(objID)
+	cond := condition.CreateCondition()
+	cond.Field(common.GetInstIDField(objID)).Eq(instID)
+	cond.Field(common.BKOwnerIDField).Eq(ownerID)
+	if insttable == common.BKTableNameBaseInst {
+		cond.Field(common.BKObjIDField).Eq(objID)
+	}
+	return db.Table(insttable).Find(cond.ToMapStr()).Count(ctx)
+}


### PR DESCRIPTION
### 修复的问题：
- 解决直接删除主线拓扑自定义模型的实例后，进程管理还能获取到实例所拥有的模块 #2180
- 解决模型关联唯一标识重复问题
- 移除实例已经被删除的实例关联数据