### PR TITLE
object controller中get privilege接口在没有权限数据时返回格式与有权限时格式不一致 #2250

### DIFF
--- a/src/source_controller/objectcontroller/service/role_action.go
+++ b/src/source_controller/objectcontroller/service/role_action.go
@@ -53,7 +53,7 @@ func (cli *Service) GetRolePri(req *restful.Request, resp *restful.Response) {
 	}
 	if 0 == cnt { // TODO:
 		blog.V(3).Infof("failed to find the cnt")
-		info := make(map[string]interface{})
+		info := make([]string, 0)
 		resp.WriteEntity(meta.Response{BaseResp: meta.SuccessBaseResp, Data: info})
 		return
 	}
@@ -68,7 +68,7 @@ func (cli *Service) GetRolePri(req *restful.Request, resp *restful.Response) {
 	privilege, ok := result["privilege"]
 	if !ok {
 		blog.Errorf("not privilege, the origin data is %#v", result)
-		info := make(map[string]interface{})
+		info := make([]string, 0)
 		resp.WriteEntity(meta.Response{BaseResp: meta.SuccessBaseResp, Data: info})
 		return
 


### PR DESCRIPTION
### 修复的问题：
- object controller中get privilege接口在没有权限数据时返回格式与有权限时格式不一致

close #2250 
