### PR TITLE
 设置关联字段参数处理逻辑问题

### DIFF
--- a/src/scene_server/topo_server/core/operation/inst.go
+++ b/src/scene_server/topo_server/core/operation/inst.go
@@ -26,6 +26,7 @@ import (
 	frtypes "configcenter/src/common/mapstr"
 	metatype "configcenter/src/common/metadata"
 	gparams "configcenter/src/common/paraparse"
+	"configcenter/src/common/util"
 	"configcenter/src/scene_server/topo_server/core/inst"
 	"configcenter/src/scene_server/topo_server/core/model"
 	"configcenter/src/scene_server/topo_server/core/types"
@@ -240,6 +241,13 @@ func (c *commonInst) setInstAsst(params types.ContextParams, obj model.Object, i
 		asstInstIDS := []int64{}
 		switch targetAssts := asstVal.(type) {
 		default:
+		case int64, float64, float32:
+			val, err := util.GetInt64ByInterface(asstVal)
+			if err != nil {
+				blog.Errorf("unexpected error, convert value to int64 failed, err: %+v", err)
+				return fmt.Errorf("unexpected error, convert value to int64 failed, err: %+v", err)
+			}
+			asstInstIDS = append(asstInstIDS, val)
 		case string:
 			tmpIDS := strings.Split(targetAssts, common.InstAsstIDSplit)
 			for _, asstID := range tmpIDS {


### PR DESCRIPTION
### 修复的问题：
- 设置关联字段如果传入整形时，cc_InstAsst表中没有创建对应的关联关系记录
- 设置关联字段如果传入整形时，cc_ObjectBase表中实例关联属性字段保存成了整形（应该统一为,分割的字符串）

close #2165 