### PR TITLE
日志中打印redis等明文密码 不安全 #1986

### DIFF
--- a/vendor/github.com/boj/redistore/redistore.go
+++ b/vendor/github.com/boj/redistore/redistore.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -143,7 +142,6 @@ func dial(network, address, password string) (redis.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("redisSecret:::%s", password)
 	if password != "" {
 		if _, err := c.Do("AUTH", password); err != nil {
 			c.Close()


### PR DESCRIPTION
### 优化的功能:
- 日志中打印redis等明文密码 不安全 #1986


close #1986 