### PR TITLE
feature: sync data between multiple bk-cmdb

### DIFF
--- a/src/apimachinery/discovery/server.go
+++ b/src/apimachinery/discovery/server.go
@@ -51,6 +51,9 @@ type server struct {
 }
 
 func (s *server) GetServers() ([]string, error) {
+	if s == nil {
+		return []string{}, nil
+	}
 	s.RLock()
 	defer s.RUnlock()
 
@@ -70,6 +73,9 @@ func (s *server) GetServers() ([]string, error) {
 
 // IsMaster 判断当前进程是否为master 进程， 服务注册节点的第一个节点
 func (s *server) IsMaster(strAddrs string) bool {
+	if s == nil {
+		return false
+	}
 	s.RLock()
 	defer s.RUnlock()
 	if 0 < len(s.servers) {

--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -1016,10 +1016,8 @@ const (
 	SynchronizeModelTypeAttribute = "model_attribute"
 	// SynchronizeModelTypeAttributeGroup synchroneize model attribute group
 	SynchronizeModelTypeAttributeGroup = "model_atrribute_group"
-	// SynchronizeModelTypeBase synchroneize model attribute group
+	// SynchronizeModelTypeBase synchroneize model attribute
 	SynchronizeModelTypeBase = "model"
-	// SynchronizeModelTypeModelClassificationRelation synchroneize model classification relation
-	SynchronizeModelTypeModelClassificationRelation = "model_classification_relation"
 
 	/* synchronize instance assoication sign*/
 

--- a/src/common/types/serverInfo.go
+++ b/src/common/types/serverInfo.go
@@ -148,5 +148,8 @@ type EventServInfo struct {
 
 // Address convert struct to host address
 func (s *ServerInfo) Address() string {
+	if s == nil {
+		return ""
+	}
 	return fmt.Sprintf("%s://%s:%d", s.Scheme, s.IP, s.Port)
 }

--- a/src/common/types/serverInfo.go
+++ b/src/common/types/serverInfo.go
@@ -61,7 +61,7 @@ var AllModule = map[string]bool{
 	CC_MODULE_EVENTSERVER:      true,
 	CC_MODULE_TXC:              true,
 	CC_MODULE_CORESERVICE:      true,
-	// CC_MODULE_SYNCHRONZESERVER: true,
+	CC_MODULE_SYNCHRONZESERVER: true,
 }
 
 // cc functionality define

--- a/src/scene_server/synchronize_server/app/options/options.go
+++ b/src/scene_server/synchronize_server/app/options/options.go
@@ -97,4 +97,9 @@ type ConfigItem struct {
 
 	// Retry error max retry count
 	ExceptionFileCount int
+
+	// Unsynchronized model related properties
+	// 使用忽略模型属性变的模式。 用户在目标中新加对应的模型，模型的属性。
+	// 满足同步的实例将会同步到目的cmdb。 在目标系统中新建相同的唯一标识模型或者模型的字段。内容会自动展示出来
+	IgnoreModelAttr bool
 }

--- a/src/scene_server/synchronize_server/app/server.go
+++ b/src/scene_server/synchronize_server/app/server.go
@@ -121,8 +121,9 @@ func (s *SynchronizeServer) onSynchronizeServerConfigUpdate(previous, current cc
 		if witeList == "1" {
 			configItem.WiteList = true
 		}
-		// 使用忽略模型属性变的模式。 用户在目标中新加对应的模型，模型的属性。
-        // 满足同步的实例将会同步到目的cmdb。 在目标系统中新建相同的唯一标识模型或者模型的字段。内容会自动展示出来
+		// 使用忽略模型属性变的模式。 模型属性，模型分组 将不做同步
+		// 但是数据源cmdb中满足条件的实例会同步到目标cmdb。
+		// 目标cmdb中新建相同的唯一标识模型或者模型的字段。内容会自动展示出来
 		if ignoreModelAttr == "1" {
 			configItem.IgnoreModelAttr = true
 		}
@@ -145,11 +146,13 @@ func (s *SynchronizeServer) onSynchronizeServerConfigUpdate(previous, current cc
 
 }
 
+// SplitFilter split string with sep. remove blanks for blank item children and children
 func SplitFilter(s, sep string) []string {
 	itemArr := strings.Split(s, sep)
 	var strArr []string
 	for _, item := range itemArr {
-		if strings.TrimSpace(item) == "" {
+		item = strings.TrimSpace(item)
+		if item == "" {
 			continue
 		}
 		strArr = append(strArr, item)

--- a/src/scene_server/synchronize_server/app/server.go
+++ b/src/scene_server/synchronize_server/app/server.go
@@ -91,7 +91,7 @@ type SynchronizeServer struct {
 func (s *SynchronizeServer) onSynchronizeServerConfigUpdate(previous, current cc.ProcessConfig) {
 	configInfo := &options.Config{}
 	names := current.ConfigMap["synchronize.name"]
-	configInfo.Names = strings.Split(names, ",")
+	configInfo.Names = SplitFilter(names, ",")
 
 	configInfo.Trigger.TriggerType = current.ConfigMap["trigger.type"]
 	// role  unit minute.
@@ -113,19 +113,19 @@ func (s *SynchronizeServer) onSynchronizeServerConfigUpdate(previous, current cc
 		witeList := current.ConfigMap[name+".WiteList"]
 		objectIDs := current.ConfigMap[name+".ObjectID"]
 
-		configItem.AppNames = strings.Split(appNames, ",")
+		configItem.AppNames = SplitFilter(appNames, ",")
 		if syncResource == "1" {
 			configItem.SyncResource = true
 		}
 		if witeList == "1" {
 			configItem.WiteList = true
 		}
-		configItem.ObjectIDArr = strings.Split(objectIDs, ",")
+		configItem.ObjectIDArr = SplitFilter(objectIDs, ",")
 		configItem.Name = name
 		configItem.TargetHost = targetHost
 		configItem.FieldSign = fieldSign
 		configItem.SynchronizeFlag = dataSign
-		configItem.SupplerAccount = strings.Split(supplerAccount, ",")
+		configItem.SupplerAccount = SplitFilter(supplerAccount, ",")
 		configInfo.ConifgItemArray = append(configInfo.ConifgItemArray, configItem)
 		if targetHost != "" {
 			s.synchronizeClientConfig <- synchronizeUtil.SychronizeConfig{
@@ -136,6 +136,18 @@ func (s *SynchronizeServer) onSynchronizeServerConfigUpdate(previous, current cc
 	}
 	s.Config = configInfo
 
+}
+
+func SplitFilter(s, sep string) []string {
+	itemArr := strings.Split(s, sep)
+	var strArr []string
+	for _, item := range itemArr {
+		if strings.TrimSpace(item) == "" {
+			continue
+		}
+		strArr = append(strArr, item)
+	}
+	return strArr
 }
 
 func newServerInfo(op *options.ServerOption) (*types.ServerInfo, error) {

--- a/src/scene_server/synchronize_server/app/server.go
+++ b/src/scene_server/synchronize_server/app/server.go
@@ -112,6 +112,7 @@ func (s *SynchronizeServer) onSynchronizeServerConfigUpdate(previous, current cc
 		supplerAccount := current.ConfigMap[name+".SupplerAccount"]
 		witeList := current.ConfigMap[name+".WiteList"]
 		objectIDs := current.ConfigMap[name+".ObjectID"]
+		ignoreModelAttr := current.ConfigMap[name+".IgnoreModelAttribute"]
 
 		configItem.AppNames = SplitFilter(appNames, ",")
 		if syncResource == "1" {
@@ -120,6 +121,12 @@ func (s *SynchronizeServer) onSynchronizeServerConfigUpdate(previous, current cc
 		if witeList == "1" {
 			configItem.WiteList = true
 		}
+		// 使用忽略模型属性变的模式。 用户在目标中新加对应的模型，模型的属性。
+        // 满足同步的实例将会同步到目的cmdb。 在目标系统中新建相同的唯一标识模型或者模型的字段。内容会自动展示出来
+		if ignoreModelAttr == "1" {
+			configItem.IgnoreModelAttr = true
+		}
+
 		configItem.ObjectIDArr = SplitFilter(objectIDs, ",")
 		configItem.Name = name
 		configItem.TargetHost = targetHost

--- a/src/scene_server/synchronize_server/logics/background_synchronize.go
+++ b/src/scene_server/synchronize_server/logics/background_synchronize.go
@@ -348,7 +348,12 @@ func (s *synchronizeItem) sycnhronizePartModel(ctx context.Context, input *metad
 		}
 		synchronizeParameter.InfoArray = append(synchronizeParameter.InfoArray, &metadata.SynchronizeItem{ID: id, Info: item})
 	}
-
+	// 当配置不需要同步模型的时候。不去保存数据，
+	// 但是需要使用上面的功能获取需要同步模型id。 s.ojjIDMap
+	if s.config.IgnoreModelAttr {
+		blog.V(4).Infof("sycnhronizePartModel skip. rid:%s, version:%s", s.lgc.rid, s.version)
+		return errorInfoArr, nil
+	}
 	result, err := s.lgc.CoreAPI.CoreService().Synchronize().SynchronizeModel(ctx, s.lgc.header, synchronizeParameter)
 	if err != nil {
 		blog.Errorf("sycnhronizePartModel http do error, error: %s,DataSign: %s,DataTeyp: %s,rid:%s", err.Error(), input.DataClassify, input.OperateDataType, s.lgc.rid)

--- a/src/scene_server/synchronize_server/logics/background_synchronize.go
+++ b/src/scene_server/synchronize_server/logics/background_synchronize.go
@@ -270,7 +270,6 @@ func (s *synchronizeItem) synchronizeModelTask(ctx context.Context) ([]metadata.
 		common.SynchronizeModelTypeClassification,
 		common.SynchronizeModelTypeAttribute,
 		common.SynchronizeModelTypeAttributeGroup,
-		common.SynchronizeModelTypeModelClassificationRelation,
 	}
 	for _, dataClassify := range classifyArr {
 		partErrorInfoArr, err := s.synchronizeModel(ctx, model, dataClassify)

--- a/src/scene_server/synchronize_server/logics/synchronize.go
+++ b/src/scene_server/synchronize_server/logics/synchronize.go
@@ -31,6 +31,10 @@ func (lgc *Logics) TriggerSynchronize(ctx context.Context, config *options.Confi
 		blog.Errorf("TriggerSynchronize not config ")
 		return
 	}
+	if len(config.Names) == 0 {
+		blog.Errorf("TriggerSynchronize not config ")
+		return
+	}
 	lgc = lgc.NewFromHeader(copyHeader(lgc.header))
 	interval, err := util.GetInt64ByInterface(config.Trigger.Role)
 	if err != nil {
@@ -61,6 +65,7 @@ func (lgc *Logics) TriggerSynchronize(ctx context.Context, config *options.Confi
 		lgc.Synchronize(ctx, config)
 	}
 
+	blog.V(4).Infof("synchronize ready")
 	timeInterval := time.Duration(interval) * time.Minute
 	for {
 		ticker := time.NewTimer(timeInterval)
@@ -73,7 +78,6 @@ func (lgc *Logics) TriggerSynchronize(ctx context.Context, config *options.Confi
 			continue
 		}
 		lgc.Synchronize(ctx, config)
-
 	}
 
 }

--- a/src/source_controller/coreservice/core/datasynchronize/find.go
+++ b/src/source_controller/coreservice/core/datasynchronize/find.go
@@ -57,10 +57,9 @@ func (a *associationFindData) Find(ctx core.ContextParams) ([]mapstr.MapStr, uin
 }
 
 func (a *associationFindData) findModel(ctx core.ContextParams) ([]mapstr.MapStr, uint64, errors.CCError) {
+
 	switch a.dataClassify {
 	case common.SynchronizeModelTypeBase:
-		return a.dbQueryModel(ctx, common.BKTableNameBaseModule)
-	case common.SynchronizeModelTypeModelClassificationRelation:
 		return a.dbQueryModel(ctx, common.BKTableNameObjDes)
 	case common.SynchronizeModelTypeAttribute:
 		return a.dbQueryModel(ctx, common.BKTableNameObjAttDes)

--- a/src/source_controller/coreservice/core/datasynchronize/model.go
+++ b/src/source_controller/coreservice/core/datasynchronize/model.go
@@ -90,7 +90,7 @@ func (m *model) saveSynchronizeModelAttribute(ctx core.ContextParams) errors.CCE
 
 func (m *model) saveSynchronizeModelAttributeGroup(ctx core.ContextParams) errors.CCError {
 	var dbParam synchronizeAdapterDBParameter
-	//cc_PropertyGroup
+	// cc_PropertyGroup
 	dbParam.tableName = common.BKTableNamePropertyGroup
 	dbParam.InstIDField = common.BKFieldID
 	m.base.saveSynchronize(ctx, dbParam)
@@ -99,7 +99,7 @@ func (m *model) saveSynchronizeModelAttributeGroup(ctx core.ContextParams) error
 
 func (m *model) saveSynchronizeModelBase(ctx core.ContextParams) errors.CCError {
 	var dbParam synchronizeAdapterDBParameter
-	//cc_ObjDes
+	// cc_ObjDes
 	dbParam.tableName = common.BKTableNameObjDes
 	dbParam.InstIDField = common.BKFieldID
 	m.base.saveSynchronize(ctx, dbParam)

--- a/src/source_controller/coreservice/core/datasynchronize/model.go
+++ b/src/source_controller/coreservice/core/datasynchronize/model.go
@@ -65,21 +65,11 @@ func (m *model) SaveSynchronize(ctx core.ContextParams) errors.CCError {
 		return m.saveSynchronizeModelAttributeGroup(ctx)
 	case common.SynchronizeModelTypeBase:
 		return m.saveSynchronizeModelBase(ctx)
-	case common.SynchronizeModelTypeModelClassificationRelation:
-		return m.saveSynchronizeModelClassificationRelation(ctx)
 	default:
 		return ctx.Error.Errorf(common.CCErrCoreServiceSyncDataClassifyNotExistError, m.dataType, m.DataClassify)
 	}
 }
 
-func (m *model) saveSynchronizeModelClassificationRelation(ctx core.ContextParams) errors.CCError {
-	var dbParam synchronizeAdapterDBParameter
-	// "cc_ObjDes"
-	dbParam.tableName = common.BKTableNameObjDes
-	dbParam.InstIDField = common.BKFieldID
-	m.base.saveSynchronize(ctx, dbParam)
-	return nil
-}
 func (m *model) saveSynchronizeModelClassification(ctx core.ContextParams) errors.CCError {
 	var dbParam synchronizeAdapterDBParameter
 	// "cc_ObjClassification"
@@ -109,9 +99,9 @@ func (m *model) saveSynchronizeModelAttributeGroup(ctx core.ContextParams) error
 
 func (m *model) saveSynchronizeModelBase(ctx core.ContextParams) errors.CCError {
 	var dbParam synchronizeAdapterDBParameter
-	//cc_ObjectBase
-	dbParam.tableName = common.BKTableNameBaseInst
-	dbParam.InstIDField = common.BKInstIDField
+	//cc_ObjDes
+	dbParam.tableName = common.BKTableNameObjDes
+	dbParam.InstIDField = common.BKFieldID
 	m.base.saveSynchronize(ctx, dbParam)
 	return nil
 }

--- a/src/source_controller/coreservice/core/datasynchronize/util.go
+++ b/src/source_controller/coreservice/core/datasynchronize/util.go
@@ -159,7 +159,6 @@ func (s *synchronizeAdapter) replaceSynchronize(ctx core.ContextParams, dbParam 
 			}
 			if exist {
 				conds = mapstr.MapStr{dbParam.InstIDField: item.ID}
-
 			}
 		}
 

--- a/src/source_controller/coreservice/core/datasynchronize/util.go
+++ b/src/source_controller/coreservice/core/datasynchronize/util.go
@@ -19,6 +19,7 @@ import (
 	"configcenter/src/common/errors"
 	"configcenter/src/common/mapstr"
 	"configcenter/src/common/metadata"
+	"configcenter/src/common/util"
 	"configcenter/src/source_controller/coreservice/core"
 	"configcenter/src/storage/dal"
 )
@@ -140,7 +141,26 @@ func (s *synchronizeAdapter) replaceSynchronize(ctx core.ContextParams, dbParam 
 			}
 			continue
 		}
+		if !exist {
+			// Data that does not exist. Judging whether it can be combined
+			mergeInstID, exist, err := s.getSameInfo(ctx, dbParam.InstIDField, dbParam.tableName, item)
+			if err != nil {
+				blog.Errorf("replaceSynchronize getSameInfo error.DataClassify:%s,info:%#v,rid:%s", s.syncData.DataClassify, item, ctx.ReqID)
+				s.errorArray[item.ID] = synchronizeAdapterError{
+					instInfo: item,
+					err:      err,
+				}
+				continue
+			}
+			// The same data already exists, merging the existing data.
+			if exist {
+				conds = mapstr.MapStr{dbParam.InstIDField: mergeInstID}
+			}
+
+		}
 		if exist {
+			// Existing data, does not update the ID field
+			delete(item.Info, dbParam.InstIDField)
 			err := s.dbProxy.Table(dbParam.tableName).Update(ctx, conds, item.Info)
 			if err != nil {
 				blog.Errorf("replaceSynchronize update info error,err:%s.DataClassify:%s,condition:%#v,info:%#v,rid:%s", err.Error(), s.syncData.DataClassify, conds, item, ctx.ReqID)
@@ -151,6 +171,7 @@ func (s *synchronizeAdapter) replaceSynchronize(ctx core.ContextParams, dbParam 
 				continue
 			}
 		} else {
+
 			err := s.dbProxy.Table(dbParam.tableName).Insert(ctx, item.Info)
 			if err != nil {
 				blog.Errorf("replaceSynchronize insert info error,err:%s.DataClassify:%s,info:%#v,rid:%s", err.Error(), s.syncData.DataClassify, item, ctx.ReqID)
@@ -192,4 +213,171 @@ func (s *synchronizeAdapter) existSynchronizeID(ctx core.ContextParams, tableNam
 	}
 	return false, nil
 
+}
+
+func (s *synchronizeAdapter) getSameInfo(ctx core.ContextParams, instIDField, tableName string, info *metadata.SynchronizeItem) (int64, bool, errors.CCError) {
+
+	bsi := NewBuildSameInfo(info, s.syncData)
+	err := bsi.BuildSameInfoBaseCond(ctx)
+	if err != nil {
+		return 0, false, err
+	}
+
+	switch tableName {
+	case common.BKTableNameObjDes:
+		err = bsi.BuildSameInfoObjDescCond(ctx)
+		if err != nil {
+			return 0, false, err
+		}
+	case common.BKTableNameObjClassifiction:
+		err = bsi.BuildSameInfoObjClassificationCond(ctx)
+		if err != nil {
+			return 0, false, err
+		}
+	case common.BKTableNameObjAttDes:
+		err = bsi.BuildSameInfoObjAttrDescCond(ctx)
+		if err != nil {
+			return 0, false, err
+		}
+	case common.BKTableNamePropertyGroup:
+		err = bsi.BuildSameInfoObjAttrGroupCond(ctx)
+		if err != nil {
+			return 0, false, err
+		}
+	}
+
+	inst := mapstr.New()
+	err = s.dbProxy.Table(tableName).Find(bsi.Condition()).One(ctx, &inst)
+	if err != nil && s.dbProxy.IsNotFoundError(err) {
+		blog.Errorf("existSameInfo query db error. DataClassify:%s,info:%#v,condition:%#v, rid:%s", bsi.syncData.DataClassify, info.Info, bsi.Condition(), ctx.ReqID)
+		return 0, false, ctx.Error.Error(common.CCErrCommDBSelectFailed)
+	}
+
+	// not found data
+	if len(inst) == 0 {
+		return 0, false, nil
+	}
+
+	instID, err := inst.Int64(instIDField)
+	if err != nil {
+		blog.Errorf("buildSameInfoBaseCond get ownerID error. DataClassify:%s,info:%#v,rid:%s", bsi.syncData.DataClassify, info.Info, ctx.ReqID)
+		return 0, false, ctx.Error.Errorf(common.CCErrCommInstFieldConvFail, "propery data", instIDField, "int", err.Error())
+	}
+	return instID, true, nil
+
+}
+
+type buildSameInfo struct {
+	info     *metadata.SynchronizeItem
+	cond     mapstr.MapStr
+	syncData *metadata.SynchronizeParameter
+}
+
+func NewBuildSameInfo(info *metadata.SynchronizeItem, syncData *metadata.SynchronizeParameter) *buildSameInfo {
+	return &buildSameInfo{
+		info:     info,
+		cond:     mapstr.New(),
+		syncData: syncData,
+	}
+}
+
+func (bsi *buildSameInfo) BuildSameInfoBaseCond(ctx core.ContextParams) errors.CCError {
+	info := bsi.info
+	if info.Info.Exists(common.MetadataField) {
+		metadataVal, err := info.Info.MapStr(common.MetadataField)
+		if err != nil {
+			blog.Errorf("buildSameInfoBaseCond get metadata error. DataClassify:%s,info:%#v,rid:%s", bsi.syncData.DataClassify, info.Info, ctx.ReqID)
+			return ctx.Error.Errorf(common.CCErrCommInstFieldConvFail, "propery", common.MetadataField, "map", err.Error())
+		}
+		if metadataVal.Exists(metadata.LabelBusinessID) {
+			str, err := metadataVal.String(metadata.LabelBusinessID)
+			if err != nil {
+				blog.Errorf("buildSameInfoBaseCond get metadata.bk_biz_id error. DataClassify:%s,info:%#v,rid:%s", bsi.syncData.DataClassify, info.Info, ctx.ReqID)
+				return ctx.Error.Errorf(common.CCErrCommInstFieldConvFail, "propery", common.MetadataField, "map", err.Error())
+			}
+			bsi.cond.Set("metadata.label.bk_biz_id", str)
+		} else {
+			bsi.cond.Merge(metadata.BizLabelNotExist)
+		}
+
+	} else {
+		bsi.cond.Merge(metadata.BizLabelNotExist)
+	}
+	ownerID, err := info.Info.String(common.BKOwnerIDField)
+	if err != nil {
+		blog.Errorf("buildSameInfoBaseCond get ownerID error. DataClassify:%s,info:%#v,rid:%s", bsi.syncData.DataClassify, info.Info, ctx.ReqID)
+		return ctx.Error.Errorf(common.CCErrCommInstFieldConvFail, "propery", common.BKOwnerIDField, "string", err.Error())
+	}
+	bsi.cond = util.SetQueryOwner(bsi.cond, ownerID)
+	return nil
+}
+
+func (bsi *buildSameInfo) BuildSameInfoObjDescCond(ctx core.ContextParams) errors.CCError {
+	info := bsi.info
+	objID, err := info.Info.String(common.BKObjIDField)
+	if err != nil {
+		blog.Errorf("buildSameInfoObjDescCond get bk_obj_id error. DataClassify:%s,info:%#v,rid:%s", bsi.syncData.DataClassify, info.Info, ctx.ReqID)
+		return ctx.Error.Errorf(common.CCErrCommInstFieldConvFail, "propery", common.BKObjIDField, "string", err.Error())
+	}
+	objName, err := info.Info.String(common.BKObjNameField)
+	if err != nil {
+		blog.Errorf("buildSameInfoObjDescCond get bk_obj_name error. DataClassify:%s,info:%#v,rid:%s", bsi.syncData.DataClassify, info.Info, ctx.ReqID)
+		return ctx.Error.Errorf(common.CCErrCommInstFieldConvFail, "propery", common.BKObjNameField, "string", err.Error())
+	}
+
+	bsi.cond.Set(common.BKObjIDField, objID)
+	bsi.cond.Set(common.BKObjNameField, objName)
+	return nil
+}
+
+func (bsi *buildSameInfo) BuildSameInfoObjAttrDescCond(ctx core.ContextParams) errors.CCError {
+	info := bsi.info
+	objID, err := info.Info.String(common.BKObjIDField)
+	if err != nil {
+		blog.Errorf("buildSameInfoObjAttrDescCond get bk_obj_id error. DataClassify:%s,info:%#v,rid:%s", bsi.syncData.DataClassify, info.Info, ctx.ReqID)
+		return ctx.Error.Errorf(common.CCErrCommInstFieldConvFail, "propery", common.BKObjIDField, "string", err.Error())
+	}
+	propertyID, err := info.Info.String(common.BKPropertyIDField)
+	if err != nil {
+		blog.Errorf("buildSameInfoObjAttrDescCond get bk_obj_name error. DataClassify:%s,info:%#v,rid:%s", bsi.syncData.DataClassify, info.Info, ctx.ReqID)
+		return ctx.Error.Errorf(common.CCErrCommInstFieldConvFail, "propery", common.BKPropertyIDField, "string", err.Error())
+	}
+
+	bsi.cond.Set(common.BKObjIDField, objID)
+	bsi.cond.Set(common.BKPropertyIDField, propertyID)
+	return nil
+}
+
+func (bsi *buildSameInfo) BuildSameInfoObjAttrGroupCond(ctx core.ContextParams) errors.CCError {
+	info := bsi.info
+	objID, err := info.Info.String(common.BKObjIDField)
+	if err != nil {
+		blog.Errorf("existSameInfo get bk_obj_id error. DataClassify:%s,info:%#v,rid:%s", bsi.syncData.DataClassify, info.Info, ctx.ReqID)
+		return ctx.Error.Errorf(common.CCErrCommInstFieldConvFail, "propery", common.BKObjIDField, "string", err.Error())
+	}
+	groupID, err := info.Info.String(common.BKPropertyGroupIDField)
+	if err != nil {
+		blog.Errorf("existSameInfo get bk_group_id error. DataClassify:%s,info:%#v,rid:%s", bsi.syncData.DataClassify, info.Info, ctx.ReqID)
+		return ctx.Error.Errorf(common.CCErrCommInstFieldConvFail, "propery", common.BKPropertyGroupIDField, "string", err.Error())
+	}
+
+	bsi.cond.Set(common.BKObjIDField, objID)
+	bsi.cond.Set(common.BKPropertyGroupIDField, groupID)
+	return nil
+}
+
+func (bsi *buildSameInfo) BuildSameInfoObjClassificationCond(ctx core.ContextParams) errors.CCError {
+	info := bsi.info
+	classificationID, err := info.Info.String(common.BKClassificationIDField)
+	if err != nil {
+		blog.Errorf("existSameInfo get bk_classification_id error. DataClassify:%s,info:%#v,rid:%s", bsi.syncData.DataClassify, info.Info, ctx.ReqID)
+		return ctx.Error.Errorf(common.CCErrCommInstFieldConvFail, "propery", common.BKClassificationIDField, "string", err.Error())
+	}
+
+	bsi.cond.Set(common.BKClassificationIDField, classificationID)
+	return nil
+}
+
+func (bsi *buildSameInfo) Condition() mapstr.MapStr {
+	return bsi.cond
 }

--- a/src/source_controller/coreservice/service/data_synchronize.go
+++ b/src/source_controller/coreservice/service/data_synchronize.go
@@ -26,7 +26,8 @@ func (s *coreService) SynchronizeInstance(params core.ContextParams, pathParams,
 		return nil, err
 	}
 	inputData.OperateDataType = metadata.SynchronizeOperateDataTypeInstance
-	return s.core.DataSynchronizeOperation().SynchronizeInstanceAdapter(params, inputData)
+	exceptionArr, err := s.core.DataSynchronizeOperation().SynchronizeInstanceAdapter(params, inputData)
+	return metadata.SynchronizeDataResult{Exceptions: exceptionArr}, err
 }
 
 func (s *coreService) SynchronizeModel(params core.ContextParams, pathParams, queryParams ParamsGetter, data mapstr.MapStr) (interface{}, error) {
@@ -37,7 +38,8 @@ func (s *coreService) SynchronizeModel(params core.ContextParams, pathParams, qu
 		return nil, err
 	}
 	inputData.OperateDataType = metadata.SynchronizeOperateDataTypeModel
-	return s.core.DataSynchronizeOperation().SynchronizeModelAdapter(params, inputData)
+	exceptionArr, err := s.core.DataSynchronizeOperation().SynchronizeModelAdapter(params, inputData)
+	return metadata.SynchronizeDataResult{Exceptions: exceptionArr}, err
 }
 
 func (s *coreService) SynchronizeAssociation(params core.ContextParams, pathParams, queryParams ParamsGetter, data mapstr.MapStr) (interface{}, error) {
@@ -48,7 +50,8 @@ func (s *coreService) SynchronizeAssociation(params core.ContextParams, pathPara
 		return nil, err
 	}
 	inputData.OperateDataType = metadata.SynchronizeOperateDataTypeAssociation
-	return s.core.DataSynchronizeOperation().SynchronizeAssociationAdapter(params, inputData)
+	exceptionArr, err := s.core.DataSynchronizeOperation().SynchronizeAssociationAdapter(params, inputData)
+	return metadata.SynchronizeDataResult{Exceptions: exceptionArr}, err
 }
 
 func (s *coreService) SynchronizeFind(params core.ContextParams, pathParams, queryParams ParamsGetter, data mapstr.MapStr) (interface{}, error) {


### PR DESCRIPTION
### 新加的功能:
-  多个cmdb之间同步支持不同模型
- 多个cmdb直接同步模型的定义，模型的字段，模型字段分组，模型分组支持按唯一标识合并
### 优化的功能:
- 过滤配置文件空白配置
- 服务发现支持同步服务模块
### 修复的问题：
- xxxx

issue #1780  #2247 