### PR TITLE
实例查询没有按path参数指定的类型过滤 #2166

### DIFF
--- a/src/scene_server/topo_server/core/operation/inst.go
+++ b/src/scene_server/topo_server/core/operation/inst.go
@@ -945,7 +945,12 @@ func (c *commonInst) FindOriginInst(params types.ContextParams, obj model.Object
 		return &metatype.InstResult{Count: rsp.Data.Count, Info: frtypes.NewArrayFromInterface(rsp.Data.Info)}, nil
 
 	default:
-
+		if _, ok := cond.Condition.(map[string]interface{}); ok == true {
+			cond.Condition.(map[string]interface{})[common.BKObjIDField] = obj.GetID()
+		} else {
+			// TODO find appropriate method to inject bk_obj_id condition for below data format
+			blog.Warnf("search instance condition unexpected format, skip inject bk_obj_id condition, condition: %+v", cond.Condition)
+		}
 		rsp, err := c.clientSet.ObjectController().Instance().SearchObjects(context.Background(), obj.GetObjectType(), params.Header, cond)
 
 		if nil != err {


### PR DESCRIPTION
### 修复的问题：
- 如下所示实例查询时路径参数`core_switch`没有加入到过滤条件，最终把`bk_weblogic`之类的实例全部查询出来了
  - `/api/v3/inst/search/owner/0/object/core_switch`

close #2166