### PR TITLE
V3.4.x 测试用例问题修复

### DIFF
--- a/src/apimachinery/hostserver/apis.go
+++ b/src/apimachinery/hostserver/apis.go
@@ -551,8 +551,8 @@ func (hs *hostServer) GetPlat(ctx context.Context, h http.Header) (resp *metadat
 	return
 }
 
-func (hs *hostServer) CreatePlat(ctx context.Context, h http.Header, dat map[string]interface{}) (resp *metadata.Response, err error) {
-	resp = new(metadata.Response)
+func (hs *hostServer) CreatePlat(ctx context.Context, h http.Header, dat map[string]interface{}) (resp *metadata.CreatedOneOptionResult, err error) {
+	resp = new(metadata.CreatedOneOptionResult)
 	subPath := "/plat"
 
 	err = hs.client.Post().

--- a/src/apimachinery/hostserver/hostserver.go
+++ b/src/apimachinery/hostserver/hostserver.go
@@ -67,7 +67,7 @@ type HostServerClientInterface interface {
 	DelHostInApp(ctx context.Context, h http.Header, dat interface{}) (resp *metadata.Response, err error)
 	GetGitServerIp(ctx context.Context, h http.Header, dat interface{}) (resp *metadata.Response, err error)
 	GetPlat(ctx context.Context, h http.Header) (resp *metadata.QueryInstResult, err error)
-	CreatePlat(ctx context.Context, h http.Header, dat map[string]interface{}) (resp *metadata.Response, err error)
+	CreatePlat(ctx context.Context, h http.Header, dat map[string]interface{}) (resp *metadata.CreatedOneOptionResult, err error)
 	DelPlat(ctx context.Context, cloudID string, h http.Header) (resp *metadata.Response, err error)
 	SearchHost(ctx context.Context, h http.Header, dat *params.HostCommonSearch) (resp *metadata.SearchHostResult, err error)
 	SearchHostWithAsstDetail(ctx context.Context, h http.Header, dat *params.HostCommonSearch) (resp *metadata.SearchHostResult, err error)

--- a/src/apiserver/core/compatiblev2/service/plat.go
+++ b/src/apiserver/core/compatiblev2/service/plat.go
@@ -193,12 +193,5 @@ func (s *service) createPlats(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
-	rspDataV3Map, ok := result.Data.(map[string]interface{})
-	if false == ok {
-		blog.Errorf("createPlats http reply error.data not ma[string]interface.reply:%#v,input:%#v,rid:%s", result.Data, formData, srvData.rid)
-		converter.RespFailV2(common.CCErrCommReplyDataFormatError, defErr.Error(common.CCErrCommReplyDataFormatError).Error(), resp)
-		return
-	}
-
-	converter.RespSuccessV2(rspDataV3Map[common.BKCloudIDField], resp)
+	converter.RespSuccessV2(result.Data.Created.ID, resp)
 }

--- a/src/scene_server/host_server/logics/app.go
+++ b/src/scene_server/host_server/logics/app.go
@@ -209,6 +209,9 @@ func (lgc *Logics) GetAppIDByCond(ctx context.Context, cond []metadata.Condition
 
 func (lgc *Logics) GetAppMapByCond(ctx context.Context, fields []string, cond mapstr.MapStr) (map[int64]types.MapStr, errors.CCError) {
 
+	if cond == nil {
+		cond = mapstr.New()
+	}
 	cond.Set(common.BKDataStatusField, mapstr.MapStr{common.BKDBNE: common.DataStatusDisabled})
 	query := &metadata.QueryCondition{
 		Condition: cond,

--- a/src/scene_server/host_server/service/host.go
+++ b/src/scene_server/host_server/service/host.go
@@ -184,6 +184,11 @@ func (s *Service) GetHostInstanceProperties(req *restful.Request, resp *restful.
 		resp.WriteError(http.StatusInternalServerError, &meta.RespError{Msg: err})
 		return
 	}
+	if len(details) == 0 {
+		blog.Errorf("host not found, hostID: %v,rid:%s", hostID, srvData.rid)
+		resp.WriteError(http.StatusInternalServerError, &meta.RespError{Msg: srvData.ccErr.Error(common.CCErrHostNotFound)})
+		return
+	}
 
 	// check authorization
 	// auth: check authorization

--- a/src/scene_server/host_server/service/phpapi.go
+++ b/src/scene_server/host_server/service/phpapi.go
@@ -1014,8 +1014,7 @@ func (s *Service) CreatePlat(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
-	ownerId := util.GetOwnerID(req.Request.Header)
-	input[common.BKOwnerIDField] = ownerId
+	input[common.BKOwnerIDField] = srvData.ownerID
 
 	valid := validator.NewValidMap(util.GetOwnerID(req.Request.Header), common.BKInnerObjIDPlat, srvData.header, s.Engine)
 	validErr := valid.ValidMap(input, common.ValidCreate, 0)


### PR DESCRIPTION
### 新加的功能:
-  
### 优化的功能:
- 优化创建云区域接口返回值
- 代码格式
### 修复的问题：
- 修复v2 api 穿件云区域，返回值没有新建的云区域ID问题
- 修复获取不存在主机未提示错误的问题
- 修复mapstr未nil，set 值的panic的问题
