### PR TITLE
主机，主线模型权限优化修复

### DIFF
--- a/scripts/init.py
+++ b/scripts/init.py
@@ -90,24 +90,28 @@ mechanism = SCRAM-SHA-1
 
 [snap-redis]
 host = $redis_host
+port = $redis_port
 usr = $redis_user
 pwd = $redis_pass
 database = 0
 
 [discover-redis]
 host = $redis_host
+port = $redis_port
 usr = $redis_user
 pwd = $redis_pass
 database = 0
 
 [netcollect-redis]
 host = $redis_host
+port = $redis_port
 usr = $redis_user
 pwd = $redis_pass
 database = 0
 
 [redis]
 host = $redis_host
+port = $redis_port
 usr = $redis_user
 pwd = $redis_pass
 database = 0
@@ -132,6 +136,7 @@ mechanism = SCRAM-SHA-1
 
 [redis]
 host = $redis_host
+port = $redis_port
 usr = $redis_user
 pwd = $redis_pass
 database = 0
@@ -154,6 +159,7 @@ pwd = L%blKas
 
 [redis]
 host = $redis_host
+port = $redis_port
 usr = $redis_user
 pwd = $redis_pass
 database = 0
@@ -186,6 +192,7 @@ mechanism = SCRAM-SHA-1
 
 [redis]
 host = $redis_host
+port = $redis_port
 usr = $redis_user
 pwd = $redis_pass
 database = 0
@@ -256,6 +263,7 @@ mechanism = SCRAM-SHA-1
 
 [redis]
 host = $redis_host
+port = $redis_port
 usr = $redis_user
 pwd = $redis_pass
 database = 0
@@ -283,6 +291,7 @@ mechanism = SCRAM-SHA-1
 
 [redis]
 host = $redis_host
+port = $redis_port
 usr = $redis_user
 pwd = $redis_pass
 database = 0
@@ -300,6 +309,7 @@ maxIDleConns = 1000
     proc_file_template_str = '''
 [redis]
 host = $redis_host
+port = $redis_port
 usr = $redis_user
 pwd = $redis_pass
 port = $redis_port
@@ -324,6 +334,7 @@ mechanism = SCRAM-SHA-1
 
 [redis]
 host = $redis_host
+port = $redis_port
 usr = $redis_user
 pwd = $redis_pass
 database = 0
@@ -350,6 +361,7 @@ maxIDleConns = 1000
 
 [redis]
 host = $redis_host
+port = $redis_port
 usr = $redis_user
 pwd = $redis_pass
 database = 0

--- a/src/auth/authcenter/adaptor.go
+++ b/src/auth/authcenter/adaptor.go
@@ -60,7 +60,7 @@ func convertResourceType(resourceType meta.ResourceType, businessID int64) (*Res
 			iamResourceType = SysModel
 		}
 
-	case meta.ModelModule, meta.ModelSet, meta.ModelInstanceTopology:
+	case meta.ModelModule, meta.ModelSet, meta.ModelInstanceTopology, meta.MainlineInstanceTopology:
 		iamResourceType = BizTopoInstance
 
 	case meta.MainlineModel, meta.ModelTopology:

--- a/src/auth/extensions/classification.go
+++ b/src/auth/extensions/classification.go
@@ -16,18 +16,53 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"configcenter/src/auth/meta"
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/condition"
 	"configcenter/src/common/metadata"
+	"configcenter/src/common/universalsql/mongo"
 	"configcenter/src/common/util"
 )
 
 /*
  * model classification which used for manage models as group
  */
+
+func (am *AuthManager) CollectClassificationByBusinessIDs(ctx context.Context, header http.Header, businessID int64) ([]metadata.Classification, error) {
+	condCheckModel := mongo.NewCondition()
+	if businessID != 0 {
+		_, metaCond := condCheckModel.Embed(metadata.BKMetadata)
+		_, labelCond := metaCond.Embed(metadata.BKLabel)
+		labelCond.Element(&mongo.Eq{Key: common.BKAppIDField, Val: strconv.FormatInt(businessID, 10)})
+	}
+	cond := condCheckModel.ToMapStr()
+	if businessID == 0 {
+		cond.Merge(metadata.BizLabelNotExist)
+	}
+	query := &metadata.QueryCondition{
+		Condition: cond,
+		Limit:     metadata.SearchLimit{Limit: common.BKNoLimit},
+	}
+	result, err := am.clientSet.CoreService().Instance().ReadInstance(ctx, header, common.BKTableNameObjClassifiction, query)
+	if err != nil {
+		blog.Errorf("get module:%+v by businessID:%d failed, err: %+v", businessID, err)
+		return nil, fmt.Errorf("get module by businessID:%d failed, err: %+v", businessID, err)
+	}
+
+	classifications := make([]metadata.Classification, 0)
+	for _, cls := range result.Data.Info {
+		classification := metadata.Classification{}
+		_, err = classification.Parse(cls)
+		if err != nil {
+			return nil, fmt.Errorf("get classication by object failed, err: %+v", err)
+		}
+		classifications = append(classifications, classification)
+	}
+	return classifications, nil
+}
 
 func (am *AuthManager) collectClassificationsByClassificationIDs(ctx context.Context, header http.Header, classificationIDs ...string) ([]metadata.Classification, error) {
 	// unique ids so that we can be aware of invalid id if query result length not equal ids's length
@@ -80,22 +115,25 @@ func (am *AuthManager) collectClassificationsByRawIDs(ctx context.Context, heade
 
 func (am *AuthManager) extractBusinessIDFromClassifications(classifications ...metadata.Classification) (int64, error) {
 	var businessID int64
-	for idx, classification := range classifications {
-
-		bizID, err := extractBusinessID(classification.Metadata.Label)
+	var err error
+	businessIDs := make([]int64, 0)
+	for _, classification := range classifications {
+		businessID, err = extractBusinessID(classification.Metadata.Label)
 		// we should ignore metadata.LabelBusinessID field not found error
 		if err != nil {
 			return 0, fmt.Errorf("parse biz id from classification: %+v failed, err: %+v", classification, err)
 		}
-		if idx > 0 && bizID != businessID {
-			return 0, fmt.Errorf("authorization failed, get multiple business ID from objects")
-		}
-		businessID = bizID
+		businessIDs = append(businessIDs, businessID)
+	}
+	businessIDs = util.IntArrayUnique(businessIDs)
+	if len(businessIDs) > 1 {
+		blog.Errorf("extractBusinessIDFromClassifications failed, get multiple business from classifications, business: %+v", businessIDs)
+		return 0, fmt.Errorf("get multiple business from classifictions, business: %+v", businessIDs)
 	}
 	return businessID, nil
 }
 
-func (am *AuthManager) makeResourcesByClassifications(header http.Header, action meta.Action, businessID int64, classifications ...metadata.Classification) []meta.ResourceAttribute {
+func (am *AuthManager) MakeResourcesByClassifications(header http.Header, action meta.Action, businessID int64, classifications ...metadata.Classification) []meta.ResourceAttribute {
 	resources := make([]meta.ResourceAttribute, 0)
 	for _, classification := range classifications {
 		resource := meta.ResourceAttribute{
@@ -131,7 +169,7 @@ func (am *AuthManager) AuthorizeByClassification(ctx context.Context, header htt
 	}
 
 	// make auth resources
-	resources := am.makeResourcesByClassifications(header, action, bizID, classifications...)
+	resources := am.MakeResourcesByClassifications(header, action, bizID, classifications...)
 
 	return am.authorize(ctx, header, bizID, resources...)
 }
@@ -152,7 +190,7 @@ func (am *AuthManager) UpdateRegisteredClassification(ctx context.Context, heade
 	}
 
 	// make auth resources
-	resources := am.makeResourcesByClassifications(header, meta.EmptyAction, bizID, classifications...)
+	resources := am.MakeResourcesByClassifications(header, meta.EmptyAction, bizID, classifications...)
 
 	for _, resource := range resources {
 		if err := am.Authorize.UpdateResource(ctx, &resource); err != nil {
@@ -179,6 +217,22 @@ func (am *AuthManager) UpdateRegisteredClassificationByID(ctx context.Context, h
 	return am.UpdateRegisteredClassification(ctx, header, classifications...)
 }
 
+func (am *AuthManager) UpdateRegisteredClassificationByRawID(ctx context.Context, header http.Header, ids ...int64) error {
+	if am.Enabled() == false {
+		return nil
+	}
+
+	if len(ids) == 0 {
+		return nil
+	}
+
+	classifications, err := am.collectClassificationsByRawIDs(ctx, header, ids...)
+	if err != nil {
+		return fmt.Errorf("update registered classifications failed, get classfication by raw id failed, err: %+v", err)
+	}
+	return am.UpdateRegisteredClassification(ctx, header, classifications...)
+}
+
 func (am *AuthManager) RegisterClassification(ctx context.Context, header http.Header, classifications ...metadata.Classification) error {
 	if am.Enabled() == false {
 		return nil
@@ -195,7 +249,7 @@ func (am *AuthManager) RegisterClassification(ctx context.Context, header http.H
 	}
 
 	// make auth resources
-	resources := am.makeResourcesByClassifications(header, meta.EmptyAction, bizID, classifications...)
+	resources := am.MakeResourcesByClassifications(header, meta.EmptyAction, bizID, classifications...)
 
 	return am.Authorize.RegisterResource(ctx, resources...)
 }
@@ -216,7 +270,7 @@ func (am *AuthManager) DeregisterClassification(ctx context.Context, header http
 	}
 
 	// make auth resources
-	resources := am.makeResourcesByClassifications(header, meta.EmptyAction, bizID, classifications...)
+	resources := am.MakeResourcesByClassifications(header, meta.EmptyAction, bizID, classifications...)
 
 	return am.Authorize.DeregisterResource(ctx, resources...)
 }

--- a/src/auth/extensions/instance.go
+++ b/src/auth/extensions/instance.go
@@ -108,8 +108,9 @@ func (am *AuthManager) extractBusinessIDFromInstances(instances ...InstanceSimpl
 		// we should ignore metadata.LabelBusinessID field not found error
 		businessIDs = append(businessIDs, instance.BizID)
 	}
+	businessIDs = util.IntArrayUnique(businessIDs)
 	if len(businessIDs) > 1 {
-		blog.V(5).Infof("extractBusinessIDFromInstances failed, get multiple business ID from instances")
+		blog.V(5).Infof("extractBusinessIDFromInstances failed, get multiple business ID from instances, businessIDs: %+v", businessIDs)
 		return 0, fmt.Errorf("get multiple business ID from objects")
 	}
 	return businessIDs[0], nil
@@ -319,16 +320,16 @@ func (am *AuthManager) UpdateRegisteredInstanceByRawID(ctx context.Context, head
 	return am.UpdateRegisteredInstances(ctx, header, instances...)
 }
 
-func (am *AuthManager) DeregisterInstanceByRawID(ctx context.Context, header http.Header, ids ...int64) error {
+func (am *AuthManager) DeregisterInstanceByRawID(ctx context.Context, header http.Header, objectID string, ids ...int64) error {
 	if am.Enabled() == false {
 		return nil
 	}
 
-	instances, err := am.collectClassificationsByRawIDs(ctx, header, ids...)
+	instances, err := am.collectInstancesByRawIDs(ctx, header, objectID, ids...)
 	if err != nil {
 		return fmt.Errorf("deregister instances failed, get instance by id failed, err: %+v", err)
 	}
-	return am.DeregisterClassification(ctx, header, instances...)
+	return am.DeregisterInstances(ctx, header, instances...)
 }
 
 func (am *AuthManager) RegisterInstancesByID(ctx context.Context, header http.Header, objectID string, ids ...int64) error {

--- a/src/auth/parser/host.go
+++ b/src/auth/parser/host.go
@@ -484,14 +484,14 @@ func (ps *parseStream) host() *parseStream {
 
 	// find hosts with condition operation.
 	if ps.hitPattern(findHostsWithConditionPattern, http.MethodPost) {
-		bizID, err := ps.parseBusinessID()
-		if err != nil {
-			ps.err = err
-			return ps
-		}
+		// bizID, err := ps.parseBusinessID()
+		// if err != nil {
+		//	ps.err = err
+		//	return ps
+		// }
 		ps.Attribute.Resources = []meta.ResourceAttribute{
 			meta.ResourceAttribute{
-				BusinessID: bizID,
+				// BusinessID: bizID,
 				Basic: meta.Basic{
 					Type:   meta.HostInstance,
 					Action: meta.FindMany,

--- a/src/auth/parser/topolatest.go
+++ b/src/auth/parser/topolatest.go
@@ -1507,7 +1507,8 @@ func (ps *parseStream) mainlineLatest() *parseStream {
 				BusinessID: bizID,
 				Basic: meta.Basic{
 					Type:   meta.MainlineModelTopology,
-					Action: meta.Find,
+					// Action: meta.Find,
+					Action: meta.SkipAction,
 				},
 			},
 		}

--- a/src/common/metadata/metadata.go
+++ b/src/common/metadata/metadata.go
@@ -80,10 +80,13 @@ func PublicAndBizCondition(meta Metadata) mapstr.MapStr {
 		return NewPublicOrBizConditionByBizID(0)
 	}
 
-	businessID, err = util.GetInt64ByInterface(bizID)
-	if err != nil {
-		blog.Errorf("PublicAndBizCondition parse business id failed, generate public condition only, bizID: %+v, err: %+v", bizID, err)
-		businessID = 0
+	bizIDStr := util.GetStrByInterface(bizID)
+	if len(bizIDStr) > 0 {
+		businessID, err = util.GetInt64ByInterface(bizID)
+		if err != nil {
+			blog.Errorf("PublicAndBizCondition parse business id failed, generate public condition only, bizID: %+v, err: %+v", bizID, err)
+			businessID = 0
+		}
 	}
 	return NewPublicOrBizConditionByBizID(businessID)
 }

--- a/src/scene_server/admin_server/synchronizer/handler/classification.go
+++ b/src/scene_server/admin_server/synchronizer/handler/classification.go
@@ -24,39 +24,39 @@ import (
 )
 
 // HandleModuleSync do sync module of one business
-func (ih *IAMHandler) HandleModuleSync(task *meta.WorkRequest) error {
+func (ih *IAMHandler) HandleClassificationSync(task *meta.WorkRequest) error {
 	businessSimplify := task.Data.(extensions.BusinessSimplify)
 	header := utils.NewAPIHeaderByBusiness(&businessSimplify)
 
 	// step1 get instances by business from core service
 	bizID := businessSimplify.BKAppIDField
-	modules, err := ih.authManager.CollectModuleByBusinessIDs(context.Background(), *header, bizID)
+	classifications, err := ih.authManager.CollectClassificationByBusinessIDs(context.Background(), *header, bizID)
 	if err != nil {
-		blog.Errorf("collect module by business id failed, err: %+v", err)
+		blog.Errorf("collect classifications by business id failed, err: %+v", err)
 		return err
 	}
-	if len(modules) == 0 {
-		blog.Infof("no modules found for business: %d", bizID)
+	if len(classifications) == 0 {
+		blog.Infof("no classifications found for business: %d", bizID)
 		return nil
 	}
-	resources := ih.authManager.MakeResourcesByModule(*header, authmeta.EmptyAction, bizID, modules...)
-	if len(resources) == 0 && len(modules) > 0 {
-		blog.Errorf("make iam resource for modules %+v return empty", modules)
+	resources := ih.authManager.MakeResourcesByClassifications(*header, authmeta.EmptyAction, bizID, classifications...)
+	if len(resources) == 0 && len(classifications) > 0 {
+		blog.Errorf("make iam resource for classifications %+v return empty", classifications)
 		return nil
 	}
 
-	// step2 get modules by business from iam
+	// step2 get classifications by business from iam
 	rs := &authmeta.ResourceAttribute{
 		Basic: authmeta.Basic{
-			Type: authmeta.ModelModule,
+			Type: authmeta.ModelClassification,
 		},
 		SupplierAccount: "",
 		BusinessID:      businessSimplify.BKAppIDField,
 		Layers:          make([]authmeta.Item, 0),
 	}
 
-	taskName := fmt.Sprintf("sync module for business: %d", businessSimplify.BKAppIDField)
-	iamIDPrefix := "module"
+	taskName := fmt.Sprintf("sync classifications for business: %d", businessSimplify.BKAppIDField)
+	iamIDPrefix := ""
 	skipDeregister := false
 	return ih.diffAndSync(taskName, rs, iamIDPrefix, resources, skipDeregister)
 }

--- a/src/scene_server/admin_server/synchronizer/handler/classification.go
+++ b/src/scene_server/admin_server/synchronizer/handler/classification.go
@@ -1,0 +1,62 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package handler
+
+import (
+	"context"
+	"fmt"
+
+	"configcenter/src/auth/extensions"
+	authmeta "configcenter/src/auth/meta"
+	"configcenter/src/common/blog"
+	"configcenter/src/scene_server/admin_server/synchronizer/meta"
+	"configcenter/src/scene_server/admin_server/synchronizer/utils"
+)
+
+// HandleModuleSync do sync module of one business
+func (ih *IAMHandler) HandleModuleSync(task *meta.WorkRequest) error {
+	businessSimplify := task.Data.(extensions.BusinessSimplify)
+	header := utils.NewAPIHeaderByBusiness(&businessSimplify)
+
+	// step1 get instances by business from core service
+	bizID := businessSimplify.BKAppIDField
+	modules, err := ih.authManager.CollectModuleByBusinessIDs(context.Background(), *header, bizID)
+	if err != nil {
+		blog.Errorf("collect module by business id failed, err: %+v", err)
+		return err
+	}
+	if len(modules) == 0 {
+		blog.Infof("no modules found for business: %d", bizID)
+		return nil
+	}
+	resources := ih.authManager.MakeResourcesByModule(*header, authmeta.EmptyAction, bizID, modules...)
+	if len(resources) == 0 && len(modules) > 0 {
+		blog.Errorf("make iam resource for modules %+v return empty", modules)
+		return nil
+	}
+
+	// step2 get modules by business from iam
+	rs := &authmeta.ResourceAttribute{
+		Basic: authmeta.Basic{
+			Type: authmeta.ModelModule,
+		},
+		SupplierAccount: "",
+		BusinessID:      businessSimplify.BKAppIDField,
+		Layers:          make([]authmeta.Item, 0),
+	}
+
+	taskName := fmt.Sprintf("sync module for business: %d", businessSimplify.BKAppIDField)
+	iamIDPrefix := "module"
+	skipDeregister := false
+	return ih.diffAndSync(taskName, rs, iamIDPrefix, resources, skipDeregister)
+}

--- a/src/scene_server/admin_server/synchronizer/meta/types.go
+++ b/src/scene_server/admin_server/synchronizer/meta/types.go
@@ -28,6 +28,7 @@ var (
 	AuditCategory        = ResourceType("audit")
 	ProcessResource      = ResourceType("process")
 	DynamicGroupResource = ResourceType("dynamicGroup")
+	ClassificationResource = ResourceType("classification")
 )
 
 // ResourceType represent a resource type that will be enqueue to WorkerQueue
@@ -52,4 +53,5 @@ type SyncHandler interface {
 	HandleAuditSync(task *WorkRequest) error
 	HandleProcessSync(task *WorkRequest) error
 	HandleDynamicGroupSync(task *WorkRequest) error
+	HandleClassificationSync(task *WorkRequest) error
 }

--- a/src/scene_server/admin_server/synchronizer/producer.go
+++ b/src/scene_server/admin_server/synchronizer/producer.go
@@ -104,8 +104,16 @@ func (p *Producer) generateJobs() *[]meta.WorkRequest {
 	blog.Info("list business businessList: %+v", businessList)
 
 	// job of synchronize business scope resources to iam
-	// resourceTypes := []meta.ResourceType{meta.HostResource, meta.SetResource, meta.ModuleResource, meta.ModelResource, meta.ProcessResource, meta.DynamicGroupResource, meta.AuditCategory}
-	resourceTypes := []meta.ResourceType{}
+	resourceTypes := []meta.ResourceType{
+		meta.HostResource, 
+		meta.SetResource, 
+		meta.ModuleResource, 
+		meta.ModelResource, 
+		meta.ProcessResource, 
+		meta.DynamicGroupResource, 
+		meta.AuditCategory,
+		meta.ClassificationResource,
+	}
 	for _, resourceType := range resourceTypes {
 		for _, businessSimplify := range businessList {
 			jobs = append(jobs, meta.WorkRequest{

--- a/src/scene_server/admin_server/synchronizer/producer.go
+++ b/src/scene_server/admin_server/synchronizer/producer.go
@@ -123,25 +123,23 @@ func (p *Producer) generateJobs() *[]meta.WorkRequest {
 		}
 	}
 
-	/*
-		for _, business := range businessList {
-			header := utils.NewListBusinessAPIHeader()
-			objects, err := p.authManager.CollectObjectsByBusinessID(context.Background(), *header, business.BKAppIDField)
-			if err != nil {
-				blog.Errorf("get models by business id: %d failed, err: %+v", business.BKAppIDField, err)
-				continue
-			}
-			for _, object := range objects {
-				jobs = append(jobs, meta.WorkRequest{
-					ResourceType: meta.InstanceResource,
-					Data:         object,
-					Header:       *header,
-				})
-			}
+	for _, business := range businessList {
+		header := utils.NewListBusinessAPIHeader()
+		objects, err := p.authManager.CollectObjectsByBusinessID(context.Background(), *header, business.BKAppIDField)
+		if err != nil {
+			blog.Errorf("get models by business id: %d failed, err: %+v", business.BKAppIDField, err)
+			continue
 		}
-	*/
+		for _, object := range objects {
+			jobs = append(jobs, meta.WorkRequest{
+				ResourceType: meta.InstanceResource,
+				Data:         object,
+				Header:       *header,
+			})
+		}
+	}
 
-	// some resoure type neeed sync global resource
+	// some resource type need sync global resource
 	globalBusiness := extensions.BusinessSimplify{
 		BKAppIDField:      0,
 		BKAppNameField:    "",
@@ -149,7 +147,10 @@ func (p *Producer) generateJobs() *[]meta.WorkRequest {
 		BKOwnerIDField:    "",
 		IsDefault:         0,
 	}
-	resourceTypes = []meta.ResourceType{meta.AuditCategory}
+	resourceTypes = []meta.ResourceType{
+		meta.AuditCategory,
+		meta.ClassificationResource,
+	}
 	for _, resourceType := range resourceTypes {
 		jobs = append(jobs, meta.WorkRequest{
 			ResourceType: resourceType,

--- a/src/scene_server/admin_server/synchronizer/worker.go
+++ b/src/scene_server/admin_server/synchronizer/worker.go
@@ -90,6 +90,9 @@ func (w *Worker) doWork(work *meta.WorkRequest) error {
 		w.SyncHandler.HandleProcessSync(work)
 	case meta.DynamicGroupResource:
 		w.SyncHandler.HandleDynamicGroupSync(work)
+	case meta.ClassificationResource:
+		w.SyncHandler.HandleClassificationSync(work)
+
 	default:
 		blog.Errorf("work type:%s didn't register yet.", work.ResourceType)
 

--- a/src/scene_server/topo_server/core/operation/classification.go
+++ b/src/scene_server/topo_server/core/operation/classification.go
@@ -259,13 +259,6 @@ func (c *classification) UpdateClassification(params types.ContextParams, data m
 
 	class := cls.Classify()
 	class.ID = id
-	if len(class.ClassificationName) != 0 {
-		// auth: update registered classifications
-		if err := c.authManager.UpdateRegisteredClassification(params.Context, params.Header, class); err != nil {
-			blog.Errorf("update classification %s, but update to auth failed, err: %v", class.ClassificationName, err)
-			return params.Err.New(common.CCErrCommRegistResourceToIAMFailed, err.Error())
-		}
-	}
 
 	// auth: check authorization
 	// if err := c.authManager.AuthorizeByClassification(params.Context, params.Header, meta.Update, class); err != nil {
@@ -277,6 +270,19 @@ func (c *classification) UpdateClassification(params types.ContextParams, data m
 	if nil != err {
 		blog.Errorf("[operation-cls]failed to update the classification(%#v), error info is %s", cls, err.Error())
 		return err
+	}
+	
+	// auth: update registered classifications
+	if len(class.ClassificationID) > 0 {
+		if err := c.authManager.UpdateRegisteredClassificationByID(params.Context, params.Header, class.ClassificationID); err != nil {
+			blog.Errorf("update classification %s, but update to auth failed, err: %v", class.ClassificationName, err)
+			return params.Err.New(common.CCErrCommRegistResourceToIAMFailed, err.Error())
+		}
+	} else {
+		if err := c.authManager.UpdateRegisteredClassificationByID(params.Context, params.Header, class.ClassificationID); err != nil {
+			blog.Errorf("update classification %s, but update to auth failed, err: %v", class.ClassificationName, err)
+			return params.Err.New(common.CCErrCommRegistResourceToIAMFailed, err.Error())
+		}
 	}
 
 	return nil

--- a/src/scene_server/topo_server/service/association.go
+++ b/src/scene_server/topo_server/service/association.go
@@ -27,6 +27,7 @@ import (
 func (s *Service) CreateMainLineObject(params types.ContextParams, pathParams, queryParams ParamsGetter, data mapstr.MapStr) (output interface{}, retErr error) {
 	tx, err := s.Txn.StartTransaction(context.Background())
 	if err != nil {
+		blog.Errorf("create mainline object failed, start transaction failed, err: %v", err)
 		return nil, params.Err.Error(common.CCErrObjectDBOpErrno)
 	}
 	params.Header = tx.TxnInfo().IntoHeader(params.Header)

--- a/src/scene_server/topo_server/service/inst.go
+++ b/src/scene_server/topo_server/service/inst.go
@@ -122,7 +122,7 @@ func (s *Service) DeleteInsts(params types.ContextParams, pathParams, queryParam
 	}
 
 	// auth: deregister resources
-	if err := s.AuthManager.DeregisterInstanceByRawID(params.Context, params.Header, deleteCondition.Delete.InstID...); err != nil {
+	if err := s.AuthManager.DeregisterInstanceByRawID(params.Context, params.Header, obj.GetObjectID(), deleteCondition.Delete.InstID...); err != nil {
 		blog.Errorf("batch delete instance failed, deregister instance failed, instID: %d, err: %s", deleteCondition.Delete.InstID, err)
 		return nil, params.Err.Error(common.CCErrCommUnRegistResourceToIAMFailed)
 	}
@@ -150,7 +150,7 @@ func (s *Service) DeleteInst(params types.ContextParams, pathParams, queryParams
 	}
 
 	// auth: deregister resources
-	if err := s.AuthManager.DeregisterInstanceByRawID(params.Context, params.Header, instID); err != nil {
+	if err := s.AuthManager.DeregisterInstanceByRawID(params.Context, params.Header, obj.GetObjectID(), instID); err != nil {
 		blog.Errorf("delete instance failed, deregister instance failed, instID: %d, err: %s", instID, err)
 		return nil, params.Err.Error(common.CCErrCommUnRegistResourceToIAMFailed)
 	}


### PR DESCRIPTION
### 修复的问题：
- [x] 非业务下搜索主机信息失败
- [x] 主线模型查询放开
- [x] cmdb启动配置文件默认将redis端口与host信息分开配置
- [x] 模型分组编辑/删除失败bugfix
- [x] 实例批量删除/编辑bugfix
- [x] apiserver中跳过/identifier/host/search权限校验
- [x] apiserver部分接口鉴权区根据参数分业务模式和全局模式
- [x] metadata解析业务ID兼容空字符串问题（部分接口传递的metadata信息中业务id空字符串）
- [x] 1. 开启iam同步任务；2. 新增模型分组同步到iam
- [x] 模型分组属性修改bugfix
- [x] 批量删除实例bugfix

close #2301 
