### PR TITLE
回滚：coreservice中进程模块metadata采用结构体替换mapstr #2439

### DIFF
--- a/src/common/metadata/metadata.go
+++ b/src/common/metadata/metadata.go
@@ -116,15 +116,6 @@ func NewMetaDataFromBusinessID(value string) Metadata {
 	return meta
 }
 
-func NewMetaDataNGFromBusinessID(bizID int64) MetadataNG {
-	md := MetadataNG{
-		Label: LabelNG{
-			BusinessID: strconv.FormatInt(bizID, 10),
-		},
-	}
-	return md
-}
-
 func GetBusinessIDFromMeta(data interface{}) string {
 	if nil == data {
 		return ""
@@ -216,15 +207,6 @@ func (label Label) ToMapStr() mapstr.MapStr {
 		result[key] = value
 	}
 	return result
-}
-
-// MetadataNG is next generation metadata that define with struct
-type MetadataNG struct {
-	Label LabelNG `field:"label" json:"label" bson:"label"`
-}
-
-type LabelNG struct {
-	BusinessID string `field:"bk_biz_id" json:"bk_biz_id" bson:"bk_biz_id"`
 }
 
 // isTrue is used to check if the label key is a true value or not.

--- a/src/common/metadata/process.go
+++ b/src/common/metadata/process.go
@@ -233,7 +233,7 @@ type Process struct {
 }
 
 type ServiceCategory struct {
-	Metadata MetadataNG `field:"metadata" json:"metadata" bson:"metadata"`
+	Metadata Metadata `field:"metadata" json:"metadata" bson:"metadata"`
 
 	ID   int64  `field:"id" json:"id,omitempty" bson:"id"`
 	Name string `field:"name" json:"name,omitempty" bson:"name"`
@@ -263,7 +263,7 @@ type ServiceCategoryWithStatistics struct {
 }
 
 type ServiceTemplate struct {
-	Metadata MetadataNG `field:"metadata" json:"metadata" bson:"metadata"`
+	Metadata Metadata `field:"metadata" json:"metadata" bson:"metadata"`
 
 	ID int64 `field:"id" json:"id,omitempty" bson:"id"`
 	// name of this service, can not be empty
@@ -293,8 +293,8 @@ func (st *ServiceTemplate) Validate() (field string, err error) {
 
 // this works for the process instance which is used for a template.
 type ProcessTemplate struct {
-	ID       int64      `field:"id" json:"id,omitempty" bson:"id"`
-	Metadata MetadataNG `field:"metadata" json:"metadata" bson:"metadata"`
+	ID       int64    `field:"id" json:"id,omitempty" bson:"id"`
+	Metadata Metadata `field:"metadata" json:"metadata" bson:"metadata"`
 	// the service template's, which this process template belongs to.
 	ServiceTemplateID int64 `field:"service_template_id" json:"service_template_id" bson:"service_template_id"`
 
@@ -508,9 +508,9 @@ func (ti *PropertyProtocol) Validate() error {
 
 // ServiceInstance is a service, which created when a host binding with a service template.
 type ServiceInstance struct {
-	Metadata MetadataNG `field:"metadata" json:"metadata" bson:"metadata"`
-	ID       int64      `field:"id" json:"id,omitempty" bson:"id"`
-	Name     string     `field:"name" json:"name,omitempty" bson:"name"`
+	Metadata Metadata `field:"metadata" json:"metadata" bson:"metadata"`
+	ID       int64    `field:"id" json:"id,omitempty" bson:"id"`
+	Name     string   `field:"name" json:"name,omitempty" bson:"name"`
 
 	// the template id can not be updated, once the service is created.
 	// it can be 0 when the service is not created with a service template.
@@ -540,7 +540,7 @@ func (si *ServiceInstance) Validate() (field string, err error) {
 
 // ServiceInstanceRelations record which service instance and process template are current process binding, process identified by ProcessID
 type ProcessInstanceRelation struct {
-	Metadata MetadataNG `field:"metadata" json:"metadata" bson:"metadata"`
+	Metadata Metadata `field:"metadata" json:"metadata" bson:"metadata"`
 
 	// unique field, 1:1 mapping with ProcessInstance.
 	ProcessID         int64 `field:"process_id" json:"process_id" bson:"process_id"`

--- a/src/source_controller/coreservice/core/process/process.go
+++ b/src/source_controller/coreservice/core/process/process.go
@@ -14,7 +14,6 @@ package process
 
 import (
 	"fmt"
-	"strconv"
 
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
@@ -34,11 +33,11 @@ func New(dbProxy dal.RDB) core.ProcessOperation {
 	return processOps
 }
 
-func (p *processOperation) validateBizID(ctx core.ContextParams, md metadata.MetadataNG) (int64, error) {
+func (p *processOperation) validateBizID(ctx core.ContextParams, md metadata.Metadata) (int64, error) {
 	// extract biz id from metadata
-	bizID, err := strconv.ParseInt(md.Label.BusinessID, 10, 64)
+	bizID, err := metadata.BizIDFromMetadata(md)
 	if err != nil {
-		blog.Errorf("parse biz id from metadata failed, bizID: %s, err: %+v", md.Label.BusinessID, err)
+		blog.Errorf("parse biz id from metadata failed, metadata: %+v, err: %+v", md, err)
 		return 0, err
 	}
 

--- a/src/source_controller/coreservice/core/process/process_instance_relation.go
+++ b/src/source_controller/coreservice/core/process/process_instance_relation.go
@@ -37,7 +37,7 @@ func (p *processOperation) CreateProcessInstanceRelation(ctx core.ContextParams,
 	}
 
 	// keep metadata clean
-	relation.Metadata = metadata.NewMetaDataNGFromBusinessID(bizID)
+	relation.Metadata = metadata.NewMetaDataFromBusinessID(strconv.FormatInt(bizID, 10))
 
 	// validate service category id field
 	_, err = p.GetServiceInstance(ctx, relation.ServiceInstanceID)

--- a/src/source_controller/coreservice/core/process/process_template.go
+++ b/src/source_controller/coreservice/core/process/process_template.go
@@ -38,7 +38,7 @@ func (p *processOperation) CreateProcessTemplate(ctx core.ContextParams, templat
 	}
 
 	// keep metadata clean
-	template.Metadata = metadata.NewMetaDataNGFromBusinessID(bizID)
+	template.Metadata = metadata.NewMetaDataFromBusinessID(strconv.FormatInt(bizID, 10))
 
 	// validate service template id field
 	_, err = p.GetServiceTemplate(ctx, template.ServiceTemplateID)

--- a/src/source_controller/coreservice/core/process/service_category.go
+++ b/src/source_controller/coreservice/core/process/service_category.go
@@ -38,7 +38,7 @@ func (p *processOperation) CreateServiceCategory(ctx core.ContextParams, categor
 	}
 
 	// keep metadata clean
-	category.Metadata = metadata.NewMetaDataNGFromBusinessID(bizID)
+	category.Metadata = metadata.NewMetaDataFromBusinessID(strconv.FormatInt(bizID, 10))
 
 	category.RootID = 0
 	if category.ParentID > 0 {

--- a/src/source_controller/coreservice/core/process/service_instance.go
+++ b/src/source_controller/coreservice/core/process/service_instance.go
@@ -38,7 +38,7 @@ func (p *processOperation) CreateServiceInstance(ctx core.ContextParams, instanc
 	}
 
 	// keep metadata clean
-	instance.Metadata = metadata.NewMetaDataNGFromBusinessID(bizID)
+	instance.Metadata = metadata.NewMetaDataFromBusinessID(strconv.FormatInt(bizID, 10))
 
 	// validate service template id field
 	_, err = p.GetServiceTemplate(ctx, instance.ServiceTemplateID)

--- a/src/source_controller/coreservice/core/process/service_template.go
+++ b/src/source_controller/coreservice/core/process/service_template.go
@@ -39,7 +39,7 @@ func (p *processOperation) CreateServiceTemplate(ctx core.ContextParams, templat
 	}
 
 	// keep metadata clean
-	template.Metadata = metadata.NewMetaDataNGFromBusinessID(bizID)
+	template.Metadata = metadata.NewMetaDataFromBusinessID(strconv.FormatInt(bizID, 10))
 
 	// validate service category id field
 	_, err = p.GetServiceCategory(ctx, template.ServiceCategoryID)


### PR DESCRIPTION
### 优化的功能:
- 回滚：coreservice中进程模块metadata采用结构体替换mapstr
