### PR TITLE
feat 配置平台-业务主机 右侧过滤，增加sn批量查询功能，方便根据sn批量查询主机

### DIFF
--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -226,6 +226,9 @@ const (
 	// BKHostIDField the host id field
 	BKHostIDField = "bk_host_id"
 
+	// BKSnField the host sn field
+	BKSnField = "bk_sn"
+
 	// BKHostNameField the host name field
 	BKHostNameField = "bk_host_name"
 

--- a/src/common/metadata/hostserver.go
+++ b/src/common/metadata/hostserver.go
@@ -88,6 +88,7 @@ type HostToAppModule struct {
 type HostCommonSearch struct {
 	AppID     int64             `json:"bk_biz_id,omitempty"`
 	Ip        IPInfo            `json:"ip"`
+	Sn        []string          `json:"sn"`
 	Condition []SearchCondition `json:"condition"`
 	Page      BasePage          `json:"page"`
 	Pattern   string            `json:"pattern,omitempty"`

--- a/src/common/paraparse/host.go
+++ b/src/common/paraparse/host.go
@@ -145,3 +145,20 @@ func ParseHostIPParams(ipCond metadata.IPInfo, output map[string]interface{}) er
 	}
 	return nil
 }
+
+//SN 批量查询
+func ParseSnParam(sn []string, output map[string]interface{}) error {
+	if len(sn) < 1 {
+		return nil
+	}
+	c := make(map[string]interface{})
+	c[common.BKDBIN] = sn
+
+	snCon := make(map[string]map[string]interface{})
+	snCon[common.BKSnField] = c
+
+	orCond := make([]map[string]map[string]interface{}, 0)
+	output[common.BKDBAND] = append(orCond, snCon)
+
+	return nil
+}

--- a/src/scene_server/host_server/logics/hostsearch.go
+++ b/src/scene_server/host_server/logics/hostsearch.go
@@ -683,6 +683,7 @@ func (sh *searchHost) searchByHostConds() error {
 	condition := make(map[string]interface{})
 	hostParse.ParseHostParams(sh.conds.hostCond.Condition, condition)
 	hostParse.ParseHostIPParams(sh.hostSearchParam.Ip, condition)
+	hostParse.ParseSnParam(sh.hostSearchParam.Sn, condition)
 
 	query := &metadata.QueryInput{
 		Condition: condition,
@@ -691,7 +692,10 @@ func (sh *searchHost) searchByHostConds() error {
 		Sort:      sh.hostSearchParam.Page.Sort,
 	}
 
+	blog.Infof("searchByHostConds query:%v", query)
+
 	gResult, err := sh.lgc.CoreAPI.HostController().Host().GetHosts(context.Background(), sh.pheader, query)
+
 	if err != nil {
 		blog.Errorf("get hosts failed, err: %v, rid:%s", err, sh.ccRid)
 		return err

--- a/src/ui/src/components/hosts/filter/_filter.vue
+++ b/src/ui/src/components/hosts/filter/_filter.vue
@@ -14,6 +14,8 @@
                 <cmdb-form-bool class="filter-field-bool" v-model="ip.exact" :true-value="1" :false-value="0">
                     <span class="filter-field-bool-label">{{$t('HostResourcePool[\'精确\']')}}</span>
                 </cmdb-form-bool>
+                <label for="filterSn" class="filter-label">SN</label>
+                <textarea id="filterSn" class="filter-field filter-field-ip" v-model.trim="sn"></textarea>
             </div>
             <slot name="scope"></slot>
             <div class="filter-group">
@@ -137,6 +139,7 @@
                     'bk_host_outerip': true,
                     exact: 0
                 },
+                sn: '',
                 condition: {},
                 associateFieldMap: {
                     'biz': 'bk_biz_name',
@@ -197,6 +200,15 @@
                     }
                 })
                 return ipArray
+            },
+            snArray () {
+                const snArray = []
+                this.sn.split(/\n|;|；|,|，/).forEach(text => {
+                    if (text.trim().length) {
+                        snArray.push(text.trim())
+                    }
+                })
+                return snArray
             }
         },
         watch: {
@@ -309,6 +321,7 @@
                         exact: this.ip.exact,
                         data: this.ipArray
                     },
+                    sn: this.snArray,
                     condition: []
                 }
                 // 填充必要模型查询参数
@@ -626,7 +639,7 @@
             font-size: 12px;
         }
         .form-name {
-            color: $cmdbTextColor;    
+            color: $cmdbTextColor;
         }
         .form-error {
             position: absolute;


### PR DESCRIPTION
### 新加的功能:
- 蓝鲸配置平台-业务主机 右侧过滤，增加sn批量查询功能，方便根据sn批量查询主机


