### PR TITLE
V3.5.x 新增进程模板相关功能

### DIFF
--- a/src/apimachinery/coreservice/process/api.go
+++ b/src/apimachinery/coreservice/process/api.go
@@ -107,8 +107,8 @@ func (p *process) DeleteServiceCategory(ctx context.Context, h http.Header, cate
 	return nil
 }
 
-func (p *process) ListServiceCategories(ctx context.Context, h http.Header, bizID int64, withStatistics bool) (resp *metadata.MultipleServiceCategory, err error) {
-	ret := new(metadata.MultipleServiceCategoryResult)
+func (p *process) ListServiceCategories(ctx context.Context, h http.Header, bizID int64, withStatistics bool) (resp *metadata.MultipleServiceCategoryWithStatistics, err error) {
+	ret := new(metadata.MultipleServiceCategoryWithStatisticsResult)
 	subPath := "/findmany/process/service_category"
 
 	input := map[string]interface{}{

--- a/src/apimachinery/coreservice/process/process.go
+++ b/src/apimachinery/coreservice/process/process.go
@@ -25,7 +25,7 @@ type ProcessInterface interface {
 	CreateServiceCategory(ctx context.Context, h http.Header, category *metadata.ServiceCategory) (resp *metadata.ServiceCategory, err error)
 	GetServiceCategory(ctx context.Context, h http.Header, categoryID int64) (resp *metadata.ServiceCategory, err error)
 	UpdateServiceCategory(ctx context.Context, h http.Header, categoryID int64, category *metadata.ServiceCategory) (resp *metadata.ServiceCategory, err error)
-	ListServiceCategories(ctx context.Context, h http.Header, bizID int64, withStatistics bool) (resp *metadata.MultipleServiceCategory, err error)
+	ListServiceCategories(ctx context.Context, h http.Header, bizID int64, withStatistics bool) (resp *metadata.MultipleServiceCategoryWithStatistics, err error)
 	DeleteServiceCategory(ctx context.Context, h http.Header, categoryID int64) error
 
 	// service template

--- a/src/common/metadata/core_service.go
+++ b/src/common/metadata/core_service.go
@@ -266,7 +266,7 @@ type OneServiceCategoryResult struct {
 	Data     ServiceCategory `json:"data"`
 }
 
-type ServiceCategoryWithStatisticsResult struct {
+type OneServiceCategoryWithStatisticsResult struct {
 	BaseResp `json:",inline"`
 	Data     ServiceCategoryWithStatistics `json:"data"`
 }
@@ -276,9 +276,19 @@ type MultipleServiceCategory struct {
 	Info  []ServiceCategory `json:"info"`
 }
 
+type MultipleServiceCategoryWithStatistics struct {
+	Count int64                           `json:"count"`
+	Info  []ServiceCategoryWithStatistics `json:"info"`
+}
+
 type MultipleServiceCategoryResult struct {
 	BaseResp `json:",inline"`
 	Data     MultipleServiceCategory `json:"data"`
+}
+
+type MultipleServiceCategoryWithStatisticsResult struct {
+	BaseResp `json:",inline"`
+	Data     MultipleServiceCategoryWithStatistics `json:"data"`
 }
 
 type ListServiceTemplateOption struct {

--- a/src/common/metadata/core_service.go
+++ b/src/common/metadata/core_service.go
@@ -346,9 +346,10 @@ type DeleteProcessInstanceRelationOption struct {
 }
 
 type ListProcessTemplatesOption struct {
-	BusinessID         int64   `json:"bk_biz_id"`
-	ServiceTemplateID  int64   `json:"service_template_id,omitempty"`
-	ProcessTemplateIDs []int64 `json:"process_template_ids,omitempty"`
+	BusinessID         int64    `json:"bk_biz_id" bson:"bk_biz_id"`
+	ServiceTemplateID  int64    `json:"service_template_id,omitempty" bson:"service_template_id"`
+	ProcessTemplateIDs *[]int64 `json:"process_template_ids,omitempty" bson:"process_template_ids"`
+	Page               BasePage `json:"page" field:"page" bson:"page"`
 }
 
 type OneServiceInstanceResult struct {

--- a/src/common/metadata/process.go
+++ b/src/common/metadata/process.go
@@ -67,7 +67,7 @@ type CreateServiceInstanceForServiceTemplateInput struct {
 	Metadata   Metadata                `json:"metadata"`
 	Name       string                  `json:"name"`
 	TemplateID int64                   `json:"service_template_id"`
-	ModuleID   int64                   `json:"module_id"`
+	ModuleID   int64                   `json:"bk_module_id"`
 	Instances  []ServiceInstanceDetail `json:"instances"`
 }
 
@@ -78,35 +78,35 @@ type DeleteProcessInstanceInServiceInstanceInput struct {
 
 type GetServiceInstanceInModuleInput struct {
 	Metadata Metadata `json:"metadata"`
-	ModuleID int64    `json:"module_id"`
+	ModuleID int64    `json:"bk_module_id"`
 	Page     BasePage `json:"page"`
 	WithName bool     `json:"with_name"`
 }
 
 type FindServiceTemplateAndInstanceDifferenceOption struct {
 	Metadata          Metadata `json:"metadata"`
-	ModuleID          int64    `json:"module_id"`
+	ModuleID          int64    `json:"bk_module_id"`
 	ServiceTemplateID int64    `json:"service_template_id"`
 }
 
 type DeleteServiceInstanceOption struct {
-	Metadata          Metadata `json:"metadata"`
-	ServiceInstanceID int64    `json:"id"`
+	Metadata          Metadata `json:"metadata" field:"metadata" bson:"metadata"`
+	ServiceInstanceID int64    `json:"id" field:"id" bson:"id"`
 }
 
 type FindServiceAndProcessInstanceOption struct {
-	Metadata          Metadata `json:"metadata"`
-	ModuleID          int64    `json:"module_id"`
-	ServiceTemplateID int64    `json:"service_template_id"`
+	Metadata          Metadata `json:"metadata" field:"metadata" bson:"metadata"`
+	ModuleID          int64    `json:"bk_module_id" field:"bk_module_id" bson:"bk_module_id"`
+	ServiceTemplateID int64    `json:"service_template_id" field:"service_template_id" bson:"service_template_id"`
 }
 
 // to describe the differences between service instance and it's service template's
 // process template's attribute.
 type ServiceProcessInstanceDifference struct {
-	ServiceInstanceID   int64             `json:"service_instance_id"`
-	ServiceInstanceName string            `json:"service_instance_name"`
-	HostID              int64             `json:"host_id"`
-	Differences         *DifferenceDetail `json:"differences"`
+	ServiceInstanceID   int64             `json:"service_instance_id" field:"service_instance_id" bson:"service_instance_id"`
+	ServiceInstanceName string            `json:"service_instance_name" field:"service_instance_name" bson:"service_instance_name"`
+	HostID              int64             `json:"bk_host_id" field:"bk_host_id" bson:"bk_host_id"`
+	Differences         *DifferenceDetail `json:"differences" field:"differences" bson:"differences"`
 }
 
 type DifferenceDetail struct {
@@ -159,7 +159,7 @@ type ServiceDifferenceDetails struct {
 }
 
 type ServiceInstanceDetail struct {
-	HostID    int64                   `json:"host_id"`
+	HostID    int64                   `json:"bk_host_id"`
 	Processes []ProcessInstanceDetail `json:"processes"`
 }
 
@@ -177,13 +177,13 @@ type ListProcessTemplateWithServiceTemplateInput struct {
 type ForceSyncServiceInstanceWithTemplateInput struct {
 	Metadata          Metadata `json:"metadata"`
 	ServiceTemplateID int64    `json:"service_template_id"`
-	ModuleID          int64    `json:"module_id"`
+	ModuleID          int64    `json:"bk_module_id"`
 	ServiceInstances  []int64  `json:"service_instances"`
 }
 
 type ListServiceInstancesWithHostInput struct {
 	Metadata Metadata `json:"metadata"`
-	HostID   int64    `json:"host_id"`
+	HostID   int64    `json:"bk_host_id"`
 	WithName bool     `json:"with_name"`
 }
 
@@ -391,6 +391,7 @@ type ProcessProperty struct {
 	TimeoutSeconds     PropertyInt64       `field:"timeout" json:"timeout,omitempty" bson:"timeout,omitempty"`
 	Protocol           PropertyProtocol    `field:"protocol" json:"protocol,omitempty" bson:"protocol,omitempty"`
 	Description        PropertyString      `field:"description" json:"description,omitempty" bson:"description,omitempty"`
+	StartParamRegex    PropertyString      `field:"bk_start_param_regex" json:"bk_start_param_regex,omitempty" bson:"bk_start_param_regex,omitempty"`
 }
 
 func (pt *ProcessProperty) Validate() (field string, err error) {
@@ -567,10 +568,10 @@ type ServiceInstance struct {
 	// the template id can not be updated, once the service is created.
 	// it can be 0 when the service is not created with a service template.
 	ServiceTemplateID int64 `field:"service_template_id" json:"service_template_id,omitempty" bson:"service_template_id"`
-	HostID            int64 `field:"bk_host_id" json:"host_id,omitempty" bson:"host_id"`
+	HostID            int64 `field:"bk_host_id" json:"bk_host_id,omitempty" bson:"bk_host_id"`
 
 	// the module that this service belongs to.
-	ModuleID int64 `field:"module_id" json:"module_id,omitempty" bson:"module_id"`
+	ModuleID int64 `field:"bk_module_id" json:"bk_module_id,omitempty" bson:"bk_module_id"`
 
 	Creator         string    `field:"creator" json:"creator,omitempty" bson:"creator"`
 	Modifier        string    `field:"modifier" json:"modifier,omitempty" bson:"modifier"`

--- a/src/common/metadata/process.go
+++ b/src/common/metadata/process.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"configcenter/src/common"
+	"configcenter/src/common/mapstr"
 	"configcenter/src/common/util"
 )
 
@@ -185,6 +186,11 @@ type ListServiceInstancesWithHostInput struct {
 	Metadata Metadata `json:"metadata"`
 	HostID   int64    `json:"bk_host_id"`
 	WithName bool     `json:"with_name"`
+}
+
+type ListProcessInstancesOption struct {
+	Metadata          Metadata `json:"metadata"`
+	ServiceInstanceID int64    `json:"service_instance_id"`
 }
 
 type UpdateProcessTemplateInput struct {
@@ -609,4 +615,9 @@ type ProcessInstanceRelation struct {
 
 func (pir *ProcessInstanceRelation) Validate() (field string, err error) {
 	return "", nil
+}
+
+type ProcessInstance struct {
+	Property mapstr.MapStr           `json:"property"`
+	Relation ProcessInstanceRelation `json:"relation"`
 }

--- a/src/scene_server/proc_server/service/category.go
+++ b/src/scene_server/proc_server/service/category.go
@@ -62,6 +62,28 @@ func (ps *ProcServer) CreateServiceCategory(ctx *rest.Contexts) {
 	ctx.RespEntity(category)
 }
 
+func (ps *ProcServer) UpdateServiceCategory(ctx *rest.Contexts) {
+	input := new(metadata.ServiceCategory)
+	if err := ctx.DecodeInto(input); err != nil {
+		ctx.RespAutoError(err)
+		return
+	}
+
+	_, err := metadata.BizIDFromMetadata(input.Metadata)
+	if err != nil {
+		ctx.RespErrorCodeOnly(common.CCErrCommHTTPInputInvalid, "update service category, but get business id failed, err: %v", err)
+		return
+	}
+
+	category, err := ps.CoreAPI.CoreService().Process().UpdateServiceCategory(ctx.Kit.Ctx, ctx.Kit.Header, input.ID, input)
+	if err != nil {
+		ctx.RespWithError(err, common.CCErrCommHTTPDoRequestFailed, "update service category failed, err: %v", err)
+		return
+	}
+
+	ctx.RespEntity(category)
+}
+
 func (ps *ProcServer) DeleteServiceCategory(ctx *rest.Contexts) {
 	input := new(metadata.DeleteCategoryInput)
 	if err := ctx.DecodeInto(input); err != nil {

--- a/src/scene_server/proc_server/service/processtemplate.go
+++ b/src/scene_server/proc_server/service/processtemplate.go
@@ -153,7 +153,7 @@ func (ps *ProcServer) ListProcessTemplate(ctx *rest.Contexts) {
 	option := &metadata.ListProcessTemplatesOption{
 		BusinessID:         bizID,
 		ServiceTemplateID:  input.ServiceTemplateID,
-		ProcessTemplateIDs: input.ProcessTemplatesIDs,
+		ProcessTemplateIDs: &input.ProcessTemplatesIDs,
 	}
 	tmp, err := ps.CoreAPI.CoreService().Process().ListProcessTemplates(ctx.Kit.Ctx, ctx.Kit.Header, option)
 	if err != nil {

--- a/src/scene_server/proc_server/service/service.go
+++ b/src/scene_server/proc_server/service/service.go
@@ -127,6 +127,7 @@ func (ps *ProcServer) newProcessService(web *restful.WebService) {
 	// service category
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/findmany/proc/service_category", Handler: ps.GetServiceCategory})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/create/proc/service_category", Handler: ps.CreateServiceCategory})
+	utility.AddHandler(rest.Action{Verb: http.MethodPut, Path: "/update/proc/service_category", Handler: ps.UpdateServiceCategory})
 	utility.AddHandler(rest.Action{Verb: http.MethodDelete, Path: "/delete/proc/service_category", Handler: ps.DeleteServiceCategory})
 
 	// service template

--- a/src/scene_server/proc_server/service/service.go
+++ b/src/scene_server/proc_server/service/service.go
@@ -152,6 +152,7 @@ func (ps *ProcServer) newProcessService(web *restful.WebService) {
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/proc/service_instance/difference", Handler: ps.FindDifferencesBetweenProcessTemplateAndInstancesInServiceInstance})
 	utility.AddHandler(rest.Action{Verb: http.MethodPut, Path: "/update/proc/service_instance/with_template", Handler: ps.ForceSyncServiceInstanceAccordingToServiceTemplate})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/findmany/proc/service_instance/with_host", Handler: ps.ListServiceInstancesWithHost})
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/findmany/proc/process_instance", Handler: ps.ListProcessInstances})
 
 	utility.AddToRestfulWebService(web)
 }

--- a/src/source_controller/coreservice/core/core.go
+++ b/src/source_controller/coreservice/core/core.go
@@ -186,7 +186,7 @@ type ProcessOperation interface {
 	CreateProcessTemplate(ctx ContextParams, template metadata.ProcessTemplate) (*metadata.ProcessTemplate, error)
 	GetProcessTemplate(ctx ContextParams, templateID int64) (*metadata.ProcessTemplate, error)
 	UpdateProcessTemplate(ctx ContextParams, templateID int64, template metadata.ProcessTemplate) (*metadata.ProcessTemplate, error)
-	ListProcessTemplates(ctx ContextParams, bizID int64, serviceTemplateID int64, processTemplateIDs *[]int64, limit metadata.BasePage) (*metadata.MultipleProcessTemplate, error)
+	ListProcessTemplates(ctx ContextParams, option metadata.ListProcessTemplatesOption) (*metadata.MultipleProcessTemplate, error)
 	DeleteProcessTemplate(ctx ContextParams, processTemplateID int64) error
 
 	// service instance

--- a/src/source_controller/coreservice/core/core.go
+++ b/src/source_controller/coreservice/core/core.go
@@ -172,7 +172,7 @@ type ProcessOperation interface {
 	CreateServiceCategory(ctx ContextParams, category metadata.ServiceCategory) (*metadata.ServiceCategory, error)
 	GetServiceCategory(ctx ContextParams, categoryID int64) (*metadata.ServiceCategory, error)
 	UpdateServiceCategory(ctx ContextParams, categoryID int64, category metadata.ServiceCategory) (*metadata.ServiceCategory, error)
-	ListServiceCategories(ctx ContextParams, bizID int64, withStatistics bool) (*metadata.MultipleServiceCategory, error)
+	ListServiceCategories(ctx ContextParams, bizID int64, withStatistics bool) (*metadata.MultipleServiceCategoryWithStatistics, error)
 	DeleteServiceCategory(ctx ContextParams, categoryID int64) error
 
 	// service template

--- a/src/source_controller/coreservice/core/process/process_template.go
+++ b/src/source_controller/coreservice/core/process/process_template.go
@@ -101,7 +101,7 @@ func (p *processOperation) UpdateProcessTemplate(ctx core.ContextParams, templat
 	}
 
 	if field, err := input.Validate(); err != nil {
-		blog.Errorf("UpdateServiceTemplate failed, validation failed, code: %d, err: %+v, rid: %s", common.CCErrCommParamsInvalid, err, ctx.ReqID)
+		blog.Errorf("UpdateProcessTemplate failed, validation failed, code: %d, err: %+v, rid: %s", common.CCErrCommParamsInvalid, err, ctx.ReqID)
 		err := ctx.Error.Errorf(common.CCErrCommParamsInvalid, field)
 		return nil, err
 	}
@@ -111,10 +111,13 @@ func (p *processOperation) UpdateProcessTemplate(ctx core.ContextParams, templat
 		template.Property.Update(*input.Property)
 	}
 
+	template.Modifier = ctx.User
+	template.LastTime = time.Now()
+
 	// do update
 	filter := map[string]int64{common.BKFieldID: templateID}
-	if err := p.dbProxy.Table(common.BKTableNameServiceTemplate).Update(ctx, filter, template); nil != err {
-		blog.Errorf("UpdateServiceTemplate failed, mongodb failed, table: %s, filter: %+v, template: %+v, err: %+v, rid: %s", common.BKTableNameServiceTemplate, filter, template, err, ctx.ReqID)
+	if err := p.dbProxy.Table(common.BKTableNameProcessTemplate).Update(ctx, filter, &template); nil != err {
+		blog.Errorf("UpdateProcessTemplate failed, mongodb failed, table: %s, filter: %+v, template: %+v, err: %+v, rid: %s", common.BKTableNameProcessTemplate, filter, template, err, ctx.ReqID)
 		return nil, ctx.Error.Errorf(common.CCErrCommDBUpdateFailed)
 	}
 	return template, nil
@@ -158,7 +161,7 @@ func (p *processOperation) ListProcessTemplates(ctx core.ContextParams, option m
 func (p *processOperation) DeleteProcessTemplate(ctx core.ContextParams, processTemplateID int64) error {
 	template, err := p.GetProcessTemplate(ctx, processTemplateID)
 	if err != nil {
-		blog.Errorf("DeleteProcessTemplate failed, GetServiceTemplate failed, templateID: %d, err: %+v, rid: %s", processTemplateID, err, ctx.ReqID)
+		blog.Errorf("DeleteProcessTemplate failed, GetProcessTemplate failed, templateID: %d, err: %+v, rid: %s", processTemplateID, err, ctx.ReqID)
 		return err
 	}
 

--- a/src/source_controller/coreservice/core/process/process_template.go
+++ b/src/source_controller/coreservice/core/process/process_template.go
@@ -120,18 +120,18 @@ func (p *processOperation) UpdateProcessTemplate(ctx core.ContextParams, templat
 	return template, nil
 }
 
-func (p *processOperation) ListProcessTemplates(ctx core.ContextParams, bizID int64, serviceTemplateID int64, processTemplateIDs *[]int64, limit metadata.BasePage) (*metadata.MultipleProcessTemplate, error) {
-	md := metadata.NewMetaDataFromBusinessID(strconv.FormatInt(bizID, 10))
+func (p *processOperation) ListProcessTemplates(ctx core.ContextParams, option metadata.ListProcessTemplatesOption) (*metadata.MultipleProcessTemplate, error) {
+	md := metadata.NewMetaDataFromBusinessID(strconv.FormatInt(option.BusinessID, 10))
 	filter := map[string]interface{}{}
 	filter[common.MetadataField] = md.ToMapStr()
 
-	if serviceTemplateID != 0 {
-		filter[common.BKServiceTemplateIDField] = serviceTemplateID
+	if option.ServiceTemplateID != 0 {
+		filter[common.BKServiceTemplateIDField] = option.ServiceTemplateID
 	}
 
-	if processTemplateIDs != nil {
+	if option.ProcessTemplateIDs != nil {
 		filter[common.BKProcessTemplateIDField] = map[string][]int64{
-			common.BKDBIN: *processTemplateIDs,
+			common.BKDBIN: *option.ProcessTemplateIDs,
 		}
 	}
 
@@ -143,7 +143,7 @@ func (p *processOperation) ListProcessTemplates(ctx core.ContextParams, bizID in
 	}
 	templates := make([]metadata.ProcessTemplate, 0)
 	if err := p.dbProxy.Table(common.BKTableNameProcessTemplate).Find(filter).Start(
-		uint64(limit.Start)).Limit(uint64(limit.Limit)).All(ctx.Context, &templates); nil != err {
+		uint64(option.Page.Start)).Limit(uint64(option.Page.Limit)).All(ctx.Context, &templates); nil != err {
 		blog.Errorf("ListProcessTemplates failed, mongodb failed, table: %s, err: %+v, rid: %s", common.BKTableNameProcessTemplate, err, ctx.ReqID)
 		return nil, ctx.Error.Errorf(common.CCErrCommDBSelectFailed)
 	}

--- a/src/source_controller/coreservice/core/process/service_instance.go
+++ b/src/source_controller/coreservice/core/process/service_instance.go
@@ -55,13 +55,13 @@ func (p *processOperation) CreateServiceInstance(ctx core.ContextParams, instanc
 	// validate module id field
 	if err = p.validateModuleID(ctx, instance.ModuleID); err != nil {
 		blog.Errorf("CreateServiceInstance failed, module id invalid, code: %d, err: %+v, rid: %s", common.CCErrCommParamsInvalid, err, ctx.ReqID)
-		return nil, ctx.Error.Errorf(common.CCErrCommParamsInvalid, "module_id")
+		return nil, ctx.Error.Errorf(common.CCErrCommParamsInvalid, common.BKModuleIDField)
 	}
 
 	// validate host id field
 	if err = p.validateHostID(ctx, instance.HostID); err != nil {
 		blog.Errorf("CreateServiceInstance failed, host id invalid, code: %d, err: %+v, rid: %s", common.CCErrCommParamsInvalid, err, ctx.ReqID)
-		return nil, ctx.Error.Errorf(common.CCErrCommParamsInvalid, "host_id")
+		return nil, ctx.Error.Errorf(common.CCErrCommParamsInvalid, common.BKModuleIDField)
 	}
 
 	// make sure biz id identical with service template
@@ -149,6 +149,10 @@ func (p *processOperation) ListServiceInstance(ctx core.ContextParams, option me
 
 	if option.HostID != 0 {
 		filter[common.BKHostIDField] = option.HostID
+	}
+
+	if option.ModuleID != 0 {
+		filter[common.BKModuleIDField] = option.ModuleID
 	}
 
 	var total uint64

--- a/src/source_controller/coreservice/core/process/service_template.go
+++ b/src/source_controller/coreservice/core/process/service_template.go
@@ -130,7 +130,7 @@ func (p *processOperation) ListServiceTemplates(ctx core.ContextParams, bizID in
 
 	// filter with matching any sub category
 	if categoryID > 0 {
-		categories, err := p.ListServiceCategories(ctx, bizID, false)
+		categoriesWithSts, err := p.ListServiceCategories(ctx, bizID, false)
 		if err != nil {
 			blog.Errorf("ListServiceTemplates failed, ListServiceCategories failed, err: %+v, rid: %s", err, ctx.ReqID)
 			return nil, err
@@ -139,7 +139,8 @@ func (p *processOperation) ListServiceTemplates(ctx core.ContextParams, bizID in
 		childrenIDs = append(childrenIDs, categoryID)
 		for {
 			pre := len(childrenIDs)
-			for _, category := range categories.Info {
+			for _, categoryWithSts := range categoriesWithSts.Info {
+				category := categoryWithSts.ServiceCategory
 				if category.ParentID == 0 {
 					continue
 				}

--- a/src/source_controller/coreservice/service/process_template.go
+++ b/src/source_controller/coreservice/service/process_template.go
@@ -60,13 +60,7 @@ func (s *coreService) GetProcessTemplate(params core.ContextParams, pathParams, 
 
 func (s *coreService) ListProcessTemplates(params core.ContextParams, pathParams, queryParams ParamsGetter, data mapstr.MapStr) (interface{}, error) {
 	// filter parameter
-	fp := struct {
-		BusinessID         int64             `json:"bk_biz_id" field:"bk_biz_id"`
-		ServiceTemplateID  int64             `json:"service_template_id" field:"service_template_id"`
-		ProcessTemplateIDs *[]int64          `json:"process_template_ids" field:"process_template_ids"`
-		Page               metadata.BasePage `json:"page" field:"page"`
-	}{}
-
+	fp := metadata.ListProcessTemplatesOption{}
 	if err := mapstr.DecodeFromMapStr(&fp, data); err != nil {
 		blog.Errorf("ListProcessTemplates failed, decode request body failed, body: %+v, err: %v, rid: %s", data, err, params.ReqID)
 		return nil, params.Error.Error(common.CCErrCommJSONUnmarshalFailed)
@@ -77,7 +71,7 @@ func (s *coreService) ListProcessTemplates(params core.ContextParams, pathParams
 		return nil, params.Error.Errorf(common.CCErrCommParamsInvalid, common.BKAppIDField)
 	}
 
-	result, err := s.core.ProcessOperation().ListProcessTemplates(params, fp.BusinessID, fp.ServiceTemplateID, fp.ProcessTemplateIDs, fp.Page)
+	result, err := s.core.ProcessOperation().ListProcessTemplates(params, fp)
 	if err != nil {
 		blog.Errorf("ListProcessTemplates failed, err: %+v, rid: %s", err, params.ReqID)
 		return nil, err


### PR DESCRIPTION
### 新加的功能:
1. 进程模版新增start_param_regex字段;
2. 根据模块过滤服务实例不生效问题；
3. 字段重命名 module_id -> bk_module_id; host_id -> bk_host_id
4. code refactor: 进程模板接口过滤参数该用统一option结构
5. 新增：根据服务实例查询进程实例接口 
6. 服务分类信息带上使用量

close #2490