### PR TITLE
暂时关闭事件对比功能

### DIFF
--- a/src/common/eventclient/eventclient.go
+++ b/src/common/eventclient/eventclient.go
@@ -69,21 +69,24 @@ func (c *ClientViaRedis) Push(ctx context.Context, events ...*metadata.EventInst
 	c.queueLock.Lock()
 	for i := range events {
 		if events[i] != nil {
-			var allEqual = true
-			for _, data := range events[i].Data {
-				equal, err := instEqual(data)
-				if err != nil {
-					return fmt.Errorf("[event] compare failed: %v, source data is %#v", err, data)
+			// TODO: fixme comparing uncomparable type mapstr.MapStr
+			/*
+				var allEqual = true
+				for _, data := range events[i].Data {
+					equal, err := instEqual(data)
+					if err != nil {
+						return fmt.Errorf("[event] compare failed: %v, source data is %#v", err, data)
+					}
+					if !equal {
+						allEqual = false
+						break
+					}
 				}
-				if !equal {
-					allEqual = false
-					break
-				}
-			}
 
-			if allEqual {
-				continue
-			}
+				if allEqual {
+					continue
+				}
+			*/
 
 			eventID, err := c.rdb.NextSequence(ctx, common.EventCacheEventIDKey)
 			if err != nil {

--- a/src/common/metadata/process.go
+++ b/src/common/metadata/process.go
@@ -273,33 +273,33 @@ func (p ProtocolType) Validate() error {
 }
 
 type Process struct {
-	Metadata        Metadata        `field:"metadata" json:"metadata" bson:"metadata"`
-	ProcNum         *int64          `field:"proc_num" json:"proc_num,omitempty" bson:"proc_num"`
-	StopCmd         string          `field:"stop_cmd" json:"stop_cmd,omitempty" bson:"stop_cmd"`
-	RestartCmd      string          `field:"restart_cmd" json:"restart_cmd,omitempty" bson:"restart_cmd"`
-	ForceStopCmd    string          `field:"face_stop_cmd" json:"face_stop_cmd,omitempty" bson:"face_stop_cmd"`
-	ProcessID       int64           `field:"bk_process_id" json:"bk_process_id,omitempty" bson:"bk_process_id"`
-	FuncName        string          `field:"bk_func_name" json:"bk_func_name,omitempty" bson:"bk_func_name"`
-	WorkPath        string          `field:"work_path" json:"work_path,omitempty" bson:"work_path"`
-	BindIP          *SocketBindType `field:"bind_ip" json:"bind_ip,omitempty" bson:"bind_ip"`
-	Priority        *int64          `field:"priority" json:"priority,omitempty" bson:"priority"`
-	ReloadCmd       string          `field:"reload_cmd" json:"reload_cmd,omitempty" bson:"reload_cmd"`
-	ProcessName     string          `field:"bk_process_name" json:"bk_process_name,omitempty" bson:"bk_process_name"`
-	Port            string          `field:"port" json:"port,omitempty" bson:"port"`
-	PidFile         string          `field:"pid_file" json:"pid_file,omitempty" bson:"pid_file"`
-	AutoStart       bool            `field:"auto_start" json:"auto_start,omitempty" bson:"auto_start"`
-	AutoTimeGap     *int64          `field:"auto_time_gap" json:"auto_time_gap,omitempty" bson:"auto_time_gap"`
-	LastTime        time.Time       `field:"last_time" json:"last_time,omitempty" bson:"last_time"`
-	CreateTime      time.Time       `field:"create_time" json:"create_time,omitempty" bson:"create_time"`
-	BusinessID      int64           `field:"bk_biz_id" json:"bk_biz_id,omitempty" bson:"bk_biz_id"`
-	StartCmd        string          `field:"start_cmd" json:"start_cmd,omitempty" bson:"start_cmd"`
-	FuncID          string          `field:"bk_func_id" json:"bk_func_id,omitempty" bson:"bk_func_id"`
-	User            string          `field:"user" json:"user,omitempty" bson:"user"`
-	TimeoutSeconds  *int64          `field:"timeout" json:"timeout,omitempty" bson:"timeout"`
-	Protocol        ProtocolType    `field:"protocol" json:"protocol,omitempty" bson:"protocol"`
-	Description     string          `field:"description" json:"description,omitempty" bson:"description"`
-	SupplierAccount string          `field:"bk_supplier_account" json:"bk_supplier_account,omitempty" bson:"bk_supplier_account"`
-	StartParamRegex string          `field:"bk_start_param_regex" json:"bk_start_param_regex,omitempty" bson:"bk_start_param_regex,omitempty"`
+	Metadata        Metadata        `field:"metadata" json:"metadata" bson:"metadata" structs:"metadata"`
+	ProcNum         *int64          `field:"proc_num" json:"proc_num,omitempty" bson:"proc_num" structs:"proc_num"`
+	StopCmd         string          `field:"stop_cmd" json:"stop_cmd,omitempty" bson:"stop_cmd" structs:"stop_cmd"`
+	RestartCmd      string          `field:"restart_cmd" json:"restart_cmd,omitempty" bson:"restart_cmd" structs:"restart_cmd"`
+	ForceStopCmd    string          `field:"face_stop_cmd" json:"face_stop_cmd,omitempty" bson:"face_stop_cmd" structs:"face_stop_cmd"`
+	ProcessID       int64           `field:"bk_process_id" json:"bk_process_id,omitempty" bson:"bk_process_id" structs:"bk_process_id"`
+	FuncName        string          `field:"bk_func_name" json:"bk_func_name,omitempty" bson:"bk_func_name" structs:"bk_func_name"`
+	WorkPath        string          `field:"work_path" json:"work_path,omitempty" bson:"work_path" structs:"work_path"`
+	BindIP          *SocketBindType `field:"bind_ip" json:"bind_ip,omitempty" bson:"bind_ip" structs:"bind_ip"`
+	Priority        *int64          `field:"priority" json:"priority,omitempty" bson:"priority" structs:"priority"`
+	ReloadCmd       string          `field:"reload_cmd" json:"reload_cmd,omitempty" bson:"reload_cmd" structs:"reload_cmd"`
+	ProcessName     string          `field:"bk_process_name" json:"bk_process_name,omitempty" bson:"bk_process_name" structs:"bk_process_name"`
+	Port            string          `field:"port" json:"port,omitempty" bson:"port" structs:"port"`
+	PidFile         string          `field:"pid_file" json:"pid_file,omitempty" bson:"pid_file" structs:"pid_file"`
+	AutoStart       bool            `field:"auto_start" json:"auto_start,omitempty" bson:"auto_start" structs:"auto_start"`
+	AutoTimeGap     *int64          `field:"auto_time_gap" json:"auto_time_gap,omitempty" bson:"auto_time_gap" structs:"auto_time_gap"`
+	LastTime        time.Time       `field:"last_time" json:"last_time,omitempty" bson:"last_time" structs:"last_time"`
+	CreateTime      time.Time       `field:"create_time" json:"create_time,omitempty" bson:"create_time" structs:"create_time"`
+	BusinessID      int64           `field:"bk_biz_id" json:"bk_biz_id,omitempty" bson:"bk_biz_id" structs:"bk_biz_id"`
+	StartCmd        string          `field:"start_cmd" json:"start_cmd,omitempty" bson:"start_cmd" structs:"start_cmd"`
+	FuncID          string          `field:"bk_func_id" json:"bk_func_id,omitempty" bson:"bk_func_id" structs:"bk_func_id"`
+	User            string          `field:"user" json:"user,omitempty" bson:"user" structs:"user"`
+	TimeoutSeconds  *int64          `field:"timeout" json:"timeout,omitempty" bson:"timeout" structs:"timeout"`
+	Protocol        ProtocolType    `field:"protocol" json:"protocol,omitempty" bson:"protocol" structs:"protocol"`
+	Description     string          `field:"description" json:"description,omitempty" bson:"description" structs:"description"`
+	SupplierAccount string          `field:"bk_supplier_account" json:"bk_supplier_account,omitempty" bson:"bk_supplier_account" structs:"bk_supplier_account"`
+	StartParamRegex string          `field:"bk_start_param_regex" json:"bk_start_param_regex,omitempty" bson:"bk_start_param_regex,omitempty" structs:"bk_start_param_regex"`
 }
 
 type ServiceCategory struct {

--- a/src/source_controller/coreservice/core/process/process_instance_relation.go
+++ b/src/source_controller/coreservice/core/process/process_instance_relation.go
@@ -13,13 +13,14 @@
 package process
 
 import (
+	"strconv"
+	"strings"
+
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/errors"
 	"configcenter/src/common/metadata"
 	"configcenter/src/source_controller/coreservice/core"
-	"strconv"
-	"strings"
 )
 
 func (p *processOperation) CreateProcessInstanceRelation(ctx core.ContextParams, relation *metadata.ProcessInstanceRelation) (*metadata.ProcessInstanceRelation, errors.CCErrorCoder) {

--- a/src/ui/src/store/modules/api/process-template.js
+++ b/src/ui/src/store/modules/api/process-template.js
@@ -57,7 +57,7 @@ const actions = {
      * @return {promises} promises 对象
      */
     updateProcessTemplate ({ commit, state, dispatch, rootGetters }, { params, config }) {
-        return $http.put(`update/proc/proc_template/for_service_template`, params, config)
+        return $http.put(`update/proc/proc_template`, params, config)
     },
     /**
      * 删除服务模板中的进程模板
@@ -68,7 +68,7 @@ const actions = {
      * @return {promises} promises 对象
      */
     deleteProcessTemplate ({ commit, state, dispatch, rootGetters }, { params, config }) {
-        return $http.delete(`deletemany/proc/proc_template/for_service_template`, params, config)
+        return $http.delete(`deletemany/proc/proc_template`, params, config)
     }
 }
 


### PR DESCRIPTION
### 修复的问题：
- 事件推送功能中新增的对比差异逻辑有点问题，编辑进程实例时出现panic，暂时关闭事件对比功能
- 后端http path变更了，前端有两个前端url没有调整过来
