### PR TITLE
V3.4.x 权限回归

### DIFF
--- a/src/ui/src/api/index.js
+++ b/src/ui/src/api/index.js
@@ -221,7 +221,7 @@ function popupPermissionModal (permission = []) {
 function getPermissionText (data, necessaryKey, extraKey, split = '：') {
     const text = [data[necessaryKey]]
     if (data[extraKey]) {
-        text.push(data)
+        text.push(data[extraKey])
     }
     return text.join(split)
 }

--- a/src/ui/src/components/ui/tree/_tree-layout.js
+++ b/src/ui/src/components/ui/tree/_tree-layout.js
@@ -74,6 +74,18 @@ class TreeLayout {
         }
     }
 
+    toggleDisabled (id, disabled) {
+        const state = this.getStateById(id)
+        if (state) {
+            state.disabled = disabled
+            if (state.node.hasOwnProperty('disabled')) {
+                state.node.disabled = disabled
+            }
+        } else {
+            console.error('state lost, cannot toggle disabled with node id:' + id)
+        }
+    }
+
     addFlatternState (state) {
         this.flatternStates[state.id] = state
     }

--- a/src/ui/src/components/ui/tree/_tree-node.vue
+++ b/src/ui/src/components/ui/tree/_tree-node.vue
@@ -151,6 +151,9 @@
                 this.layout.toggleExpanded(this.state.id, expanded)
             },
             async handleNodeClick () {
+                if (this.state.disabled) {
+                    return false
+                }
                 if (typeof this.treeInstance.beforeClick === 'function') {
                     let confirm
                     try {

--- a/src/ui/src/components/ui/tree/tree.vue
+++ b/src/ui/src/components/ui/tree/tree.vue
@@ -62,6 +62,9 @@
             toggleExpanded (id, expanded) {
                 this.layout.toggleExpanded(id, expanded)
             },
+            toggleDisabled (id, disabled) {
+                this.layout.toggleDisabled(id, disabled)
+            },
             selectNode (id) {
                 this.layout.selectState(id)
             },

--- a/src/ui/src/dictionary/auth.js
+++ b/src/ui/src/dictionary/auth.js
@@ -92,8 +92,6 @@ export const R_CONFIRM_HISTORY = 'cloudConfirmHistory.findMany'
 export const STATIC_BUSINESS_MODE = [
     C_MODEL,
     R_MODEL,
-    U_MODEL,
-    D_MODEL,
 
     C_MODEL_GROUP,
     U_MODEL_GROUP,

--- a/src/ui/src/dictionary/auth.js
+++ b/src/ui/src/dictionary/auth.js
@@ -114,7 +114,8 @@ export const STATIC_BUSINESS_MODE = [
     
     C_HOST,
     U_HOST,
-    D_HOST
+    D_HOST,
+    HOST_TO_RESOURCE
 ]
 
 export const DYNAMIC_BUSINESS_MODE = [

--- a/src/ui/src/dictionary/auth.js
+++ b/src/ui/src/dictionary/auth.js
@@ -158,10 +158,18 @@ export const RESOURCE_ACTION_NAME = {
     modelTopologyView: '模型拓扑视图'
 }
 
+const AUTH_META_KEYS = ['bk_biz_id', 'parent_layers', 'resource_id']
+
 export const GET_AUTH_META = (auth, options = {}) => {
     const [type, action] = auth.split('.')
-    return {
+    const meta = {
         resource_type: type,
         action: action
     }
+    Object.keys(options).forEach(key => {
+        if (AUTH_META_KEYS.includes(key)) {
+            meta[key] = options[key]
+        }
+    })
+    return meta
 }

--- a/src/ui/src/directives/cursor.js
+++ b/src/ui/src/directives/cursor.js
@@ -28,7 +28,7 @@ const options = {
     y: 0,
     width: 16,
     height: 16,
-    zIndex: 1000,
+    zIndex: 100000,
     cursor: 'pointer',
     className: 'v-cursor',
     activeClass: 'v-cursor-active'

--- a/src/ui/src/setup/afterload.js
+++ b/src/ui/src/setup/afterload.js
@@ -1,26 +1,4 @@
-export function getBusiness (app) {
-    return app.$store.dispatch('objectBiz/searchBusiness', {
-        params: {
-            'fields': ['bk_biz_id', 'bk_biz_name'],
-            'condition': {
-                'bk_data_status': {
-                    '$ne': 'disabled'
-                }
-            }
-        },
-        config: {
-            requestId: 'post_searchBusiness_$ne_disabled'
-        }
-    }).then(business => {
-        app.$store.commit('objectBiz/setBusiness', business.info)
-        return business
-    })
-}
-
 export default async function (app, to, from) {
     const functions = []
-    if (to.meta.requireBusiness) {
-        functions.push(getBusiness)
-    }
     return Promise.all(functions.map(func => func(app, to, from)))
 }

--- a/src/ui/src/store/modules/api/auth.js
+++ b/src/ui/src/store/modules/api/auth.js
@@ -133,8 +133,9 @@ const mutations = {
     setBusinessMeta (state, meta = {}) {
         state.businessMeta = meta
     },
-    setResourceMeta (state, meta = {}) {
-        state.resourceMeta.push(meta)
+    setResourceMeta (state, meta) {
+        const resourceMeta = Array.isArray(meta) ? meta : [meta]
+        state.resourceMeta.push(...resourceMeta)
     },
     setAdminEntranceAuth (state, data) {
         state.adminEntranceAuth = data

--- a/src/ui/src/store/modules/api/auth.js
+++ b/src/ui/src/store/modules/api/auth.js
@@ -28,7 +28,7 @@ const state = {
 const getters = {
     operation: state => state.operation,
     isAuthorized: (state, getters) => (auth, option = { type: 'operation' }) => {
-        const authMeta = getters.getAuthMeta(auth)
+        const authMeta = getters.getAuthMeta(auth, option)
         const authList = state[option.type] || []
         const authData = authList.find(auth => {
             const sameType = auth.resource_type === authMeta.resource_type
@@ -38,8 +38,8 @@ const getters = {
         })
         return (authData || {}).is_pass
     },
-    getAuthMeta: (state, getters, rootState, rootGetters) => auth => {
-        const meta = GET_AUTH_META(auth)
+    getAuthMeta: (state, getters, rootState, rootGetters) => (auth, option = {}) => {
+        const meta = GET_AUTH_META(auth, option)
         const isBusinessMode = !rootGetters.isAdminView
         const bizId = rootGetters['objectBiz/bizId']
         if (

--- a/src/ui/src/store/modules/api/auth.js
+++ b/src/ui/src/store/modules/api/auth.js
@@ -21,6 +21,7 @@ const state = {
     system: [],
     businessMeta: {},
     parentMeta: {},
+    resourceMeta: [],
     adminEntranceAuth: {}
 }
 
@@ -51,6 +52,13 @@ const getters = {
         if (DYNAMIC_BUSINESS_MODE.includes(auth)) {
             Object.assign(meta, state.parentMeta)
             Object.assign(meta, state.businessMeta)
+        }
+        const resourceMeta = state.resourceMeta.find(resourceMeta => {
+            return resourceMeta.resource_type === meta.resource_type
+                && resourceMeta.action === meta.action
+        })
+        if (resourceMeta) {
+            Object.assign(meta, resourceMeta)
         }
         return meta
     }
@@ -125,12 +133,16 @@ const mutations = {
     setBusinessMeta (state, meta = {}) {
         state.businessMeta = meta
     },
+    setResourceMeta (state, meta = {}) {
+        state.resourceMeta.push(meta)
+    },
     setAdminEntranceAuth (state, data) {
         state.adminEntranceAuth = data
     },
     clearDynamicMeta (state) {
         state.parentMeta = {}
         state.businessMeta = {}
+        state.resourceMeta = []
     }
 }
 

--- a/src/ui/src/store/modules/view/host-details.js
+++ b/src/ui/src/store/modules/view/host-details.js
@@ -13,10 +13,7 @@ const state = {
         target: []
     },
     associationTypes: [],
-    expandAll: false,
-    indeterminate: true,
-    tableCount: 0,
-    expandCount: 0
+    expandAll: false
 }
 
 const getters = {
@@ -92,15 +89,6 @@ const mutations = {
     },
     toggleExpandAll (state, expandAll) {
         state.expandAll = expandAll
-    },
-    setExpandIndeterminate (state, indeterminate) {
-        state.indeterminate = indeterminate
-    },
-    updateTableCount (state, count) {
-        state.tableCount = state.tableCount + count
-    },
-    updateExpandCount (state, count) {
-        state.expandCount = state.expandCount + count
     }
 }
 

--- a/src/ui/src/views/business/archived.vue
+++ b/src/ui/src/views/business/archived.vue
@@ -16,11 +16,11 @@
             <template slot="options" slot-scope="{ item }">
                 <span class="inline-block-middle"
                     v-cursor="{
-                        active: $isAuthorized(archiveAuth),
+                        active: !$isAuthorized(archiveAuth),
                         auth: [archiveAuth]
                     }">
                     <bk-button type="primary" size="mini"
-                        :disabled="$isAuthorized(archiveAuth)"
+                        :disabled="!$isAuthorized(archiveAuth)"
                         @click="handleRecovery(item)">
                         {{$t('Inst["恢复业务"]')}}
                     </bk-button>

--- a/src/ui/src/views/host-details/children/association-list-table.vue
+++ b/src/ui/src/views/host-details/children/association-list-table.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="table" v-bkloading="{ isLoading: $loading(propertyRequest, instanceRequest) }">
         <div class="table-info clearfix">
-            <div class="info-title fl" @click="localVisible = !localVisible">
+            <div class="info-title fl" @click="expanded = !expanded">
                 <i class="icon bk-icon icon-right-shape"
-                    :class="{ 'is-open': localVisible }">
+                    :class="{ 'is-open': expanded }">
                 </i>
                 <span class="title-text">{{title}}</span>
                 <span class="title-count">({{instances.length}})</span>
@@ -24,7 +24,7 @@
         </div>
         <cmdb-collapse-transition>
             <cmdb-table class="association-table"
-                v-show="localVisible"
+                v-show="expanded"
                 :header="header"
                 :list="flatternList"
                 :show-footer="false"
@@ -73,8 +73,7 @@
             associationType: {
                 type: Object,
                 required: true
-            },
-            visible: Boolean
+            }
         },
         data () {
             return {
@@ -85,7 +84,7 @@
                     current: 1,
                     size: 10
                 },
-                localVisible: this.visible,
+                expanded: false,
                 confirm: {
                     instance: null,
                     item: null,
@@ -98,12 +97,6 @@
                 'sourceInstances',
                 'targetInstances'
             ]),
-            expandAll () {
-                return this.$store.state.hostDetails.expandAll
-            },
-            indeterminate () {
-                return this.$store.state.hostDetails.indeterminate
-            },
             updateAuth () {
                 const isResourceHost = this.$route.name === RESOURCE_HOST
                 if (isResourceHost) {
@@ -164,39 +157,25 @@
                     width: 150
                 })
                 return header
+            },
+            expandAll () {
+                return this.$store.state.hostDetails.expandAll
             }
         },
         watch: {
-            visible (visible) {
-                this.localVisible = visible
-            },
-            localVisible (visible) {
-                if (visible) {
-                    this.getData()
-                }
-                this.$store.commit('hostDetails/updateExpandCount', visible ? 1 : -1)
-                this.checkExpandAllState()
-            },
             instances () {
-                if (this.localVisible) {
+                if (this.expanded) {
                     this.getData()
                 }
             },
-            expandAll (expandAll) {
-                if (!this.indeterminate) {
-                    this.localVisible = expandAll
+            expandAll (expanded) {
+                this.expanded = expanded
+            },
+            expanded (expanded) {
+                if (expanded) {
+                    this.getData()
                 }
             }
-        },
-        created () {
-            this.$store.commit('hostDetails/updateTableCount', 1)
-            if (this.visible) {
-                this.getData()
-                this.$store.commit('hostDetails/updateExpandCount', 1)
-            }
-        },
-        beforeDestroy () {
-            this.$store.commit('hostDetails/updateTableCount', -1)
         },
         methods: {
             getData () {
@@ -393,15 +372,6 @@
                     target: event.target
                 })
                 this.confirm.instance.$el.append(this.$refs.confirmTips)
-            },
-            checkExpandAllState () {
-                this.$nextTick(() => {
-                    const state = this.$store.state.hostDetails
-                    const tableCount = state.tableCount
-                    const expandCount = state.expandCount
-                    this.$store.commit('hostDetails/setExpandIndeterminate', expandCount !== 0 && tableCount !== expandCount)
-                    this.$store.commit('hostDetails/toggleExpandAll', tableCount === expandCount)
-                })
             }
         }
     }

--- a/src/ui/src/views/host-details/children/association-list.vue
+++ b/src/ui/src/views/host-details/children/association-list.vue
@@ -8,14 +8,14 @@
             </div>
         </div>
         <template v-else>
-            <template v-for="(item, itemIndex) in list">
+            <template v-for="item in list">
                 <cmdb-host-association-list-table
-                    v-for="(association, associationIndex) in item.associations"
+                    ref="associationListTable"
+                    v-for="association in item.associations"
                     :key="association.id"
                     :type="item.type"
                     :id="item.id"
-                    :association-type="item.associationType"
-                    :visible="!(itemIndex || associationIndex)">
+                    :association-type="item.associationType">
                 </cmdb-host-association-list-table>
             </template>
         </template>
@@ -69,7 +69,7 @@
                 } catch (e) {
                     console.log(e)
                 }
-                return false
+                return []
             },
             loading () {
                 return this.$loading([
@@ -78,6 +78,14 @@
                     'getAssociationType',
                     'getInstRelation'
                 ])
+            }
+        },
+        watch: {
+            list () {
+                this.$nextTick(() => {
+                    const [firstAssociationListTable] = this.$refs.associationListTable
+                    firstAssociationListTable && (firstAssociationListTable.expanded = true)
+                })
             }
         },
         created () {

--- a/src/ui/src/views/host-details/children/association.vue
+++ b/src/ui/src/views/host-details/children/association.vue
@@ -15,8 +15,6 @@
                 </span>
                 <cmdb-form-bool v-if="hasAssociation"
                     :size="16" class="options-checkbox"
-                    :checked="expandAll"
-                    :indeterminate="indeterminate"
                     @change="handleExpandAll">
                     <span class="checkbox-label">{{$t('Common["全部展开"]')}}</span>
                 </cmdb-form-bool>
@@ -67,12 +65,6 @@
             }
         },
         computed: {
-            expandAll () {
-                return this.$store.state.hostDetails.expandAll
-            },
-            indeterminate () {
-                return this.$store.state.hostDetails.indeterminate
-            },
             updateAuth () {
                 const isResourceHost = this.$route.name === RESOURCE_HOST
                 if (isResourceHost) {
@@ -87,7 +79,6 @@
         },
         beforeDestroy () {
             this.$store.commit('hostDetails/toggleExpandAll', false)
-            this.$store.commit('hostDetails/setExpandIndeterminate', true)
         },
         methods: {
             toggleView (view) {
@@ -95,7 +86,6 @@
             },
             handleExpandAll (expandAll) {
                 this.$store.commit('hostDetails/toggleExpandAll', expandAll)
-                this.$store.commit('hostDetails/setExpandIndeterminate', false)
             }
         }
     }

--- a/src/ui/src/views/host-details/children/history.vue
+++ b/src/ui/src/views/host-details/children/history.vue
@@ -83,7 +83,7 @@
                         inst_id: this.id
                     }
                     if (this.dateRange.length) {
-                        condition.op_time = this.dateRange
+                        condition.op_time = [this.dateRange[0] + ' 00:00:00', this.dateRange[1] + ' 23:59:59']
                     }
                     if (this.operator) {
                         condition.operator = this.operator

--- a/src/ui/src/views/host-details/children/property.vue
+++ b/src/ui/src/views/host-details/children/property.vue
@@ -204,6 +204,10 @@
                 &:hover {
                     opacity: .8;
                 }
+                &.disabled {
+                    opacity: 1;
+                    color: #ccc;
+                }
             }
             .property-form {
                 display: inline-block;

--- a/src/ui/src/views/host-details/index.vue
+++ b/src/ui/src/views/host-details/index.vue
@@ -72,7 +72,6 @@
             active (active) {
                 if (active !== 'association') {
                     this.$store.commit('hostDetails/toggleExpandAll', false)
-                    this.$store.commit('hostDetails/setExpandIndeterminate', true)
                 }
             }
         },

--- a/src/ui/src/views/host-details/router.config.js
+++ b/src/ui/src/views/host-details/router.config.js
@@ -1,6 +1,7 @@
 import {
     U_HOST,
-    U_RESOURCE_HOST
+    U_RESOURCE_HOST,
+    GET_AUTH_META
 } from '@/dictionary/auth'
 
 const component = () => import(/* webpackChunkName: "hostDetails" */ './index.vue')
@@ -21,7 +22,14 @@ export default [{
     meta: {
         auth: {
             view: null,
-            operation: [U_RESOURCE_HOST]
+            operation: [U_RESOURCE_HOST],
+            setDynamicMeta (to, from, app) {
+                const meta = GET_AUTH_META(U_RESOURCE_HOST)
+                app.$store.commit('auth/setResourceMeta', {
+                    ...meta,
+                    resource_id: parseInt(to.params.id)
+                })
+            }
         }
     }
 }, {
@@ -31,7 +39,15 @@ export default [{
     meta: {
         auth: {
             view: null,
-            operation: [U_HOST]
+            operation: [U_HOST],
+            setDynamicMeta (to, from, app) {
+                const meta = GET_AUTH_META(U_HOST)
+                app.$store.commit('auth/setResourceMeta', {
+                    ...meta,
+                    resource_id: parseInt(to.params.id),
+                    bk_biz_id: parseInt(to.params.business)
+                })
+            }
         }
     }
 }]

--- a/src/ui/src/views/model-manage/children/field.vue
+++ b/src/ui/src/views/model-manage/children/field.vue
@@ -137,7 +137,7 @@
                 return this.$route.params.modelId
             },
             createDisabled () {
-                return !this.isAdminView && this.objId === 'biz'
+                return !this.isAdminView && this.isPublicModel
             },
             isReadOnly () {
                 if (this.activeModel) {

--- a/src/ui/src/views/model-manage/children/field.vue
+++ b/src/ui/src/views/model-manage/children/field.vue
@@ -1,12 +1,12 @@
 <template>
     <div class="model-field-wrapper">
-        <div>
-            <span v-cursor="{
+        <div class="options">
+            <span class="inline-block-middle" v-cursor="{
                 active: !$isAuthorized(OPERATION.U_MODEL),
                 auth: [OPERATION.U_MODEL]
             }">
                 <bk-button class="create-btn" type="primary"
-                    :disabled="isReadOnly || !updateAuth"
+                    :disabled="createDisabled || isReadOnly || !updateAuth"
                     @click="createField">
                     {{$t('ModelManagement["新建字段"]')}}
                 </bk-button>
@@ -136,6 +136,9 @@
             objId () {
                 return this.$route.params.modelId
             },
+            createDisabled () {
+                return !this.isAdminView && this.objId === 'biz'
+            },
             isReadOnly () {
                 if (this.activeModel) {
                     return this.activeModel['bk_ispaused']
@@ -243,8 +246,8 @@
 </script>
 
 <style lang="scss" scoped>
-    .create-btn {
-        margin: 10px 0;
+    .options {
+        padding: 10px 0;
     }
     .field-pre {
         display: inline-block;

--- a/src/ui/src/views/model-manage/children/index.vue
+++ b/src/ui/src/views/model-manage/children/index.vue
@@ -346,7 +346,13 @@
                 this.exportExcel(res)
             },
             dialogConfirm (type) {
-                if (!this.$isAuthorized(OPERATION.U_MODEL)) return
+                if (type === 'delete') {
+                    if (!this.$isAuthorized(OPERATION.D_MODEL)) {
+                        return false
+                    }
+                } else if (!this.$isAuthorized(OPERATION.U_MODEL)) {
+                    return false
+                }
                 switch (type) {
                     case 'restart':
                         this.$bkInfo({

--- a/src/ui/src/views/model-manage/children/index.vue
+++ b/src/ui/src/views/model-manage/children/index.vue
@@ -84,8 +84,8 @@
                         </label>
                         <label class="label-btn"
                             v-cursor="{
-                                active: !$isAuthorized(OPERATION.U_MODEL),
-                                auth: [OPERATION.U_MODEL]
+                                active: !$isAuthorized(OPERATION.D_MODEL),
+                                auth: [OPERATION.D_MODEL]
                             }"
                             v-tooltip="$t('ModelManagement[\'删除模型和其下所有实例，此动作不可逆，请谨慎操作\']')"
                             @click="dialogConfirm('delete')">

--- a/src/ui/src/views/model-manage/children/verification.vue
+++ b/src/ui/src/views/model-manage/children/verification.vue
@@ -1,9 +1,11 @@
 <template>
-    <div>
-        <span v-cursor="{
-            active: !$isAuthorized(OPERATION.U_MODEL),
-            auth: [OPERATION.U_MODEL]
-        }">
+    <div class="verification-layout">
+        <span class="inline-block-middle"
+            v-if="!isTopoModel"
+            v-cursor="{
+                active: !$isAuthorized(OPERATION.U_MODEL),
+                auth: [OPERATION.U_MODEL]
+            }">
             <bk-button class="create-btn" type="primary"
                 :disabled="isReadOnly || !updateAuth"
                 @click="createVerification">
@@ -11,7 +13,7 @@
             </bk-button>
         </span>
         <cmdb-table
-            class="relation-table"
+            class="verification-table"
             :loading="$loading(['searchObjectUniqueConstraints', 'deleteObjectUniqueConstraints'])"
             :sortable="false"
             :header="table.header"
@@ -97,6 +99,9 @@
                 'activeModel',
                 'isInjectable'
             ]),
+            isTopoModel () {
+                return this.activeModel.bk_classification_id === 'bk_biz_topo'
+            },
             isReadOnly () {
                 if (this.activeModel) {
                     return this.activeModel['bk_ispaused']
@@ -113,7 +118,7 @@
             }
         },
         async created () {
-            if (!this.updateAuth) {
+            if (!this.updateAuth || this.isTopoModel) {
                 this.table.header.pop()
             }
             this.initAttrList()
@@ -208,7 +213,10 @@
 </script>
 
 <style lang="scss" scoped>
-    .create-btn {
-        margin: 10px 0;
+    .verification-layout {
+        padding: 10px 0;
+    }
+    .verification-table {
+        margin: 10px 0 0 0;
     }
 </style>

--- a/src/ui/src/views/model-manage/router.config.js
+++ b/src/ui/src/views/model-manage/router.config.js
@@ -7,7 +7,8 @@ import {
     D_MODEL_GROUP,
     C_MODEL,
     U_MODEL,
-    D_MODEL
+    D_MODEL,
+    GET_AUTH_META
 } from '@/dictionary/auth'
 
 export const OPERATION = {
@@ -51,11 +52,19 @@ export default [{
                 const modelId = to.params.modelId
                 const model = app.$store.getters['objectModelClassify/getModelById'](modelId)
                 const bizId = getMetadataBiz(model)
+                const resourceMeta = [{
+                    ...GET_AUTH_META(OPERATION.U_MODEL),
+                    resource_id: model.id
+                }, {
+                    ...GET_AUTH_META(OPERATION.D_MODEL),
+                    resource_id: model.id
+                }]
                 if (bizId) {
-                    app.$store.commit('auth/setBusinessMeta', {
-                        bk_biz_id: parseInt(bizId)
+                    resourceMeta.forEach(meta => {
+                        meta.bk_biz_id = parseInt(bizId)
                     })
                 }
+                app.$store.commit('auth/setResourceMeta', resourceMeta)
             }
         },
         checkAvailable: (to, from, app) => {

--- a/src/ui/src/views/model-topology/index.old.vue
+++ b/src/ui/src/views/model-topology/index.old.vue
@@ -4,11 +4,11 @@
             <template v-if="!topoEdit.isEdit">
                 <span style="display: inline-block;"
                     v-cursor="{
-                        active: !$isAuthorized(OPERATION.U_MODEL),
-                        auth: [OPERATION.U_MODEL]
+                        active: !$isAuthorized(OPERATION.U_MODEL) || !$isAuthorized(OPERATION.SYSTEM_MODEL_GRAPHICS),
+                        auth: [OPERATION.U_MODEL, OPERATION.SYSTEM_MODEL_GRAPHICS]
                     }">
                     <bk-button class="edit-button" type="primary"
-                        :disabled="!$isAuthorized(OPERATION.U_MODEL)"
+                        :disabled="!$isAuthorized(OPERATION.U_MODEL) || !$isAuthorized(OPERATION.SYSTEM_MODEL_GRAPHICS)"
                         @click="editTopo">
                         {{$t('ModelManagement["编辑拓扑"]')}}
                     </bk-button>

--- a/src/ui/src/views/model-topology/index.old.vue
+++ b/src/ui/src/views/model-topology/index.old.vue
@@ -4,11 +4,11 @@
             <template v-if="!topoEdit.isEdit">
                 <span style="display: inline-block;"
                     v-cursor="{
-                        active: !$isAuthorized(OPERATION.U_MODEL) || !$isAuthorized(OPERATION.SYSTEM_MODEL_GRAPHICS),
-                        auth: [OPERATION.U_MODEL, OPERATION.SYSTEM_MODEL_GRAPHICS]
+                        active: !$isAuthorized(OPERATION.SYSTEM_MODEL_GRAPHICS),
+                        auth: [OPERATION.SYSTEM_MODEL_GRAPHICS]
                     }">
                     <bk-button class="edit-button" type="primary"
-                        :disabled="!$isAuthorized(OPERATION.U_MODEL) || !$isAuthorized(OPERATION.SYSTEM_MODEL_GRAPHICS)"
+                        :disabled="!$isAuthorized(OPERATION.SYSTEM_MODEL_GRAPHICS)"
                         @click="editTopo">
                         {{$t('ModelManagement["编辑拓扑"]')}}
                     </bk-button>
@@ -784,7 +784,7 @@
                     edges: this.networkDataSet.edges
                 }, this.network.options)
                 this.networkInstance.setOptions({ nodes: { fixed: true } })
-                if (this.$isAuthorized(OPERATION.U_MODEL)) {
+                if (this.$isAuthorized(OPERATION.SYSTEM_MODEL_GRAPHICS)) {
                     this.initPosition()
                 }
                 this.addListener()

--- a/src/ui/src/views/model-topology/router.config.js
+++ b/src/ui/src/views/model-topology/router.config.js
@@ -1,13 +1,9 @@
 import Meta from '@/router/meta'
 import { NAV_MODEL_MANAGEMENT } from '@/dictionary/menu'
 
-import {
-    U_MODEL,
-    SYSTEM_MODEL_GRAPHICS
-} from '@/dictionary/auth'
+import { SYSTEM_MODEL_GRAPHICS } from '@/dictionary/auth'
 
 export const OPERATION = {
-    U_MODEL,
     SYSTEM_MODEL_GRAPHICS
 }
 

--- a/src/ui/src/views/model-topology/router.config.js
+++ b/src/ui/src/views/model-topology/router.config.js
@@ -2,11 +2,13 @@ import Meta from '@/router/meta'
 import { NAV_MODEL_MANAGEMENT } from '@/dictionary/menu'
 
 import {
-    U_MODEL
+    U_MODEL,
+    SYSTEM_MODEL_GRAPHICS
 } from '@/dictionary/auth'
 
 export const OPERATION = {
-    U_MODEL
+    U_MODEL,
+    SYSTEM_MODEL_GRAPHICS
 }
 
 const path = '/model/topology'

--- a/src/ui/src/views/topology/index.vue
+++ b/src/ui/src/views/topology/index.vue
@@ -553,11 +553,11 @@
                 const selectedNode = this.tree.selectedNode
                 const selectedNodeModel = this.topoModel.find(model => model['bk_obj_id'] === selectedNode['bk_obj_id'])
                 const nextObjId = selectedNodeModel['bk_next_obj']
-                const formData = {
+                const formData = this.$injectMetadata({
                     ...value,
                     'bk_biz_id': this.bizId,
                     'bk_parent_id': selectedNode['bk_inst_id']
-                }
+                })
                 let promise
                 let instIdKey
                 let instNameKey
@@ -610,7 +610,7 @@
                 return promise
             },
             updateNode (value) {
-                const formData = { ...value }
+                const formData = this.$injectMetadata({ ...value })
                 const selectedNode = this.tree.selectedNode
                 const objId = selectedNode['bk_obj_id']
                 let promise
@@ -664,7 +664,7 @@
                 const selectedNode = this.tree.selectedNode
                 const parentNode = this.tree.selectedNodeState.parent.node
                 const objId = selectedNode['bk_obj_id']
-                const config = { requestId: 'deleteNode' }
+                const config = { requestId: 'deleteNode', data: this.$injectMetadata({}) }
                 this.$bkInfo({
                     title: `${this.$t('Common["确定删除"]')} ${selectedNode['bk_inst_name']}?`,
                     content: objId === 'module'
@@ -689,10 +689,7 @@
                             promise = this.deleteInst({
                                 objId,
                                 instId: selectedNode['bk_inst_id'],
-                                config: {
-                                    ...config,
-                                    data: this.$injectMetadata({})
-                                }
+                                config
                             })
                         }
                         promise.then(() => {


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- 拓扑视图编辑按钮鉴权调整
- 业务模型禁止添加业务私有字段
- 去除主机关联全部展开的半选状态
### 修复的问题：
- 修复主机详情页面未对具体主机实例做鉴权的问题
- 修复归档UI鉴权判断反了的问题
- 修复转移主机到资源池鉴权参数缺少业务id的问题
- 修复转移主机资源池鉴权错误的问题
- 修复删除模型鉴权错误的问题
- 修复主机变更记录选择日期时筛选传参不正确的问题
