### PR TITLE
 fix: mongodb用户名密码包括特殊字符导致拼接的URI无法连接到mongodb issue #2690

### DIFF
--- a/src/storage/dal/mongo/mongo.go
+++ b/src/storage/dal/mongo/mongo.go
@@ -41,6 +41,11 @@ func (c Config) BuildURI() string {
 		c.Address = c.Address + ":" + c.Port
 	}
 
+	strings.ReplaceAll(c.User, "@", "%40")
+	strings.ReplaceAll(c.Password, "@", "%40")
+	strings.ReplaceAll(c.User, ":", "%3a")
+	strings.ReplaceAll(c.Password, ":", "%3a")
+
 	uri := fmt.Sprintf("mongodb://%s:%s@%s/%s", c.User, c.Password, c.Address, c.Database)
 	if c.Mechanism != "" {
 		uri += "?authMechanism=" + c.Mechanism

--- a/src/storage/dal/mongo/mongo.go
+++ b/src/storage/dal/mongo/mongo.go
@@ -41,10 +41,10 @@ func (c Config) BuildURI() string {
 		c.Address = c.Address + ":" + c.Port
 	}
 
-	strings.ReplaceAll(c.User, "@", "%40")
-	strings.ReplaceAll(c.Password, "@", "%40")
-	strings.ReplaceAll(c.User, ":", "%3a")
-	strings.ReplaceAll(c.Password, ":", "%3a")
+	strings.Replace(c.User, "@", "%40", -1)
+	strings.Replace(c.Password, "@", "%40", -1)
+	strings.Replace(c.User, ":", "%3a", -1)
+	strings.Replace(c.Password, ":", "%3a", -1)
 
 	uri := fmt.Sprintf("mongodb://%s:%s@%s/%s", c.User, c.Password, c.Address, c.Database)
 	if c.Mechanism != "" {

--- a/src/storage/dal/mongo/mongo.go
+++ b/src/storage/dal/mongo/mongo.go
@@ -41,10 +41,10 @@ func (c Config) BuildURI() string {
 		c.Address = c.Address + ":" + c.Port
 	}
 
-	strings.Replace(c.User, "@", "%40", -1)
-	strings.Replace(c.Password, "@", "%40", -1)
-	strings.Replace(c.User, ":", "%3a", -1)
-	strings.Replace(c.Password, ":", "%3a", -1)
+	c.User = strings.Replace(c.User, "@", "%40", -1)
+	c.Password = strings.Replace(c.Password, "@", "%40", -1)
+	c.User = strings.Replace(c.User, ":", "%3a", -1)
+	c.Password = strings.Replace(c.Password, ":", "%3a", -1)
 
 	uri := fmt.Sprintf("mongodb://%s:%s@%s/%s", c.User, c.Password, c.Address, c.Database)
 	if c.Mechanism != "" {


### PR DESCRIPTION
### 修复的问题：
- mongodb用户名密码包括特殊字符导致拼接的URI无法连接到mongodb

close #2690