### PR TITLE
V3.2.4 修复查询指定模型的指定实例关联top报错

### DIFF
--- a/src/apimachinery/toposerver/inst/api.go
+++ b/src/apimachinery/toposerver/inst/api.go
@@ -42,7 +42,7 @@ type InstanceInterface interface {
 	SelectInstsByAssociation(ctx context.Context, ownerID string, objID string, h http.Header, p *metadata.AssociationParams) (resp *metadata.SearchInstResult, err error)
 	SelectInst(ctx context.Context, ownerID string, objID string, instID string, h http.Header, p *metadata.SearchParams) (resp *metadata.SearchInstResult, err error)
 	SelectTopo(ctx context.Context, ownerID string, objID string, instID string, h http.Header, p *metadata.SearchParams) (resp *metadata.SearchInstResult, err error)
-	SelectAssociationTopo(ctx context.Context, ownerID string, objID string, instID string, h http.Header, p *metadata.SearchParams) (resp *metadata.SearchInstResult, err error)
+	SelectAssociationTopo(ctx context.Context, ownerID string, objID string, instID string, h http.Header, p *metadata.SearchParams) (resp *metadata.SearchAssociationTopoResult, err error)
 	CreateModule(ctx context.Context, appID string, setID string, h http.Header, dat map[string]interface{}) (resp *metadata.CreateInstResult, err error)
 	DeleteModule(ctx context.Context, appID string, setID string, moduleID string, h http.Header) (resp *metadata.Response, err error)
 	UpdateModule(ctx context.Context, appID string, setID string, moduleID string, h http.Header, dat map[string]interface{}) (resp *metadata.Response, err error)

--- a/src/apimachinery/toposerver/inst/inst.go
+++ b/src/apimachinery/toposerver/inst/inst.go
@@ -147,8 +147,8 @@ func (t *instanceClient) SelectTopo(ctx context.Context, ownerID string, objID s
 	return
 }
 
-func (t *instanceClient) SelectAssociationTopo(ctx context.Context, ownerID string, objID string, instID string, h http.Header, p *metadata.SearchParams) (resp *metadata.SearchInstResult, err error) {
-	resp = new(metadata.SearchInstResult)
+func (t *instanceClient) SelectAssociationTopo(ctx context.Context, ownerID string, objID string, instID string, h http.Header, p *metadata.SearchParams) (resp *metadata.SearchAssociationTopoResult, err error) {
+	resp = new(metadata.SearchAssociationTopoResult)
 	subPath := fmt.Sprintf("/inst/association/topo/search/owner/%s/object/%s/inst/%s", ownerID, objID, instID)
 
 	err = t.client.Post().

--- a/src/common/metadata/toposerver.go
+++ b/src/common/metadata/toposerver.go
@@ -35,3 +35,20 @@ type MainlineObjectTopoResult struct {
 	BaseResp `json:",inline"`
 	Data     []MainlineObjectTopo `json:"data"`
 }
+
+type CommonInstTopo struct {
+	InstNameAsst
+	Count    int            `json:"count"`
+	Children []InstNameAsst `json:"children"`
+}
+
+type CommonInstTopoV2 struct {
+	Prev []*CommonInstTopo `json:"prev"`
+	Next []*CommonInstTopo `json:"next"`
+	Curr interface{}       `json:"curr"`
+}
+
+type SearchAssociationTopoResult struct {
+	BaseResp `json:",inline"`
+	Data     []CommonInstTopoV2 `json:"data"`
+}


### PR DESCRIPTION
### 修复的问题：
- apimachinery的SelectInstsByAssociation函数的返回值与/inst/association/search/owner/%s/object/%s接口的返回值不匹配
