### PR TITLE
fix:ui: 修复切换资源池已分配/未分配主机切换时参数不正确的问题

### DIFF
--- a/src/ui/src/components/hosts/table/index.vue
+++ b/src/ui/src/components/hosts/table/index.vue
@@ -473,12 +473,20 @@
             },
             injectScope (params) {
                 const biz = params.condition.find(condition => condition.bk_obj_id === 'biz')
-                if (this.scope !== 'all') {
-                    biz.condition.push({
+                if (this.scope === 'all') {
+                    biz.condition = biz.condition.filter(condition => condition.field !== 'default')
+                } else {
+                    const newCondition = {
                         field: 'default',
                         operator: '$eq',
                         value: this.scope
-                    })
+                    }
+                    const existCondition = biz.condition.find(condition => condition.field === 'default')
+                    if (existCondition) {
+                        Object.assign(existCondition, newCondition)
+                    } else {
+                        biz.condition.push(newCondition)
+                    }
                 }
                 return params
             },


### PR DESCRIPTION
### 修复的问题：
- 修复切换资源池已分配/未分配主机切换时参数不正确的问题
