### PR TITLE
删除查询关联关系类型，不返回业务主线拓扑模型

### DIFF
--- a/src/scene_server/topo_server/service/association.go
+++ b/src/scene_server/topo_server/service/association.go
@@ -203,18 +203,6 @@ func (s *Service) SearchAssociationType(params types.ContextParams, pathParams, 
 	if request.Condition == nil {
 		request.Condition = make(map[string]interface{}, 0)
 	}
-	if _, exist := request.Condition[common.BKDBAND]; exist {
-		return nil, params.Err.New(common.CCErrCommParamsInvalid, common.BKDBAND)
-	}
-
-	// 主线模型不能与其他模型关系
-	request.Condition[common.BKDBAND] = []interface{}{
-		map[string]interface{}{
-			common.AssociationKindIDField: map[string]interface{}{
-				common.BKDBNE: common.AssociationKindMainline,
-			},
-		},
-	}
 
 	ret, err := s.Core.AssociationOperation().SearchType(params, request)
 	if err != nil {

--- a/src/source_controller/coreservice/service/model_attribute_test.go
+++ b/src/source_controller/coreservice/service/model_attribute_test.go
@@ -42,7 +42,7 @@ func createModelAttributes(t *testing.T, client *httpclient.HttpClient, modelID,
 	require.NotNil(t, inputParams)
 	t.Logf("create one model attribute:%s", inputParams)
 
-	dataResult, err := client.POST("http://127.0.0.1:3308/api/v3/create/model/"+modelID+"/attributes", defaultHeader, inputParams)
+	dataResult, err := client.POST("http://host:port/api/v3/create/model/"+modelID+"/attributes", defaultHeader, inputParams)
 	require.NoError(t, err)
 	require.NotNil(t, dataResult)
 
@@ -85,7 +85,7 @@ func setModelAttributes(t *testing.T, client *httpclient.HttpClient, modelID, mo
 	require.NotNil(t, inputParams)
 	t.Logf("set one model attributes:%s", inputParams)
 
-	dataResult, err := client.POST("http://127.0.0.1:3308/api/v3/set/model/"+modelID+"/attributes", defaultHeader, inputParams)
+	dataResult, err := client.POST("http://host:port/api/v3/set/model/"+modelID+"/attributes", defaultHeader, inputParams)
 	require.NoError(t, err)
 	require.NotNil(t, dataResult)
 
@@ -128,7 +128,7 @@ func queryModelAttributes(t *testing.T, client *httpclient.HttpClient, modelID, 
 	require.NotNil(t, inputParams)
 	t.Logf("read some model attributes:%s", inputParams)
 
-	dataResult, err := client.POST("http://127.0.0.1:3308/api/v3/read/model/"+modelID+"/attributes", defaultHeader, inputParams)
+	dataResult, err := client.POST("http://host:port/api/v3/read/model/"+modelID+"/attributes", defaultHeader, inputParams)
 	require.NoError(t, err)
 	require.NotNil(t, dataResult)
 
@@ -171,7 +171,7 @@ func updateModelAttributes(t *testing.T, client *httpclient.HttpClient, modelID,
 	require.NotNil(t, inputParams)
 	t.Logf("update some model attributes:%s", inputParams)
 
-	dataResult, err := client.PUT("http://127.0.0.1:3308/api/v3/update/model/"+modelID+"/attributes", defaultHeader, inputParams)
+	dataResult, err := client.PUT("http://host:port/api/v3/update/model/"+modelID+"/attributes", defaultHeader, inputParams)
 	require.NoError(t, err)
 	require.NotNil(t, dataResult)
 
@@ -200,7 +200,7 @@ func deleteModelAttributes(t *testing.T, client *httpclient.HttpClient, modelID,
 	require.NotNil(t, inputParams)
 	t.Logf("delete some model attributes:%s", inputParams)
 
-	dataResult, err := client.DELETE("http://127.0.0.1:3308/api/v3/delete/model/"+modelID+"/attributes", defaultHeader, inputParams)
+	dataResult, err := client.DELETE("http://host:port/api/v3/delete/model/"+modelID+"/attributes", defaultHeader, inputParams)
 	require.NoError(t, err)
 	require.NotNil(t, dataResult)
 
@@ -223,7 +223,7 @@ func deleteCascadeModelAttributes(t *testing.T, client *httpclient.HttpClient, m
 func TestModelAttributeCRUD(t *testing.T) {
 
 	// base
-	startCoreService(t, "127.0.0.1", 3308)
+	startCoreService(t, "host", 3308)
 	client := httpclient.NewHttpClient()
 
 	classID := xid.New().String()


### PR DESCRIPTION
### 新加的功能:
- 删除查询关联关系类型，不返回业务主线拓扑模型
- 删除侧泳用例的IP
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
