### PR TITLE
去掉BKHostOuterIPField

### DIFF
--- a/src/scene_server/datacollection/datacollection/hostsnap/hostsnap.go
+++ b/src/scene_server/datacollection/datacollection/hostsnap/hostsnap.go
@@ -491,7 +491,7 @@ const MockMessageData = `{
                 "stolen": 0
             }
         },
-        BKHostOuterIPField       "env": {
+        "env": {
             "crontab": [
                 {
                     "user": "root",


### PR DESCRIPTION
不符合json格式了


### 修复的问题：
- BKHostOuterIPField
