### PR TITLE
降低migrate文件版本号 #3163

### DIFF
--- a/src/scene_server/admin_server/imports.go
+++ b/src/scene_server/admin_server/imports.go
@@ -34,5 +34,5 @@ import (
 	_ "configcenter/src/scene_server/admin_server/upgrader/x18.12.12.04"
 	_ "configcenter/src/scene_server/admin_server/upgrader/x18.12.12.05"
 	_ "configcenter/src/scene_server/admin_server/upgrader/x18.12.12.06"
-	_ "configcenter/src/scene_server/admin_server/upgrader/x19.08.30.01"
+	_ "configcenter/src/scene_server/admin_server/upgrader/x18.12.12.07"
 )

--- a/src/scene_server/admin_server/upgrader/x18.12.12.07/pkg.go
+++ b/src/scene_server/admin_server/upgrader/x18.12.12.07/pkg.go
@@ -9,7 +9,7 @@
  * either express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package x19_08_30_01
+package x18_12_12_07
 
 import (
 	"context"
@@ -20,13 +20,13 @@ import (
 )
 
 func init() {
-	upgrader.RegistUpgrader("x19.08.30.01", upgrade)
+	upgrader.RegistUpgrader("x18.12.12.07", upgrade)
 }
 
 func upgrade(ctx context.Context, db dal.RDB, conf *upgrader.Config) (err error) {
 	err = updateIPRegex(ctx, db, conf)
 	if err != nil {
-		blog.Errorf("[upgrade x19.08.30.01] updateIPRegex error  %s", err.Error())
+		blog.Errorf("[upgrade x18.12.12.07] updateIPRegex error  %s", err.Error())
 		return err
 	}
 	return

--- a/src/scene_server/admin_server/upgrader/x18.12.12.07/update_ip_regex.go
+++ b/src/scene_server/admin_server/upgrader/x18.12.12.07/update_ip_regex.go
@@ -9,7 +9,7 @@
  * either express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package x19_08_30_01
+package x18_12_12_07
 
 import (
 	"context"


### PR DESCRIPTION
# 修复的问题：
- 降低migrate文件版本号 

版本号从 x19.08.30.01 ==> x18.12.12.07

#3163
