### PR TITLE
调整longchar字段类型最大长度为 15000

### DIFF
--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -719,7 +719,7 @@ const (
 	FieldTypeSingleLenChar int = 256
 
 	// FieldTypeLongLenChar the long char length limit
-	FieldTypeLongLenChar int = 2000
+	FieldTypeLongLenChar int = 15000
 )
 
 const (

--- a/src/scene_server/topo_server/core/operation/association_mainline_inst.go
+++ b/src/scene_server/topo_server/core/operation/association_mainline_inst.go
@@ -355,7 +355,7 @@ func (assoc *association) fillStatistics(params types.ContextParams, bizID int64
 	exactNodes := []string{common.BKInnerObjIDApp, common.BKInnerObjIDSet, common.BKInnerObjIDModule}
 	for _, tir := range parentInsts {
 		tir.DeepFirstTraverse(func(node *metadata.TopoInstRst) {
-			if util.InStrArr(exactNodes, node.ObjID) == false && len(node.Child) > 0 {
+			if len(node.Child) > 0 {
 				// calculate service instance count
 				subTreeSvcInstCount := int64(0)
 				for _, child := range node.Child {
@@ -363,6 +363,7 @@ func (assoc *association) fillStatistics(params types.ContextParams, bizID int64
 				}
 				node.ServiceInstanceCount = subTreeSvcInstCount
 
+			} else if util.InStrArr(exactNodes, node.ObjID) == false && len(node.Child) > 0 {
 				// calculate host count
 				subTreeHosts := make([]int64, 0)
 				for _, child := range node.Child {


### PR DESCRIPTION
### 优化的功能:
- 调整longchar字段类型最大长度为 15000

close #3176