### PR TITLE
v3.5.x mapstr的String(key string)函数问题修复

### DIFF
--- a/src/common/mapstr/mapstr.go
+++ b/src/common/mapstr/mapstr.go
@@ -192,8 +192,10 @@ func (cli MapStr) String(key string) (string, error) {
 	switch t := cli[key].(type) {
 	case nil:
 		return "", nil
-	default:
-		return fmt.Sprintf("%v", t), nil
+	case float32:
+		return strconv.FormatFloat(float64(t),'f',-1,32), nil
+	case float64:
+		return strconv.FormatFloat(float64(t),'f',-1,64), nil
 	case map[string]interface{}, []interface{}:
 		rest, err := json.Marshal(t)
 		if nil != err {
@@ -204,6 +206,8 @@ func (cli MapStr) String(key string) (string, error) {
 		return t.String(), nil
 	case string:
 		return t, nil
+	default:
+		return fmt.Sprintf("%v", t), nil
 	}
 }
 

--- a/src/common/mapstr/mapstr_test.go
+++ b/src/common/mapstr/mapstr_test.go
@@ -373,3 +373,32 @@ func TestClone(t *testing.T) {
 	t.Logf("origin:%#v private:%s", (targetMapStr["struct"].(*targetTest)).TargetInline.Field1Inline, (targetMapStr["struct"].(*targetTest)).privateField)
 	t.Logf("clone:%#v private:%s", (cloneInst["struct"].(*targetTest)).TargetInline.Field1Inline, (cloneInst["struct"].(*targetTest)).privateField)
 }
+
+func TestLargeNumber(t *testing.T) {
+	testData := mapstr.MapStr{
+		"int": int(5000000000000000000),
+		"uint": uint(5000000000000000000),
+		"int64": int64(5000000000000000000),
+		"uint64": uint64(5000000000000000000),
+		"float64": float64(5000000000000000000),
+		"float32": float32(5000000000000000000),
+	}
+	str, err := testData.String("int")
+	require.NoError(t, err)
+	require.Equal(t, str, "5000000000000000000")
+	str, err = testData.String("uint")
+	require.NoError(t, err)
+	require.Equal(t, str, "5000000000000000000")
+	str, err = testData.String("int64")
+	require.NoError(t, err)
+	require.Equal(t, str, "5000000000000000000")
+	str, err = testData.String("uint64")
+	require.NoError(t, err)
+	require.Equal(t, str, "5000000000000000000")
+	str, err = testData.String("float64")
+	require.NoError(t, err)
+	require.Equal(t, str, "5000000000000000000")
+	str, err = testData.String("float32")
+	require.NoError(t, err)
+	require.Equal(t, str, "5000000000000000000")
+}


### PR DESCRIPTION
### 修复的问题：
- mapstr的String(key string)函数使用fmt.Sprintf("%v", t)转换float数据时，由于%v对应float类型的%g占位符，在数据过长时可能会转换为科学计数法
