### PR TITLE
fix: generate.py生成dockerfile的时候复制文件少了个'/'

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -30,7 +30,7 @@ def generate_docker_file(image, src_dir, dst_dir, output):
             target_dir = os.path.normpath(dst_dir+"/"+new_root+"/"+d)
             run_cmd_params.append("RUN mkdir -p /" + target_dir)
         for f in files:
-            target_file = os.path.normpath(dst_dir+"/"+new_root+f)
+            target_file = os.path.normpath(dst_dir+"/"+new_root+"/"+f)
             copy_cmd_params.append("COPY /" + os.path.normpath(dst_dir+"/"+new_root) + "/" + f + " /" + target_file)
 
     template = DockerfileTemplate(docker_file_template_str)


### PR DESCRIPTION
### 修复的问题：
- generate.py生成dockerfile的时候复制文件少了个'/'
