### PR TITLE
optimize: a  operator in mongodb can not be empty in search host api.

### DIFF
--- a/src/common/paraparse/host.go
+++ b/src/common/paraparse/host.go
@@ -85,7 +85,11 @@ func ParseHostParams(input []metadata.ConditionItem, output map[string]interface
 				}
 				fields = append(fields, mapstr.MapStr{i.Field: mapstr.MapStr{common.BKDBLIKE: mstr}})
 			}
-			output[common.BKDBOR] = fields
+			if len(fields) != 0 {
+			    // only when the fields is none empty, then the fields is valid.
+			    // a or operator can not have a empty value in mongodb.
+                output[common.BKDBOR] = fields
+            } 
 		default:
 			queryCondItem, ok := output[i.Field].(map[string]interface{})
 			if !ok {


### PR DESCRIPTION

### 优化的功能:
- 主机查询中的$multilike操作符值为空时，不执行查询动作，否则mongodb无法正常进行查询。

