### PR TITLE
查询实例关联关系API 

### DIFF
--- a/src/common/metadata/association.go
+++ b/src/common/metadata/association.go
@@ -453,3 +453,28 @@ type ResponeImportAssociationData struct {
 type RequestImportAssociation struct {
 	AssociationInfoMap map[int]ExcelAssocation `json:"association_info"`
 }
+
+// RequestInstAssociationObjectID 要求根据实例信息（实例的模型ID，实例ID）和模型ID（关联关系中的源，目的模型ID）, 返回关联关系的请求参数
+type RequestInstAssociationObjectID struct {
+	Condition RequestInstAssociationObjectIDCondition `json:"condition"`
+	Page      BasePage                                `json:"page"`
+}
+
+// RequestInstAssociationObjectIDCondition  query condition
+type RequestInstAssociationObjectIDCondition struct {
+	// 实例得模型ID
+	ObjectID string `json:"bk_obj_id"`
+	// 实例ID
+	InstID int64 `json:"bk_inst_id"`
+	// ObjectID是否为目标模型， 默认false， 关联关系中的源模型，否则是目标模型
+	IsTargetObject bool `json:"is_target_object"`
+
+	// 关联对象的模型ID
+	AssociationObjectID string `json:"association_obj_id"`
+}
+
+// InstBaseInfo instance base info
+type InstBaseInfo struct {
+	ID   int64  `json:"bk_inst_id"`
+	Name string `json:"bk_inst_name"`
+}

--- a/src/scene_server/topo_server/core/operation/association.go
+++ b/src/scene_server/topo_server/core/operation/association.go
@@ -1065,6 +1065,10 @@ func (assoc *association) SearchInstAssociationSingleObjectInstInfo(params types
 	// association count
 	cnt = rsp.Data.Count
 
+	if cnt == 0 {
+		return nil, 0, nil
+	}
+
 	var objIDInstIDArr []int64
 
 	for _, instAsst := range rsp.Data.Info {

--- a/src/scene_server/topo_server/core/operation/association.go
+++ b/src/scene_server/topo_server/core/operation/association.go
@@ -78,6 +78,7 @@ type AssociationOperationInterface interface {
 	SearchInstAssociation(params types.ContextParams, query *metadata.QueryInput) ([]metadata.InstAsst, error)
 	SearchInstAssociationList(params types.ContextParams, query *metadata.QueryCondition) ([]metadata.InstAsst, uint64, error)
 	SearchInstAssociationUIList(params types.ContextParams, objID string, query *metadata.QueryCondition) (result interface{}, asstCnt uint64, err error)
+	SearchInstAssociationSingleObjectInstInfo(params types.ContextParams, returnInstInfoObjID string, query *metadata.QueryCondition) (result []metadata.InstBaseInfo, cnt uint64, err error)
 	CheckBeAssociation(params types.ContextParams, obj model.Object, cond condition.Condition) error
 	CreateCommonInstAssociation(params types.ContextParams, data *metadata.InstAsst) error
 	DeleteInstAssociation(params types.ContextParams, cond condition.Condition) error
@@ -1045,4 +1046,78 @@ func (assoc *association) SearchInstAssociationUIList(params types.ContextParams
 	}
 
 	return result, rsp.Data.Count, nil
+}
+
+// SearchInstAssociationUIList 与实例有关系的实例关系数据,以分页的方式返回
+// returnInstInfoObjID 根据条件查询出来关联关系，需要返回实例信息（实例名，实例ID）的模型ID
+func (assoc *association) SearchInstAssociationSingleObjectInstInfo(params types.ContextParams, returnInstInfoObjID string, query *metadata.QueryCondition) (result []metadata.InstBaseInfo, cnt uint64, err error) {
+
+	rsp, err := assoc.clientSet.CoreService().Association().ReadInstAssociation(context.Background(), params.Header, query)
+	if nil != err {
+		blog.Errorf("ReadInstAssociation http do error, err: %s, rid: %s", err.Error(), params.ReqID)
+		return nil, 0, params.Err.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
+	}
+
+	if !rsp.Result {
+		blog.ErrorJSON("ReadInstAssociation http response error, query: %s, response: %s, rid: %s", query, rsp, params.ReqID)
+		return nil, 0, params.Err.New(rsp.Code, rsp.ErrMsg)
+	}
+	// association count
+	cnt = rsp.Data.Count
+
+	var objIDInstIDArr []int64
+
+	for _, instAsst := range rsp.Data.Info {
+		if instAsst.ObjectID == returnInstInfoObjID {
+			objIDInstIDArr = append(objIDInstIDArr, instAsst.InstID)
+		} else if instAsst.AsstObjectID == returnInstInfoObjID {
+			objIDInstIDArr = append(objIDInstIDArr, instAsst.AsstInstID)
+
+		}
+	}
+
+	idField := metadata.GetInstIDFieldByObjID(returnInstInfoObjID)
+	nameField := metadata.GetInstNameFieldName(returnInstInfoObjID)
+	cond := condition.CreateCondition()
+	cond.Field(idField).In(objIDInstIDArr)
+	input := &metadata.QueryCondition{
+		Condition: cond.ToMapStr(),
+		Limit: metadata.SearchLimit{
+			Offset: 0,
+			Limit:  common.BKNoLimit,
+		},
+		Fields: []string{nameField, idField},
+	}
+	instResp, err := assoc.clientSet.CoreService().Instance().
+		ReadInstance(context.Background(), params.Header, returnInstInfoObjID, input)
+	if err != nil {
+		blog.Errorf("ReadInstance http do error, err: %s, input:%s, rid: %s", err.Error(), input, params.ReqID)
+		return nil, 0, params.Err.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
+	}
+	if !instResp.Result {
+		blog.ErrorJSON("ReadInstance http response error, query: %s, response: %s, rid: %s", query, rsp, params.ReqID)
+		return nil, 0, params.Err.New(rsp.Code, rsp.ErrMsg)
+	}
+
+	result = make([]metadata.InstBaseInfo, 0)
+	for _, row := range instResp.Data.Info {
+		id, err := row.Int64(idField)
+		if err != nil {
+			blog.ErrorJSON("ReadInstance  convert field(%s) to int error. err:%s, inst:%s,rid:%s", idField, err.Error(), row, params.ReqID)
+			// CCErrCommInstFieldConvertFail  convert %s  field %s to %s error %s
+			return nil, 0, params.Err.Errorf(common.CCErrCommInstFieldConvertFail, returnInstInfoObjID, idField, "int", err.Error())
+		}
+		name, err := row.String(nameField)
+		if err != nil {
+			blog.ErrorJSON("ReadInstance  convert field(%s) to int error. err:%s, inst:%s,rid:%s", nameField, err.Error(), row, params.ReqID)
+			// CCErrCommInstFieldConvertFail  convert %s  field %s to %s error %s
+			return nil, 0, params.Err.Errorf(common.CCErrCommInstFieldConvertFail, returnInstInfoObjID, idField, "string", err.Error())
+		}
+		result = append(result, metadata.InstBaseInfo{
+			ID:   id,
+			Name: name,
+		})
+	}
+
+	return result, cnt, nil
 }

--- a/src/scene_server/topo_server/service/inst.go
+++ b/src/scene_server/topo_server/service/inst.go
@@ -527,7 +527,7 @@ func (s *Service) SearchInstAssociation(params types.ContextParams, pathParams, 
 
 func (s *Service) SearchInstAssociationUI(params types.ContextParams, pathParams, queryParams ParamsGetter, data mapstr.MapStr) (interface{}, error) {
 
-	objID := pathParams("bk_obj_id")
+	objID := pathParams(common.BKObjIDField)
 	instID, err := strconv.ParseInt(pathParams("id"), 10, 64)
 	if err != nil {
 		return nil, params.Err.Errorf(common.CCErrCommParamsNeedInt, "id")
@@ -569,5 +569,54 @@ func (s *Service) SearchInstAssociationUI(params types.ContextParams, pathParams
 		"data":              infos,
 		"association_count": cnt,
 		"page":              input.Limit,
+	}, err
+}
+
+// SearchInstAssociationWithOtherObject  要求根据实例信息（实例的模型ID，实例ID）和模型ID（关联关系中的源，目的模型ID） 返回实例关联或者被关联模型实例得数据。
+func (s *Service) SearchInstAssociationWithOtherObject(params types.ContextParams, pathParams, queryParams ParamsGetter, data mapstr.MapStr) (interface{}, error) {
+
+	reqParams := &metadata.RequestInstAssociationObjectID{}
+	if err := data.MarshalJSONInto(reqParams); nil != err {
+		blog.Errorf("SearchInstAssociationWithOtherObject failed to parse the data and the condition, the input (%#v), error info is %s, rid: %s", data, err.Error(), params.ReqID)
+		return nil, err
+	}
+
+	cond := condition.CreateCondition()
+	if reqParams.Condition.IsTargetObject {
+		// 作为目标模型
+		cond.Field(common.BKAsstObjIDField).Eq(reqParams.Condition.ObjectID)
+		cond.Field(common.BKAsstInstIDField).Eq(reqParams.Condition.InstID)
+		cond.Field(common.BKObjIDField).Eq(reqParams.Condition.AssociationObjectID)
+	} else {
+		// 作为源模型
+		cond.Field(common.BKObjIDField).Eq(reqParams.Condition.ObjectID)
+		cond.Field(common.BKInstIDField).Eq(reqParams.Condition.InstID)
+		cond.Field(common.BKAsstObjIDField).Eq(reqParams.Condition.AssociationObjectID)
+	}
+
+	input := &metadata.QueryCondition{
+		Condition: cond.ToMapStr(),
+		Limit: metadata.SearchLimit{
+			Limit:  int64(reqParams.Page.Limit),
+			Offset: int64(reqParams.Page.Start),
+		},
+	}
+
+	if input.IsIllegal() {
+		blog.ErrorJSON("parse page illegal, input:%s,rid:%s", input, params.ReqID)
+		return nil, params.Err.Error(common.CCErrCommPageLimitIsExceeded)
+	}
+
+	blog.V(5).Infof("input:%#v, rid:%s", input, params.ReqID)
+	infos, cnt, err := s.Core.AssociationOperation().SearchInstAssociationSingleObjectInstInfo(params, reqParams.Condition.AssociationObjectID, input)
+	if err != nil {
+		blog.ErrorJSON("parse page illegal, input:%s, err:%s, rid:%s", input, err.Error(), params.ReqID)
+		return nil, err
+	}
+
+	return map[string]interface{}{
+		"info":  infos,
+		"count": cnt,
+		"page":  input.Limit,
 	}, err
 }

--- a/src/scene_server/topo_server/service/service_initfunc.go
+++ b/src/scene_server/topo_server/service/service_initfunc.go
@@ -128,6 +128,7 @@ func (s *Service) initInst() {
 	// 2019-09-30 废弃接口
 	//s.addAction(http.MethodPost, "/findmany/inst/association/object/{bk_obj_id}/inst_id/{id}/offset/{start}/limit/{limit}", s.SearchInstAssociation, nil)
 	s.addAction(http.MethodPost, "/findmany/inst/association/object/{bk_obj_id}/inst_id/{id}/offset/{start}/limit/{limit}/web", s.SearchInstAssociationUI, nil)
+	s.addAction(http.MethodPost, "/findmany/inst/association/association_object/inst_base_info", s.SearchInstAssociationWithOtherObject, nil)
 
 }
 


### PR DESCRIPTION
### 新加的功能:
- 要求根据实例信息（实例的模型ID，实例ID）和模型ID（关联关系中的源，目的模型ID） 返回实例关联或者被关联模型实例得数据。
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx


close #3282 