### PR TITLE
fix: excel import enum field fail

### DIFF
--- a/src/source_controller/validator/util.go
+++ b/src/source_controller/validator/util.go
@@ -18,6 +18,7 @@ import (
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/metadata"
+	"configcenter/src/scene_server/validator"
 
 	"github.com/tidwall/gjson"
 	"gopkg.in/mgo.v2/bson"
@@ -103,11 +104,21 @@ func FillLostedFieldValue(valData map[string]interface{}, propertys []metadata.A
 
 // ParseEnumOption convert val to []EnumVal
 func ParseEnumOption(val interface{}) EnumOption {
+
 	enumOptions := []EnumVal{}
 	if nil == val || "" == val {
 		return enumOptions
 	}
 	switch options := val.(type) {
+	case validator.EnumOption:
+		for _, optionVal := range options {
+			enumOption := EnumVal{}
+			enumOption.ID = optionVal.ID
+			enumOption.Name = optionVal.Name
+			enumOption.Type = optionVal.Type
+			enumOption.IsDefault = optionVal.IsDefault
+			enumOptions = append(enumOptions, enumOption)
+		}
 	case []EnumVal:
 		return options
 	case string:

--- a/src/source_controller/validator/valid_basic.go
+++ b/src/source_controller/validator/valid_basic.go
@@ -82,6 +82,7 @@ func (valid *Validator) ValidateCreate(valData map[string]interface{}) error {
 	}
 	err := valid.ValidateMap(valData)
 	if err != nil {
+		blog.Errorf("ValidateMap, err: %v", err)
 		return err
 	}
 	return valid.validCreateUnique(valData)
@@ -444,6 +445,7 @@ func (valid *Validator) validEnum(val interface{}, key string) error {
 	}
 	// validate within enum
 	enumOption := ParseEnumOption(option.Option)
+
 	match := false
 	for _, k := range enumOption {
 		if k.ID == valStr {


### PR DESCRIPTION
### 修复的问题：
- excel导入实例时，有枚举字段会导入失败

- 原因：解析枚举字段的Option没考虑validator.EnumOption这个类型
