### PR TITLE
进程升级到3.5时进程实例supplier account与服务实例保持一致

### DIFF
--- a/src/scene_server/admin_server/upgrader/x19.05.16.01/upgrade_service_template.go
+++ b/src/scene_server/admin_server/upgrader/x19.05.16.01/upgrade_service_template.go
@@ -302,6 +302,7 @@ func upgradeServiceTemplate(ctx context.Context, db dal.RDB, conf *upgrader.Conf
 						} else {
 							inst.BindIP = new(string)
 						}
+						inst.SupplierAccount = ownerID
 						blog.InfoJSON("procInst: %s", inst)
 						if err = db.Table(common.BKTableNameBaseProcess).Insert(ctx, inst); err != nil {
 							return err

--- a/src/scene_server/proc_server/service/serviceinstance.go
+++ b/src/scene_server/proc_server/service/serviceinstance.go
@@ -523,11 +523,13 @@ func (ps *ProcServer) DiffServiceInstanceWithTemplate(ctx *rest.Contexts) {
 					return
 				}
 			}
-
+			processName := ""
+			if process.ProcessName != nil {
+				processName = *process.ProcessName
+			}
 			property, exist := pTemplateMap[relation.ProcessTemplateID]
 			if !exist {
 				// process's template doesn't exist means the template has already been removed.
-				processName := *process.ProcessName
 				removed[processName] = append(removed[processName], recorder{
 					ProcessID:       relation.ProcessID,
 					Process:         process,
@@ -542,7 +544,7 @@ func (ps *ProcServer) DiffServiceInstanceWithTemplate(ctx *rest.Contexts) {
 				// nothing changed
 				unchanged[relation.ProcessTemplateID] = append(unchanged[relation.ProcessTemplateID], recorder{
 					ProcessID:       relation.ProcessID,
-					ProcessName:     *process.ProcessName,
+					ProcessName:     processName,
 					ServiceInstance: &serviceInstances.Info[idx],
 				})
 				continue
@@ -551,7 +553,7 @@ func (ps *ProcServer) DiffServiceInstanceWithTemplate(ctx *rest.Contexts) {
 			// something has already changed.
 			changed[relation.ProcessTemplateID] = append(changed[relation.ProcessTemplateID], recorder{
 				ProcessID:        relation.ProcessID,
-				ProcessName:      *process.ProcessName,
+				ProcessName:      processName,
 				ServiceInstance:  &serviceInstances.Info[idx],
 				ChangedAttribute: changedAttributes,
 			})
@@ -1117,12 +1119,12 @@ func (ps *ProcServer) ServiceInstanceLabelsAggregation(ctx *rest.Contexts) {
 			return
 		}
 	}
-	
+
 	if bizID == 0 {
-        ctx.RespErrorCodeF(common.CCErrCommParamsIsInvalid, "list service instance label, but got invalid biz id: 0", "bk_biz_id")
-        return
-    }
-	
+		ctx.RespErrorCodeF(common.CCErrCommParamsIsInvalid, "list service instance label, but got invalid biz id: 0", "bk_biz_id")
+		return
+	}
+
 	listOption := &metadata.ListServiceInstanceOption{
 		BusinessID: bizID,
 	}


### PR DESCRIPTION
### 修复的问题：
- 进程升级到3.5时进程实例supplier account必须与服务实例保持一致
- 进程实例没找到时空指针异常规避
