### PR TITLE
fix: 查看主机删除历史页面查看不到被删除的主机记录

### DIFF
--- a/src/scene_server/host_server/service/host.go
+++ b/src/scene_server/host_server/service/host.go
@@ -130,12 +130,6 @@ func (s *Service) DeleteHostBatch(req *restful.Request, resp *restful.Response) 
 			return
 		}
 
-		if err := logger.WithCurrent(strconv.FormatInt(hostID, 10)); err != nil {
-			blog.Errorf("delet host batch, but get current host data failed, err: %v", err)
-			resp.WriteError(http.StatusBadRequest, &meta.RespError{Msg: defErr.Error(common.CCErrHostGetFail)})
-			return
-		}
-
 		logConents = append(logConents, *logger.AuditLog(hostID))
 	}
 


### PR DESCRIPTION
### 修复的问题：
- 主机删除的操作审计日志中设置了当前值和删除前的值相同导致操作审计日志未添加进数据库
