### PR TITLE
通过模板同步进程实例属性时，进程实例属性bind_ip原始值nil时同步的bind_ip没有转换成ip地址bugfix(模板中的值为1, 2)

### DIFF
--- a/src/common/metadata/process.go
+++ b/src/common/metadata/process.go
@@ -727,7 +727,7 @@ func (pt *ProcessTemplate) ExtractChangeInfo(i *Process) (mapstr.MapStr, bool) {
 			process["bind_ip"] = nil
 			changed = true
 		} else if t.BindIP.Value != nil && i.BindIP == nil {
-			process["bind_ip"] = *t.BindIP.Value
+			process["bind_ip"] = t.BindIP.Value.IP()
 			changed = true
 		} else if t.BindIP.Value != nil && i.BindIP != nil && t.BindIP.Value.IP() != *i.BindIP {
 			process["bind_ip"] = t.BindIP.Value.IP()


### PR DESCRIPTION
### 修复的问题：
- 通过模板同步进程实例属性时，进程实例属性bind_ip原始值nil时同步的bind_ip没有转换成ip地址bugfix(模板中的值为1, 2)
