### PR TITLE
optimize: 查询业务接口优化，删除查询归档业务接口

### DIFF
--- a/src/apimachinery/apiserver/api.go
+++ b/src/apimachinery/apiserver/api.go
@@ -39,20 +39,6 @@ func (a *apiServer) AddDefaultApp(ctx context.Context, h http.Header, ownerID st
 	return
 }
 
-func (a *apiServer) SearchDefaultApp(ctx context.Context, h http.Header, ownerID string, params mapstr.MapStr) (resp *metadata.QueryInstResult, err error) {
-	resp = new(metadata.QueryInstResult)
-	subPath := fmt.Sprintf("biz/default/%s/search", ownerID)
-
-	err = a.client.Post().
-		WithContext(ctx).
-		Body(params).
-		SubResource(subPath).
-		WithHeaders(h).
-		Do().
-		Into(resp)
-	return
-}
-
 func (a *apiServer) GetObjectData(ctx context.Context, h http.Header, params mapstr.MapStr) (resp *metadata.ObjectAttrBatchResult, err error) {
 	resp = new(metadata.ObjectAttrBatchResult)
 	subPath := fmt.Sprintf("object/search/batch")

--- a/src/apimachinery/apiserver/apiserver.go
+++ b/src/apimachinery/apiserver/apiserver.go
@@ -28,7 +28,6 @@ import (
 
 type ApiServerClientInterface interface {
 	AddDefaultApp(ctx context.Context, h http.Header, ownerID string, params mapstr.MapStr) (resp *metadata.Response, err error)
-	SearchDefaultApp(ctx context.Context, h http.Header, ownerID string, params mapstr.MapStr) (resp *metadata.QueryInstResult, err error)
 	GetObjectData(ctx context.Context, h http.Header, params mapstr.MapStr) (resp *metadata.ObjectAttrBatchResult, err error)
 	GetInstDetail(ctx context.Context, h http.Header, ownerID, objID string, params mapstr.MapStr) (resp *metadata.QueryInstResult, err error)
 	CreateObjectAtt(ctx context.Context, h http.Header, obj *metadata.ObjAttDes) (resp *metadata.Response, err error)

--- a/src/apimachinery/toposerver/inst/api.go
+++ b/src/apimachinery/toposerver/inst/api.go
@@ -30,7 +30,6 @@ type InstanceInterface interface {
 	UpdateAppDataStatus(ctx context.Context, ownerID string, flag common.DataStatusFlag, appID string, h http.Header) (resp *metadata.Response, err error)
 	SearchApp(ctx context.Context, ownerID string, h http.Header, s *params.SearchParams) (resp *metadata.SearchInstResult, err error)
 	GetAppBasicInfo(ctx context.Context, h http.Header, bizID int64) (resp *metadata.AppBasicInfoResult, err error)
-	GetDefaultApp(ctx context.Context, ownerID string, h http.Header, s *params.SearchParams) (resp *metadata.SearchInstResult, err error)
 	CreateDefaultApp(ctx context.Context, ownerID string, h http.Header, data map[string]interface{}) (resp *metadata.CreateInstResult, err error)
 	QueryAudit(ctx context.Context, ownerID string, h http.Header, input *metadata.QueryInput) (resp *metadata.Response, err error)
 	QueryAuditLog(ctx context.Context, h http.Header, input *metadata.QueryInput) (resp *metadata.Response, err error)

--- a/src/apimachinery/toposerver/inst/app.go
+++ b/src/apimachinery/toposerver/inst/app.go
@@ -101,19 +101,6 @@ func (t *instanceClient) GetAppBasicInfo(ctx context.Context, h http.Header, biz
 	return
 }
 
-func (t *instanceClient) GetDefaultApp(ctx context.Context, ownerID string, h http.Header, s *params.SearchParams) (resp *metadata.SearchInstResult, err error) {
-	resp = new(metadata.SearchInstResult)
-	subPath := fmt.Sprintf("/app/default/%s/search", ownerID)
-	err = t.client.Post().
-		WithContext(ctx).
-		Body(s).
-		SubResource(subPath).
-		WithHeaders(h).
-		Do().
-		Into(resp)
-	return
-}
-
 func (t *instanceClient) CreateDefaultApp(ctx context.Context, ownerID string, h http.Header, data map[string]interface{}) (resp *metadata.CreateInstResult, err error) {
 	resp = new(metadata.CreateInstResult)
 	subPath := fmt.Sprintf("/app/default/%s", ownerID)

--- a/src/auth/parser/topology.go
+++ b/src/auth/parser/topology.go
@@ -59,7 +59,6 @@ var (
 	updateBusinessRegexp             = regexp.MustCompile(`^/api/v3/biz/[^\s/]+/[0-9]+/?$`)
 	deleteBusinessRegexp             = regexp.MustCompile(`^/api/v3/biz/[^\s/]+/[0-9]+/?$`)
 	findBusinessRegexp               = regexp.MustCompile(`^/api/v3/biz/search/[^\s/]+/?$`)
-	findResourcePoolBusinessRegexp   = regexp.MustCompile(`^/api/v3/biz/default/[^\s/]+/search/?$`)
 	createResourcePoolBusinessRegexp = regexp.MustCompile(`^/api/v3/biz/default/[^\s/]+/?$`)
 	updateBusinessStatusRegexp       = regexp.MustCompile(`^/api/v3/biz/status/[^\s/]+/[^\s/]+/[0-9]+/?$`)
 )
@@ -191,20 +190,6 @@ func (ps *parseStream) business() *parseStream {
 	// find business, this is not a normalize api.
 	// TODO: update this api format
 	if ps.hitRegexp(findBusinessRegexp, http.MethodPost) {
-		ps.Attribute.Resources = []meta.ResourceAttribute{
-			{
-				Basic: meta.Basic{
-					Type:   meta.Business,
-					Action: meta.FindMany,
-				},
-				// we don't know if one or more business is to find, so we assume it's a find many
-				// business operation.
-			},
-		}
-		return ps
-	}
-
-	if ps.hitRegexp(findResourcePoolBusinessRegexp, http.MethodPost) {
 		ps.Attribute.Resources = []meta.ResourceAttribute{
 			{
 				Basic: meta.Basic{

--- a/src/common/metadata/toposerver.go
+++ b/src/common/metadata/toposerver.go
@@ -12,6 +12,8 @@
 
 package metadata
 
+import "configcenter/src/common/mapstr"
+
 type SearchInstResult struct {
 	BaseResp `json:",inline"`
 	Data     InstResult `json:"data"`
@@ -60,4 +62,10 @@ type SearchAssociationTopoResult struct {
 type SearchTopoResult struct {
 	BaseResp `json:",inline"`
 	Data     []*CommonInstTopo `json:"data"`
+}
+
+type QueryBusinessRequest struct {
+	Fields    []string      `json:"fields"`
+	Page      BasePage      `json:"page"`
+	Condition mapstr.MapStr `json:"condition"`
 }

--- a/src/common/paraparse/app.go
+++ b/src/common/paraparse/app.go
@@ -21,7 +21,6 @@ import (
 	"configcenter/src/common"
 	"configcenter/src/common/mapstr"
 	"configcenter/src/common/metadata"
-	"configcenter/src/common/util"
 )
 
 // common search struct
@@ -29,7 +28,6 @@ type SearchParams struct {
 	Condition map[string]interface{} `json:"condition"`
 	Page      map[string]interface{} `json:"page,omitempty"`
 	Fields    []string               `json:"fields,omitempty"`
-	Native    int                    `json:"native,omitempty"`
 }
 
 // common result struct
@@ -101,28 +99,4 @@ func SpecialCharChange(targetStr string) string {
 	}
 
 	return targetStr
-}
-
-// ParseAppSearchParams parse search app parameter. input user parameter, userFieldArr Fields in the business are user-type fields
-func ParseAppSearchParams(input map[string]interface{}, userFieldArr []string) map[string]interface{} {
-	output := make(map[string]interface{})
-	for i, j := range input {
-		objtype := reflect.TypeOf(j)
-		switch objtype.Kind() {
-		case reflect.String:
-			d := make(map[string]interface{})
-			targetStr := j.(string)
-			if util.InStrArr(userFieldArr, i) {
-				// field type is user, use regex
-				userName := SpecialCharChange(targetStr)
-				d[common.BKDBLIKE] = fmt.Sprintf("^%s,|,%s,|,%s$|^%s$", userName, userName, userName, userName)
-			} else {
-				d[common.BKDBLIKE] = SpecialCharChange(targetStr)
-			}
-			output[i] = d
-		default:
-			output[i] = j
-		}
-	}
-	return output
 }

--- a/src/common/universalsql/mongo/element.go
+++ b/src/common/universalsql/mongo/element.go
@@ -22,6 +22,12 @@ type element struct {
 	Val interface{}
 }
 
+func (e *element) ToMapStr() mapstr.MapStr {
+	return mapstr.MapStr{
+		e.Key: e.Val,
+	}
+}
+
 // Comparison Operator Start
 
 // Eq mongodb operator $eq

--- a/src/scene_server/topo_server/core/operation/inst_business.go
+++ b/src/scene_server/topo_server/core/operation/inst_business.go
@@ -32,7 +32,7 @@ import (
 type BusinessOperationInterface interface {
 	CreateBusiness(params types.ContextParams, obj model.Object, data mapstr.MapStr) (inst.Inst, error)
 	DeleteBusiness(params types.ContextParams, obj model.Object, bizID int64) error
-	FindBusiness(params types.ContextParams, fields []string, cond condition.Condition) (count int, results []mapstr.MapStr, err error)
+	FindBusiness(params types.ContextParams, cond *metadata.QueryBusinessRequest) (count int, results []mapstr.MapStr, err error)
 	GetInternalModule(params types.ContextParams, obj model.Object, bizID int64) (count int, result *metadata.InnterAppTopo, err error)
 	UpdateBusiness(params types.ContextParams, data mapstr.MapStr, obj model.Object, bizID int64) error
 	HasHosts(params types.ContextParams, bizID int64) (bool, error)
@@ -281,16 +281,17 @@ func (b *business) DeleteBusiness(params types.ContextParams, obj model.Object, 
 	return b.inst.DeleteInst(params, bizModel, innerCond, true)
 }
 
-func (b *business) FindBusiness(params types.ContextParams, fields []string, cond condition.Condition) (count int, results []mapstr.MapStr, err error) {
-	cond.Field(common.BKDefaultField).Eq(0)
+func (b *business) FindBusiness(params types.ContextParams, cond *metadata.QueryBusinessRequest) (count int, results []mapstr.MapStr, err error) {
+
+	cond.Condition[common.BKDefaultField] = 0
 	query := &metadata.QueryCondition{
-		Fields:    fields,
-		Condition: cond.ToMapStr(),
+		Fields:    cond.Fields,
+		Condition: cond.Condition,
 		Limit: metadata.SearchLimit{
-			Limit:  cond.GetLimit(),
-			Offset: cond.GetStart(),
+			Limit:  int64(cond.Page.Limit),
+			Offset: int64(cond.Page.Start),
 		},
-		SortArr: metadata.NewSearchSortParse().String(cond.GetSort()).ToSearchSortArr(),
+		SortArr: metadata.NewSearchSortParse().String(cond.Page.Sort).ToSearchSortArr(),
 	}
 
 	result, err := b.clientSet.CoreService().Instance().ReadInstance(params.Context, params.Header, common.BKInnerObjIDApp, query)
@@ -298,6 +299,11 @@ func (b *business) FindBusiness(params types.ContextParams, fields []string, con
 		blog.ErrorJSON("failed to find business by query condition: %s, err: %s, rid: %s", query, err.Error(), params.ReqID)
 		return 0, nil, err
 	}
+
+	if !result.Result {
+		return 0, nil, params.Err.Errorf(result.Code, result.ErrMsg)
+	}
+
 	return result.Data.Count, result.Data.Info, err
 }
 

--- a/src/scene_server/topo_server/service/inst_business.go
+++ b/src/scene_server/topo_server/service/inst_business.go
@@ -17,6 +17,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 
 	"configcenter/src/auth"
 	authmeta "configcenter/src/auth/meta"
@@ -25,7 +26,7 @@ import (
 	"configcenter/src/common/condition"
 	"configcenter/src/common/mapstr"
 	"configcenter/src/common/metadata"
-	gparams "configcenter/src/common/paraparse"
+	"configcenter/src/common/paraparse"
 	"configcenter/src/common/util"
 	"configcenter/src/scene_server/topo_server/core/types"
 )
@@ -128,7 +129,10 @@ func (s *Service) UpdateBusinessStatus(params types.ContextParams, pathParams, q
 		return nil, params.Err.Errorf(common.CCErrCommParamsNeedInt, "business id")
 	}
 	data = mapstr.New()
-	_, bizs, err := s.Core.BusinessOperation().FindBusiness(params, nil, condition.CreateCondition().Field(common.BKAppIDField).Eq(bizID))
+	query := &metadata.QueryBusinessRequest{
+		Condition: mapstr.MapStr{common.BKAppIDField: bizID},
+	}
+	_, bizs, err := s.Core.BusinessOperation().FindBusiness(params, query)
 	if nil != err {
 		return nil, err
 	}
@@ -185,10 +189,15 @@ func (s *Service) UpdateBusinessStatus(params types.ContextParams, pathParams, q
 // 1. have any authorized resources in a business.
 // 2. only returned with a few field for this business info.
 func (s *Service) SearchReducedBusinessList(params types.ContextParams, pathParams, queryParams ParamsGetter, data mapstr.MapStr) (interface{}, error) {
-	fields := []string{common.BKAppIDField, common.BKAppNameField, "business_dept_id", "business_dept_name"}
-	cond := condition.CreateCondition()
-	cond.Field(common.BKDataStatusField).NotEq(common.DataStatusDisabled)
-	cond.Field(common.BKDefaultField).Eq(0)
+	query := &metadata.QueryBusinessRequest{
+		Fields: []string{common.BKAppIDField, common.BKAppNameField, "business_dept_id", "business_dept_name"},
+		Page:   metadata.BasePage{},
+		Condition: mapstr.MapStr{
+			common.BKDataStatusField: mapstr.MapStr{common.BKDBNE: common.DataStatusDisabled},
+			common.BKDefaultField:    0,
+		},
+	}
+
 	if s.AuthManager.Enabled() {
 		user := authmeta.UserInfo{UserName: params.User, SupplierAccount: params.SupplierAccount}
 		appList, err := s.AuthManager.Authorize.GetAnyAuthorizedBusinessList(params.Context, user)
@@ -200,11 +209,11 @@ func (s *Service) SearchReducedBusinessList(params types.ContextParams, pathPara
 		// sort for prepare to find business with page.
 		sort.Sort(util.Int64Slice(appList))
 		// user can only find business that is already authorized.
-		cond.Field(common.BKAppIDField).In(appList)
+		query.Condition[common.BKAppIDField] = mapstr.MapStr{common.BKDBIN: appList}
 
 	}
 
-	cnt, instItems, err := s.Core.BusinessOperation().FindBusiness(params, fields, cond)
+	cnt, instItems, err := s.Core.BusinessOperation().FindBusiness(params, query)
 	if nil != err {
 		blog.Errorf("[api-business] failed to find the objects(%s), error info is %s, rid: %s", pathParams("obj_id"), err.Error(), params.ReqID)
 		return nil, err
@@ -263,11 +272,39 @@ func (s *Service) GetBusinessBasicInfo(params types.ContextParams, pathParams, q
 	return bizData, nil
 }
 
+// 4 scenarios, such as user's name user1, scenarios as follows:
+// user1
+// user1,user3
+// user2,user1
+// user2,user1,user4
+const exactUserRegexp = `(^USER_PLACEHOLDER$)|(^USER_PLACEHOLDER[,]{1})|([,]{1}USER_PLACEHOLDER[,]{1})|([,]{1}USER_PLACEHOLDER$)`
+
+func handleSpecialBusinessFieldSearchCond(input map[string]interface{}, userFieldArr []string) map[string]interface{} {
+	output := make(map[string]interface{})
+	for i, j := range input {
+		objType := reflect.TypeOf(j)
+		switch objType.Kind() {
+		case reflect.String:
+			targetStr := j.(string)
+			if util.InStrArr(userFieldArr, i) {
+				d := make(map[string]interface{})
+				// field type is user, use regex
+				userName := params.SpecialCharChange(targetStr)
+				// search with exactly the user's name with regexp
+				d[common.BKDBLIKE] = strings.Replace(exactUserRegexp, "USER_PLACEHOLDER", userName, -1)
+			} else {
+				output[i] = params.SpecialCharChange(targetStr)
+			}
+		default:
+			output[i] = j
+		}
+	}
+	return output
+}
+
 // SearchBusiness search the business by condition
 func (s *Service) SearchBusiness(params types.ContextParams, pathParams, queryParams ParamsGetter, data mapstr.MapStr) (interface{}, error) {
-	searchCond := &gparams.SearchParams{
-		Condition: mapstr.New(),
-	}
+	searchCond := new(metadata.QueryBusinessRequest)
 	if err := data.MarshalJSONInto(&searchCond); nil != err {
 		blog.Errorf("failed to parse the params, error info is %s, rid: %s", err.Error(), params.ReqID)
 		return nil, params.Err.New(common.CCErrCommParamsInvalid, err.Error())
@@ -283,24 +320,12 @@ func (s *Service) SearchBusiness(params types.ContextParams, pathParams, queryPa
 		return nil, err
 	}
 	// userFieldArr Fields in the business are user-type fields
-	var userFieldArr []string
+	var userFields []string
 	for _, attrInterface := range attrArr {
-		userFieldArr = append(userFieldArr, attrInterface.Attribute().PropertyID)
+		userFields = append(userFields, attrInterface.Attribute().PropertyID)
 	}
 
-	innerCond := condition.CreateCondition()
-	switch searchCond.Native {
-	case 1: // native mode
-		if err := innerCond.Parse(searchCond.Condition); nil != err {
-			blog.Errorf("[api-biz] failed to parse the input data, error info is %s, rid: %s", err.Error(), params.ReqID)
-			return nil, params.Err.Error(common.CCErrTopoAppSearchFailed)
-		}
-	default:
-		if err := innerCond.Parse(gparams.ParseAppSearchParams(searchCond.Condition, userFieldArr)); nil != err {
-			blog.Errorf("[api-biz] failed to parse the input data, err: %s, rid: %s", err.Error(), params.ReqID)
-			return nil, params.Err.Error(common.CCErrTopoAppSearchFailed)
-		}
-	}
+	searchCond.Condition = handleSpecialBusinessFieldSearchCond(searchCond.Condition, userFields)
 
 	// parse business id from user's condition for testing.
 	var bizIDs []int64
@@ -357,19 +382,18 @@ func (s *Service) SearchBusiness(params types.ContextParams, pathParams, queryPa
 			// sort for prepare to find business with page.
 			sort.Sort(util.Int64Slice(appList))
 			// user can only find business that is already authorized.
-			innerCond.Field(common.BKAppIDField).In(appList)
+			searchCond.Condition[common.BKAppIDField] = mapstr.MapStr{common.BKDBIN: appList}
 		}
 	}
 
 	if _, ok := searchCond.Condition[common.BKDataStatusField]; !ok {
-		innerCond.Field(common.BKDataStatusField).NotEq(common.DataStatusDisabled)
+		searchCond.Condition[common.BKDataStatusField] = mapstr.MapStr{common.BKDBNE: common.DataStatusDisabled}
 	}
 
-	innerCond.Field(common.BKDefaultField).Eq(0)
-	innerCond.SetPage(searchCond.Page)
-	innerCond.SetFields(searchCond.Fields)
+	// can only find normal business, but not resource pool business
+	searchCond.Condition[common.BKDefaultField] = 0
 
-	cnt, instItems, err := s.Core.BusinessOperation().FindBusiness(params, searchCond.Fields, innerCond)
+	cnt, instItems, err := s.Core.BusinessOperation().FindBusiness(params, searchCond)
 	if nil != err {
 		blog.Errorf("[api-business] failed to find the objects(%s), error info is %s, rid: %s", pathParams("obj_id"), err.Error(), params.ReqID)
 		return nil, err
@@ -379,39 +403,6 @@ func (s *Service) SearchBusiness(params types.ContextParams, pathParams, queryPa
 	result.Set("count", cnt)
 	result.Set("info", instItems)
 
-	return result, nil
-}
-
-// search archived business by condition
-func (s *Service) SearchArchivedBusiness(params types.ContextParams, pathParams, queryParams ParamsGetter, data mapstr.MapStr) (interface{}, error) {
-	innerCond := condition.CreateCondition()
-	if err := innerCond.Parse(data); nil != err {
-		blog.Errorf("[api-biz] failed to parse the input data, error info is %s, rid: %s", err.Error(), params.ReqID)
-		return nil, params.Err.New(common.CCErrTopoAppSearchFailed, err.Error())
-	}
-	innerCond.Field(common.BKDefaultField).Eq(common.DefaultAppFlag)
-
-	if s.AuthManager.Enabled() {
-		user := authmeta.UserInfo{UserName: params.User, SupplierAccount: params.SupplierAccount}
-		appList, err := s.AuthManager.Authorize.GetExactAuthorizedBusinessList(params.Context, user)
-		if err != nil {
-			blog.Errorf("[api-biz] SearchArchivedBusiness failed, GetExactAuthorizedBusinessList failed, user: %s, err: %s, rid: %s", user, err.Error(), params.ReqID)
-			return nil, params.Err.Error(common.CCErrorTopoGetAuthorizedBusinessListFailed)
-		}
-		// sort for prepare to find business with page.
-		sort.Sort(util.Int64Slice(appList))
-		// user can only find business that is already authorized.
-		innerCond.Field(common.BKAppIDField).In(appList)
-	}
-
-	cnt, instItems, err := s.Core.BusinessOperation().FindBusiness(params, []string{}, innerCond)
-	if nil != err {
-		blog.Errorf("[api-business] failed to find the objects(%s), error info is %s, rid: %s", pathParams("obj_id"), err.Error(), params.ReqID)
-		return nil, err
-	}
-	result := mapstr.MapStr{}
-	result.Set("count", cnt)
-	result.Set("info", instItems)
 	return result, nil
 }
 

--- a/src/scene_server/topo_server/service/service_initfunc.go
+++ b/src/scene_server/topo_server/service/service_initfunc.go
@@ -72,7 +72,6 @@ func (s *Service) initBusiness() {
 	s.addAction(http.MethodPut, "/app/status/{flag}/{owner_id}/{app_id}", s.UpdateBusinessStatus, nil)
 	s.addAction(http.MethodPost, "/app/search/{owner_id}", s.SearchBusiness, nil)
 	s.addAction(http.MethodGet, "/app/{app_id}/basic_info", s.GetBusinessBasicInfo, nil)
-	s.addAction(http.MethodPost, "/app/default/{owner_id}/search", s.SearchArchivedBusiness, nil)
 	s.addAction(http.MethodPost, "/app/default/{owner_id}", s.CreateDefaultBusiness, nil)
 	s.addAction(http.MethodGet, "/topo/internal/{owner_id}/{app_id}", s.GetInternalModule, nil)
 	s.addAction(http.MethodGet, "/topo/internal/{owner_id}/{app_id}/with_statistics", s.GetInternalModuleWithStatistics, nil)

--- a/src/source_controller/coreservice/service/service.go
+++ b/src/source_controller/coreservice/service/service.go
@@ -215,6 +215,7 @@ func (s *coreService) sendCompleteResponse(resp *restful.Response, errorCode int
 	resp.Header().Set("Content-Type", "application/json")
 	rsp, rspErr := s.createCompleteAPIRspStr(errorCode, errMsg, info)
 	if nil == rspErr {
+		fmt.Printf("resp ->: %s\n\n", rsp)
 		io.WriteString(resp, rsp)
 		return
 	}


### PR DESCRIPTION
1. 删除查询归档业务接口
2. 查询业务列表接口SearchBusiness优化，删除native参数，变更查询结构。
3. 查询业务列表接口去掉了,如果字段为string，则进行正则搜索的逻辑，该逻辑不对，可能会导致用户查询错业务。
4. 修复了universalsql中对regex操作符的支持问题，支持options附加操作。


### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
