### PR TITLE
修复auth在blog的flag没有赋值完成的时候调用导致blog的部分flag不生效

### DIFF
--- a/src/common/auth/auth.go
+++ b/src/common/auth/auth.go
@@ -55,7 +55,6 @@ func init() {
 func setEnableAuth(enable bool) {
 	once.Do(func() {
 		enableAuth = enable
-		blog.Infof("[auth] enableAuth: %v", enableAuth)
 	})
 }
 

--- a/src/common/util/flags.go
+++ b/src/common/util/flags.go
@@ -17,7 +17,10 @@ import (
 	"os"
 	"strings"
 
+	"configcenter/src/common/auth"
+	"configcenter/src/common/blog"
 	"configcenter/src/common/version"
+
 	"github.com/spf13/pflag"
 )
 
@@ -47,4 +50,6 @@ func InitFlags() {
 		version.ShowVersion()
 		os.Exit(0)
 	}
+
+	blog.Infof("[auth] enableAuth: %v", auth.IsAuthed())
 }


### PR DESCRIPTION
### 修复的问题：
- auth在blog的flag没有赋值完成的时候调用导致blog的部分flag不生效
