### PR TITLE
修复版本升级主机bk_state_name被删除后，升级失败

### DIFF
--- a/src/scene_server/admin_server/upgrader/x19.04.16.02/pkg.go
+++ b/src/scene_server/admin_server/upgrader/x19.04.16.02/pkg.go
@@ -26,7 +26,7 @@ func init() {
 func upgrade(ctx context.Context, db dal.RDB, conf *upgrader.Config) (err error) {
 	err = updateFranceName(ctx, db, conf)
 	if err != nil {
-		blog.Errorf("[upgrade x19.04.16.02] fixAssociationTypeName error  %s", err.Error())
+		blog.Errorf("[upgrade x19.04.16.02] updateFranceName error  %s", err.Error())
 		return err
 	}
 	return nil

--- a/src/scene_server/admin_server/upgrader/x19.04.16.02/updateFranceName.go
+++ b/src/scene_server/admin_server/upgrader/x19.04.16.02/updateFranceName.go
@@ -31,6 +31,10 @@ func updateFranceName(ctx context.Context, db dal.RDB, conf *upgrader.Config) er
 	state := metadata.Attribute{}
 	err := db.Table(common.BKTableNameObjAttDes).Find(cond.ToMapStr()).One(ctx, &state)
 	if err != nil {
+		// bk_state_name already delete
+		if err == dal.ErrDocumentNotFound {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
-修复版本升级主机bk_state_name被删除后，升级失败的问题

close #3545 
