### PR TITLE
去除GetInstTableName转换表名中使用表名作为object ID的逻辑

### DIFF
--- a/src/auth/extensions/audit.go
+++ b/src/auth/extensions/audit.go
@@ -264,8 +264,8 @@ func (am *AuthManager) GenAuthorizeAuditReadNoPermissionsResponse(ctx context.Co
 			}},
 		}
 	}
-    p.ResourceType = p.Resources[0][0].ResourceType
-    p.ResourceTypeName = p.Resources[0][0].ResourceTypeName
+	p.ResourceType = p.Resources[0][0].ResourceType
+	p.ResourceTypeName = p.Resources[0][0].ResourceTypeName
 	resp := metadata.NewNoPermissionResp([]metadata.Permission{p})
 	return &resp, nil
 }

--- a/src/auth/extensions/business.go
+++ b/src/auth/extensions/business.go
@@ -172,8 +172,8 @@ func (am *AuthManager) GenBusinessAuditNoPermissionResp(ctx context.Context, hea
 		return nil, errors.New("get business detail failed")
 	}
 	p.ScopeName = businesses[0].BKAppNameField
-    p.ResourceType = p.Resources[0][0].ResourceType
-    p.ResourceTypeName = p.Resources[0][0].ResourceTypeName
+	p.ResourceType = p.Resources[0][0].ResourceType
+	p.ResourceTypeName = p.Resources[0][0].ResourceTypeName
 	resp := metadata.NewNoPermissionResp([]metadata.Permission{p})
 	return &resp, nil
 }
@@ -317,7 +317,7 @@ func (am *AuthManager) GenBusinessNoPermissionResp(ctx context.Context, header h
 	p.ScopeTypeName = authcenter.ScopeTypeIDSystemName
 	p.ActionID = string(authcenter.Get)
 	p.ActionName = authcenter.ActionIDNameMap[authcenter.Get]
-    p.ResourceType = string(authcenter.SysBusinessInstance)
+	p.ResourceType = string(authcenter.SysBusinessInstance)
 	p.ResourceTypeName = authcenter.ResourceTypeIDMap[authcenter.SysBusinessInstance]
 	p.Resources = [][]metadata.Resource{
 		{{

--- a/src/auth/extensions/classification.go
+++ b/src/auth/extensions/classification.go
@@ -14,6 +14,7 @@ package extensions
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -48,7 +49,7 @@ func (am *AuthManager) CollectClassificationByBusinessIDs(ctx context.Context, h
 		Condition: cond,
 		Limit:     metadata.SearchLimit{Limit: common.BKNoLimit},
 	}
-	result, err := am.clientSet.CoreService().Instance().ReadInstance(ctx, header, common.BKTableNameObjClassifiction, query)
+	result, err := am.clientSet.CoreService().Model().ReadModelClassification(ctx, header, query)
 	if err != nil {
 		blog.Errorf("get module:%+v by businessID:%d failed, err: %+v, rid: %s", businessID, err, rid)
 		return nil, fmt.Errorf("get module by businessID:%d failed, err: %+v", businessID, err)
@@ -57,9 +58,15 @@ func (am *AuthManager) CollectClassificationByBusinessIDs(ctx context.Context, h
 	classifications := make([]metadata.Classification, 0)
 	for _, cls := range result.Data.Info {
 		classification := metadata.Classification{}
-		_, err = classification.Parse(cls)
+		data, err := json.Marshal(cls)
 		if err != nil {
-			return nil, fmt.Errorf("get classication by object failed, err: %+v", err)
+			blog.ErrorJSON("CollectClassificationByBusinessIDs %s failed, parse attribute %s failed, err: %s, rid: %s", businessID, cls, err, rid)
+			return nil, fmt.Errorf("CollectClassificationByBusinessIDs marshel json %+v failed, err: %+v", cls, err)
+		}
+		err = json.Unmarshal(data, &classification)
+		if err != nil {
+			blog.Errorf("CollectClassificationByBusinessIDs %+v failed, parse attribute %s failed, err: %s, rid: %s", businessID, string(data), err, rid)
+			return nil, fmt.Errorf("CollectClassificationByBusinessIDs unmarshel json %s failed, err: %+v", string(data), err)
 		}
 		classifications = append(classifications, classification)
 	}
@@ -72,10 +79,10 @@ func (am *AuthManager) collectClassificationsByClassificationIDs(ctx context.Con
 	// unique ids so that we can be aware of invalid id if query result length not equal ids's length
 	classificationIDs = util.StrArrayUnique(classificationIDs)
 
-	cond := metadata.QueryCondition{
+	cond := &metadata.QueryCondition{
 		Condition: condition.CreateCondition().Field(common.BKClassificationIDField).In(classificationIDs).ToMapStr(),
 	}
-	result, err := am.clientSet.CoreService().Instance().ReadInstance(ctx, header, common.BKTableNameObjClassifiction, &cond)
+	result, err := am.clientSet.CoreService().Model().ReadModelClassification(ctx, header, cond)
 	if err != nil {
 		blog.V(3).Infof("get classification by id failed, err: %+v, rid: %s", err, rid)
 		return nil, fmt.Errorf("get classification by id failed, err: %+v", err)
@@ -83,9 +90,15 @@ func (am *AuthManager) collectClassificationsByClassificationIDs(ctx context.Con
 	classifications := make([]metadata.Classification, 0)
 	for _, cls := range result.Data.Info {
 		classification := metadata.Classification{}
-		_, err = classification.Parse(cls)
+		data, err := json.Marshal(cls)
 		if err != nil {
-			return nil, fmt.Errorf("get classication by object failed, err: %+v", err)
+			blog.ErrorJSON("collectClassificationsByClassificationIDs %s failed, parse attribute %s failed, err: %s, rid: %s", classificationIDs, cls, err, rid)
+			return nil, fmt.Errorf("collectClassificationsByClassificationIDs marshel json %+v failed, err: %+v", cls, err)
+		}
+		err = json.Unmarshal(data, &classification)
+		if err != nil {
+			blog.Errorf("collectClassificationsByClassificationIDs %+v failed, parse attribute %s failed, err: %s, rid: %s", classificationIDs, string(data), err, rid)
+			return nil, fmt.Errorf("collectClassificationsByClassificationIDs unmarshel json %s failed, err: %+v", string(data), err)
 		}
 		classifications = append(classifications, classification)
 	}
@@ -98,10 +111,10 @@ func (am *AuthManager) collectClassificationsByRawIDs(ctx context.Context, heade
 	// unique ids so that we can be aware of invalid id if query result length not equal ids's length
 	ids = util.IntArrayUnique(ids)
 
-	cond := metadata.QueryCondition{
+	cond := &metadata.QueryCondition{
 		Condition: condition.CreateCondition().Field(common.BKFieldID).In(ids).ToMapStr(),
 	}
-	result, err := am.clientSet.CoreService().Instance().ReadInstance(ctx, header, common.BKTableNameObjClassifiction, &cond)
+	result, err := am.clientSet.CoreService().Model().ReadModelClassification(ctx, header, cond)
 	if err != nil {
 		blog.V(3).Infof("get classification by id failed, err: %+v, rid: %s", err, rid)
 		return nil, fmt.Errorf("get classification by id failed, err: %+v", err)
@@ -109,10 +122,15 @@ func (am *AuthManager) collectClassificationsByRawIDs(ctx context.Context, heade
 	classifications := make([]metadata.Classification, 0)
 	for _, cls := range result.Data.Info {
 		classification := metadata.Classification{}
-		_, err = classification.Parse(cls)
+		data, err := json.Marshal(cls)
 		if err != nil {
-			blog.Errorf("collectClassificationsByRawIDs %+v failed, parse classification %+v failed, err: %+v, rid: %s", ids, cls, err, rid)
-			return nil, fmt.Errorf("parse classification from db data failed, err: %+v", err)
+			blog.ErrorJSON("collectClassificationsByRawIDs %s failed, parse attribute %s failed, err: %s, rid: %s", ids, cls, err, rid)
+			return nil, fmt.Errorf("collectClassificationsByRawIDs marshel json %+v failed, err: %+v", cls, err)
+		}
+		err = json.Unmarshal(data, &classification)
+		if err != nil {
+			blog.Errorf("collectClassificationsByRawIDs %+v failed, parse attribute %s failed, err: %s, rid: %s", ids, string(data), err, rid)
+			return nil, fmt.Errorf("collectClassificationsByRawIDs unmarshel json %s failed, err: %+v", string(data), err)
 		}
 		classifications = append(classifications, classification)
 	}

--- a/src/auth/extensions/dynamicgroup.go
+++ b/src/auth/extensions/dynamicgroup.go
@@ -14,6 +14,7 @@ package extensions
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -32,10 +33,10 @@ import (
 func (am *AuthManager) CollectDynamicGroupByBusinessID(ctx context.Context, header http.Header, businessID int64) ([]DynamicGroupSimplify, error) {
 	rid := util.ExtractRequestIDFromContext(ctx)
 
-	cond := metadata.QueryCondition{
+	cond := metadata.QueryInput{
 		Condition: condition.CreateCondition().Field(common.BKAppIDField).Eq(businessID).ToMapStr(),
 	}
-	result, err := am.clientSet.CoreService().Instance().ReadInstance(ctx, header, common.BKTableNameUserAPI, &cond)
+	result, err := am.clientSet.CoreService().Host().GetUserConfig(ctx, header, &cond)
 	if err != nil {
 		blog.V(3).Infof("get user api by business %d failed, err: %+v, rid: %s", businessID, err, rid)
 		return nil, fmt.Errorf("get user api by business %d failed, err: %+v", businessID, err)
@@ -43,9 +44,13 @@ func (am *AuthManager) CollectDynamicGroupByBusinessID(ctx context.Context, head
 	dynamicGroups := make([]DynamicGroupSimplify, 0)
 	for _, item := range result.Data.Info {
 		dynamicGroup := DynamicGroupSimplify{}
-		_, err = dynamicGroup.Parse(item)
+		data, err := json.Marshal(item)
 		if err != nil {
-			return nil, fmt.Errorf("get user api by business %d failed, err: %+v", businessID, err)
+			return nil, fmt.Errorf("get user api by business %d marshel json %+v failed, err: %+v", businessID, item, err)
+		}
+		err = json.Unmarshal(data, &dynamicGroup)
+		if err != nil {
+			return nil, fmt.Errorf("get user api by business %d unmarshel json %s failed, err: %+v", businessID, string(data), err)
 		}
 		dynamicGroups = append(dynamicGroups, dynamicGroup)
 	}
@@ -58,10 +63,10 @@ func (am *AuthManager) collectDynamicGroupByIDs(ctx context.Context, header http
 	// unique ids so that we can be aware of invalid id if query result length not equal ids's length
 	ids = util.StrArrayUnique(ids)
 
-	cond := metadata.QueryCondition{
+	cond := metadata.QueryInput{
 		Condition: condition.CreateCondition().Field(common.BKFieldID).In(ids).ToMapStr(),
 	}
-	result, err := am.clientSet.CoreService().Instance().ReadInstance(ctx, header, common.BKTableNameUserAPI, &cond)
+	result, err := am.clientSet.CoreService().Host().GetUserConfig(ctx, header, &cond)
 	if err != nil {
 		blog.Errorf("get user api by id %+v failed, err: %+v, rid: %s", ids, err, rid)
 		return nil, fmt.Errorf("get user api by id failed, err: %+v", err)
@@ -69,10 +74,15 @@ func (am *AuthManager) collectDynamicGroupByIDs(ctx context.Context, header http
 	dynamicGroups := make([]DynamicGroupSimplify, 0)
 	for _, item := range result.Data.Info {
 		dynamicGroup := DynamicGroupSimplify{}
-		_, err = dynamicGroup.Parse(item)
+		data, err := json.Marshal(item)
 		if err != nil {
-			blog.Errorf("collectDynamicGroupByIDs by id %+v failed, parse user api %+v failed, err: %+v, rid: %s", ids, item, err, rid)
-			return nil, fmt.Errorf("parse user api from db data failed, err: %+v", err)
+			blog.ErrorJSON("collectDynamicGroupByIDs by id %s failed, parse user api %s failed, err: %s, rid: %s", ids, item, err, rid)
+			return nil, fmt.Errorf("get user api marshel json %+v failed, err: %+v", item, err)
+		}
+		err = json.Unmarshal(data, &dynamicGroup)
+		if err != nil {
+			blog.ErrorJSON("collectDynamicGroupByIDs by id %s failed, parse user api %s failed, err: %s, rid: %s", ids, string(data), err, rid)
+			return nil, fmt.Errorf("get user api unmarshel json %s failed, err: %+v", string(data), err)
 		}
 		dynamicGroups = append(dynamicGroups, dynamicGroup)
 	}

--- a/src/common/tablenames.go
+++ b/src/common/tablenames.go
@@ -173,32 +173,12 @@ func GetInstTableName(objID string) string {
 		return BKTableNameBaseSet
 	case BKInnerObjIDModule:
 		return BKTableNameBaseModule
-	// case BKInnerObjIDObject:
-	// 	return BKTableNameBaseInst
 	case BKInnerObjIDHost:
 		return BKTableNameBaseHost
 	case BKInnerObjIDProc:
 		return BKTableNameBaseProcess
 	case BKInnerObjIDPlat:
 		return BKTableNameBasePlat
-	case BKTableNameInstAsst:
-		return BKTableNameInstAsst
-	case BKTableNameModuleHostConfig:
-		return BKTableNameModuleHostConfig
-	case BKTableNameObjClassifiction:
-		return BKTableNameObjClassifiction
-	case BKTableNameObjAttDes:
-		return BKTableNameObjAttDes
-	case BKTableNamePropertyGroup:
-		return BKTableNamePropertyGroup
-	case BKTableNameObjUnique:
-		return BKTableNameObjUnique
-	case BKTableNameAsstDes:
-		return BKTableNameAsstDes
-	case BKTableNameOperationLog:
-		return BKTableNameOperationLog
-	case BKTableNameUserAPI:
-		return BKTableNameUserAPI
 	default:
 		return BKTableNameBaseInst
 	}

--- a/src/common/tablenames_test.go
+++ b/src/common/tablenames_test.go
@@ -30,7 +30,6 @@ func TestGetInstTableName(t *testing.T) {
 		{"", args{BKInnerObjIDHost}, BKTableNameBaseHost},
 		{"", args{BKInnerObjIDProc}, BKTableNameBaseProcess},
 		{"", args{BKInnerObjIDPlat}, BKTableNameBasePlat},
-		{"", args{BKTableNameInstAsst}, BKTableNameInstAsst},
 		{"", args{""}, BKTableNameBaseInst},
 	}
 	for _, tt := range tests {

--- a/src/scene_server/admin_server/upgrader/y3.6.201911141516/obj_host_add_field_type_list.go
+++ b/src/scene_server/admin_server/upgrader/y3.6.201911141516/obj_host_add_field_type_list.go
@@ -50,7 +50,7 @@ type Attribute struct {
 }
 
 func addHostFieldTypeList(ctx context.Context, db dal.RDB, conf *upgrader.Config) error {
-	attrID, err := db.NextSequence(ctx, common.BKTableNameObjUnique)
+	attrID, err := db.NextSequence(ctx, common.BKTableNameObjAttDes)
 	if err != nil {
 		return err
 	}

--- a/src/source_controller/coreservice/core/association/model_crud.go
+++ b/src/source_controller/coreservice/core/association/model_crud.go
@@ -104,7 +104,7 @@ func (m *associationModel) search(ctx core.ContextParams, cond universalsql.Cond
 	dataResult := []metadata.Association{}
 	err := m.dbProxy.Table(common.BKTableNameObjAsst).Find(cond.ToMapStr()).All(ctx, &dataResult)
 	if nil != err {
-		blog.Errorf("request(%s): it is to search some data on the table (%s) by the condition (%v), error info is %s", ctx.ReqID, common.BKTableNameAsstDes, cond.ToMapStr(), err.Error())
+		blog.Errorf("request(%s): it is to search some data on the table (%s) by the condition (%v), error info is %s", ctx.ReqID, common.BKTableNameObjAsst, cond.ToMapStr(), err.Error())
 		return dataResult, err
 	}
 	return dataResult, err
@@ -114,7 +114,7 @@ func (m *associationModel) searchReturnMapStr(ctx core.ContextParams, cond unive
 	dataResult := []mapstr.MapStr{}
 	err := m.dbProxy.Table(common.BKTableNameObjAsst).Find(cond.ToMapStr()).All(ctx, &dataResult)
 	if nil != err {
-		blog.Errorf("request(%s): it is to search data on the table (%s) by the condition (%#v), error info is %s", ctx.ReqID, common.BKTableNameAsstDes, cond.ToMapStr(), err.Error())
+		blog.Errorf("request(%s): it is to search data on the table (%s) by the condition (%#v), error info is %s", ctx.ReqID, common.BKTableNameObjAsst, cond.ToMapStr(), err.Error())
 		return dataResult, err
 	}
 	return dataResult, err

--- a/src/source_controller/coreservice/service/hostuser.go
+++ b/src/source_controller/coreservice/service/hostuser.go
@@ -186,12 +186,6 @@ func (s *coreService) GetUserConfig(params core.ContextParams, pathParams, query
 		condition = dat.Condition.(map[string]interface{})
 	}
 
-	appID, err := util.GetInt64ByInterface(condition[common.BKAppIDField])
-	if err != nil {
-		blog.Errorf("get user config failed, invalid appid[%s], err: %v, rid: %s", common.BKAppIDField, err, params.ReqID)
-		return nil, params.Error.CCError(common.CCErrCommParamsIsInvalid)
-	}
-
 	start, limit, sort := dat.Start, dat.Limit, dat.Sort
 	var fieldArr []string
 	if "" != dat.Fields {
@@ -205,7 +199,6 @@ func (s *coreService) GetUserConfig(params core.ContextParams, pathParams, query
 		sort = common.CreateTimeField
 	}
 
-	condition[common.BKAppIDField] = appID
 	condition = util.SetModOwner(condition, params.SupplierAccount)
 	count, err := s.db.Table(common.BKTableNameUserAPI).Find(condition).Count(params.Context)
 	if err != nil {

--- a/src/test/topo_server/object_test.go
+++ b/src/test/topo_server/object_test.go
@@ -9,7 +9,7 @@ import (
 	"configcenter/src/common/mapstr"
 	"configcenter/src/common/metadata"
 	params "configcenter/src/common/paraparse"
-	"configcenter/src/common/util"
+	commonutil "configcenter/src/common/util"
 	"configcenter/src/test"
 	"configcenter/src/test/util"
 
@@ -1204,7 +1204,7 @@ var _ = Describe("object test", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rsp.Result).To(Equal(true))
 			Expect(rsp.Data["bk_set_name"].(string)).To(Equal("cc_set"))
-			Expect(util.GetStrByInterface(rsp.Data["bk_parent_id"])).To(Equal(strconv.FormatInt(childInstIdInt, 10)))
+			Expect(commonutil.GetStrByInterface(rsp.Data["bk_parent_id"])).To(Equal(strconv.FormatInt(childInstIdInt, 10)))
 			Expect(int64(rsp.Data["bk_biz_id"].(float64))).To(Equal(bizIdInt))
 			setId = strconv.FormatInt(int64(rsp.Data["bk_set_id"].(float64)), 10)
 		})
@@ -1223,7 +1223,7 @@ var _ = Describe("object test", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rsp.Result).To(Equal(true))
 			Expect(rsp.Data["bk_set_name"].(string)).To(Equal("test"))
-			Expect(util.GetStrByInterface(rsp.Data["bk_parent_id"])).To(Equal(strconv.FormatInt(childInstIdInt, 10)))
+			Expect(commonutil.GetStrByInterface(rsp.Data["bk_parent_id"])).To(Equal(strconv.FormatInt(childInstIdInt, 10)))
 			Expect(int64(rsp.Data["bk_biz_id"].(float64))).To(Equal(bizIdInt))
 			setId1 = strconv.FormatInt(int64(rsp.Data["bk_set_id"].(float64)), 10)
 		})
@@ -1389,7 +1389,7 @@ var _ = Describe("object test", func() {
 			Expect(map[string]interface{}(rsp.Data.Info[rsp.Data.Count-1])).To(HaveKeyWithValue("bk_set_name", "new_test"))
 			Expect(map[string]interface{}(rsp.Data.Info[rsp.Data.Count-1])).To(HaveKeyWithValue("bk_service_status", "1"))
 			Expect(map[string]interface{}(rsp.Data.Info[rsp.Data.Count-1])).To(HaveKeyWithValue("bk_set_env", "2"))
-			Expect(util.GetStrByInterface(rsp.Data.Info[rsp.Data.Count-1]["bk_parent_id"])).To(Equal(strconv.FormatInt(childInstIdInt, 10)))
+			Expect(commonutil.GetStrByInterface(rsp.Data.Info[rsp.Data.Count-1]["bk_parent_id"])).To(Equal(strconv.FormatInt(childInstIdInt, 10)))
 			Expect(int64(rsp.Data.Info[rsp.Data.Count-1]["bk_biz_id"].(float64))).To(Equal(bizIdInt))
 		})
 	})
@@ -1410,7 +1410,7 @@ var _ = Describe("object test", func() {
 			Expect(rsp.Result).To(Equal(true))
 			Expect(rsp.Data["bk_module_name"].(string)).To(Equal("cc_module"))
 			Expect(strconv.FormatInt(int64(rsp.Data["bk_set_id"].(float64)), 10)).To(Equal(setId))
-			Expect(util.GetStrByInterface(rsp.Data["bk_parent_id"])).To(Equal(setId))
+			Expect(commonutil.GetStrByInterface(rsp.Data["bk_parent_id"])).To(Equal(setId))
 			moduleId = strconv.FormatInt(int64(rsp.Data["bk_module_id"].(float64)), 10)
 		})
 
@@ -1427,7 +1427,7 @@ var _ = Describe("object test", func() {
 			Expect(rsp.Result).To(Equal(true))
 			Expect(rsp.Data["bk_module_name"].(string)).To(Equal("test_module"))
 			Expect(strconv.FormatInt(int64(rsp.Data["bk_set_id"].(float64)), 10)).To(Equal(setId))
-			Expect(util.GetStrByInterface(rsp.Data["bk_parent_id"])).To(Equal(setId))
+			Expect(commonutil.GetStrByInterface(rsp.Data["bk_parent_id"])).To(Equal(setId))
 			moduleId1 = strconv.FormatInt(int64(rsp.Data["bk_module_id"].(float64)), 10)
 		})
 
@@ -1594,7 +1594,7 @@ var _ = Describe("object test", func() {
 			Expect(rsp.Data.Count).To(Equal(1))
 			Expect(map[string]interface{}(rsp.Data.Info[0])).To(HaveKeyWithValue("bk_module_name", "new_module"))
 			Expect(strconv.FormatInt(int64(rsp.Data.Info[0]["bk_set_id"].(float64)), 10)).To(Equal(setId))
-			Expect(util.GetStrByInterface(rsp.Data.Info[0]["bk_parent_id"])).To(Equal(setId))
+			Expect(commonutil.GetStrByInterface(rsp.Data.Info[0]["bk_parent_id"])).To(Equal(setId))
 		})
 	})
 })


### PR DESCRIPTION
### 修复的问题：
- GetInstTableName转换表名中使用表名作为object ID
- 场景层使用读实例接口读非实例数据

close #3559