### PR TITLE
修复测试用例错误时提示信息位置错误和实例查询鉴权未关联实例ID的问题

### DIFF
--- a/src/test/util/fail.go
+++ b/src/test/util/fail.go
@@ -33,5 +33,9 @@ func Fail(message string, callerSkip ...int) {
 		j, _ := json.MarshalIndent(response, "", "\t")
 		msg = fmt.Sprintf("Test failed, message:\n%v\n\nresponse:\n%s", message, j)
 	}
-	ginkgo.Fail(msg, callerSkip ...)
+	skip := 0
+	if len(callerSkip) > 0 {
+		skip = callerSkip[0] + 1
+	}
+	ginkgo.Fail(msg, skip)
 }


### PR DESCRIPTION
### 修复的问题：
- 测试用例错误时提示信息位置错误
- 实例查询鉴权未关联实例ID
