### PR TITLE
模型实例关联权限bugfix

### DIFF
--- a/src/apiserver/service/filter.go
+++ b/src/apiserver/service/filter.go
@@ -208,7 +208,7 @@ func (s *service) authFilter(errFunc func() errors.CCErrorIf) func(req *restful.
 			}
 			blog.Warnf("authFilter failed, url: %s, reason: %+v, permissions: %+v, rid: %s", path, decision, permissions, rid)
 			rsp := metadata.BaseResp{
-				Code:        9900403,
+				Code:        common.CCNoPermission,
 				ErrMsg:      errFunc().CreateDefaultCCErrorIf(language).Error(common.CCErrCommAuthNotHavePermission).Error(),
 				Result:      false,
 				Permissions: permissions,

--- a/src/auth/authcenter/adaptor.go
+++ b/src/auth/authcenter/adaptor.go
@@ -428,7 +428,7 @@ func AdoptPermissions(h http.Header, api apimachinery.ClientSetInterface, rs []m
 		rsc.ResourceType = string(*rscType)
 		rsc.ResourceTypeName = ResourceTypeIDMap[*rscType]
 		if len(rscIDs) != 0 {
-			rsc.ResourceID = rscIDs[0].ResourceID
+			rsc.ResourceID = rscIDs[len(rscIDs)-1].ResourceID
 		}
 		rsc.ResourceName = r.Basic.Name
 		p.Resources = [][]metadata.Resource{{rsc}}

--- a/src/auth/parser/topolatest.go
+++ b/src/auth/parser/topolatest.go
@@ -500,10 +500,16 @@ func (ps *parseStream) objectInstanceAssociationLatest() *parseStream {
 
 		// 处理模型自关联的情况
 		if len(models) == 1 {
+			instanceType, err := ps.getInstanceTypeByObject(models[0].ObjectID)
+			if err != nil {
+				ps.err = err
+				return ps
+			}
+
 			ps.Attribute.Resources = []meta.ResourceAttribute{
 				{
 					Basic: meta.Basic{
-						Type:       meta.ModelInstance,
+						Type:       instanceType,
 						Action:     meta.Update,
 						InstanceID: gjson.GetBytes(ps.RequestCtx.Body, common.BKInstIDField).Int(),
 					},
@@ -512,7 +518,7 @@ func (ps *parseStream) objectInstanceAssociationLatest() *parseStream {
 				},
 				{
 					Basic: meta.Basic{
-						Type:       meta.ModelInstance,
+						Type:       instanceType,
 						Action:     meta.Update,
 						InstanceID: gjson.GetBytes(ps.RequestCtx.Body, common.BKAsstInstIDField).Int(),
 					},
@@ -530,11 +536,16 @@ func (ps *parseStream) objectInstanceAssociationLatest() *parseStream {
 			} else {
 				instID = gjson.GetBytes(ps.RequestCtx.Body, common.BKAsstInstIDField).Int()
 			}
+			instanceType, err := ps.getInstanceTypeByObject(model.ObjectID)
+			if err != nil {
+				ps.err = err
+				return ps
+			}
 
 			ps.Attribute.Resources = append(ps.Attribute.Resources,
 				meta.ResourceAttribute{
 					Basic: meta.Basic{
-						Type:       meta.ModelInstance,
+						Type:       instanceType,
 						Action:     meta.Update,
 						InstanceID: instID,
 					},
@@ -574,10 +585,16 @@ func (ps *parseStream) objectInstanceAssociationLatest() *parseStream {
 
 		// 处理模型自关联的情况
 		if len(models) == 1 {
+			instanceType, err := ps.getInstanceTypeByObject(models[0].ObjectID)
+			if err != nil {
+				ps.err = err
+				return ps
+			}
+
 			ps.Attribute.Resources = []meta.ResourceAttribute{
 				{
 					Basic: meta.Basic{
-						Type:       meta.ModelInstance,
+						Type:       instanceType,
 						Action:     meta.Update,
 						InstanceID: asst.InstID,
 					},
@@ -586,7 +603,7 @@ func (ps *parseStream) objectInstanceAssociationLatest() *parseStream {
 				},
 				{
 					Basic: meta.Basic{
-						Type:       meta.ModelInstance,
+						Type:       instanceType,
 						Action:     meta.Update,
 						InstanceID: asst.AsstInstID,
 					},
@@ -604,11 +621,16 @@ func (ps *parseStream) objectInstanceAssociationLatest() *parseStream {
 			} else {
 				instID = asst.AsstInstID
 			}
+			instanceType, err := ps.getInstanceTypeByObject(model.ObjectID)
+			if err != nil {
+				ps.err = err
+				return ps
+			}
 
 			ps.Attribute.Resources = append(ps.Attribute.Resources,
 				meta.ResourceAttribute{
 					Basic: meta.Basic{
-						Type:       meta.ModelInstance,
+						Type:       instanceType,
 						Action:     meta.Update,
 						InstanceID: instID,
 					},

--- a/src/auth/parser/util.go
+++ b/src/auth/parser/util.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 
+	"configcenter/src/auth/meta"
 	"configcenter/src/common"
 	"configcenter/src/common/errors"
 	"configcenter/src/common/mapstr"
@@ -142,4 +143,29 @@ func (ps *parseStream) getInstAssociation(cond mapstr.MapStr) (metadata.InstAsst
 	}
 
 	return asst.Data.Info[0], nil
+}
+
+func (ps *parseStream) getInstanceTypeByObject(objID string) (meta.ResourceType, error) {
+	switch objID {
+	case common.BKInnerObjIDPlat:
+		return meta.Plat, nil
+	case common.BKInnerObjIDHost:
+		return meta.HostInstance, nil
+	case common.BKInnerObjIDModule:
+		return meta.ModelModule, nil
+	case common.BKInnerObjIDSet:
+		return meta.ModelSet, nil
+	case common.BKInnerObjIDApp:
+		return meta.Business, nil
+	case common.BKInnerObjIDProc:
+		return meta.Process, nil
+	}
+	isMainline, err := ps.isMainlineModel(objID)
+	if err != nil {
+		return "", err
+	}
+	if isMainline {
+		return meta.MainlineInstance, nil
+	}
+	return meta.ModelInstance, nil
 }


### PR DESCRIPTION
### 修复的问题：
- 无权限提示信息resourceID错误
- 模型实例关联权限对特殊模型的实例鉴权类型错误
