### PR TITLE
业务搜索增加除角色属性以外的字段模糊匹配查询

### DIFF
--- a/src/scene_server/topo_server/service/inst_business.go
+++ b/src/scene_server/topo_server/service/inst_business.go
@@ -291,12 +291,14 @@ func handleSpecialBusinessFieldSearchCond(input map[string]interface{}, userFiel
 				d[common.BKDBLIKE] = strings.Replace(exactUserRegexp, "USER_PLACEHOLDER", userName, -1)
 				output[i] = d
 			} else {
-				output[i] = targetStr
+				attrVal := gparams.SpecialCharChange(targetStr)
+				output[i] = map[string]interface{}{"$regex": attrVal, "$options": "i"}
 			}
 		default:
 			output[i] = j
 		}
 	}
+
 	return output
 }
 


### PR DESCRIPTION
### 修复的问题：
- 业务搜索不能模糊匹配业务名 issue #3613
