### PR TITLE
允许前端页面修改蓝鲸业务

### DIFF
--- a/src/apimachinery/coreservice/coreservice.go
+++ b/src/apimachinery/coreservice/coreservice.go
@@ -25,6 +25,7 @@ import (
 	"configcenter/src/apimachinery/coreservice/model"
 	"configcenter/src/apimachinery/coreservice/process"
 	"configcenter/src/apimachinery/coreservice/synchronize"
+	ccSystem "configcenter/src/apimachinery/coreservice/system"
 	"configcenter/src/apimachinery/coreservice/topographics"
 	"configcenter/src/apimachinery/rest"
 	"configcenter/src/apimachinery/util"
@@ -42,6 +43,7 @@ type CoreServiceClientInterface interface {
 	Cloud() cloudsync.CloudSyncClientInterface
 	Label() label.LabelInterface
 	TopoGraphics() topographics.TopoGraphicsInterface
+	System() ccSystem.SystemClientInterface
 }
 
 func NewCoreServiceClient(c *util.Capability, version string) CoreServiceClientInterface {
@@ -97,4 +99,8 @@ func (c *coreService) Label() label.LabelInterface {
 
 func (c *coreService) TopoGraphics() topographics.TopoGraphicsInterface {
 	return topographics.NewTopoGraphicsInterface(c.restCli)
+}
+
+func (c *coreService) System() ccSystem.SystemClientInterface {
+	return ccSystem.NewSystemClientInterface(c.restCli)
 }

--- a/src/apimachinery/coreservice/system/api.go
+++ b/src/apimachinery/coreservice/system/api.go
@@ -1,0 +1,48 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package auditlog
+
+import (
+	"context"
+	"net/http"
+
+	"configcenter/src/common/blog"
+	"configcenter/src/common/errors"
+	"configcenter/src/common/metadata"
+	"configcenter/src/common/util"
+)
+
+func (s *system) GetUserConfig(ctx context.Context, h http.Header) (*metadata.ResponseSysUserConfigData, errors.CCErrorCoder) {
+	rid := util.ExtractRequestIDFromContext(ctx)
+
+	resp := new(metadata.ReponseSysUserConfig)
+
+	subPath := "/find/system/user_config"
+
+	httpDoErr := s.client.Post().
+		WithContext(ctx).
+		Body(nil).
+		SubResource(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+	if httpDoErr != nil {
+		blog.Errorf("AddLabel failed, http request failed, err: %+v, rid: %s", httpDoErr, rid)
+		return nil, errors.CCHttpError
+	}
+	if resp.Result == false || resp.Code != 0 {
+		return nil, errors.New(resp.Code, resp.ErrMsg)
+	}
+
+	return &resp.Data, nil
+}

--- a/src/apimachinery/coreservice/system/system.go
+++ b/src/apimachinery/coreservice/system/system.go
@@ -1,0 +1,34 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package auditlog
+
+import (
+	"context"
+	"net/http"
+
+	"configcenter/src/apimachinery/rest"
+	"configcenter/src/common/errors"
+	"configcenter/src/common/metadata"
+)
+
+type SystemClientInterface interface {
+	GetUserConfig(ctx context.Context, h http.Header) (*metadata.ResponseSysUserConfigData, errors.CCErrorCoder)
+}
+
+func NewSystemClientInterface(client rest.ClientInterface) SystemClientInterface {
+	return &system{client: client}
+}
+
+type system struct {
+	client rest.ClientInterface
+}

--- a/src/apiserver/service/url.go
+++ b/src/apiserver/service/url.go
@@ -208,6 +208,8 @@ func (u *URLPath) WithHost(req *restful.Request) (isHit bool) {
 	case hostURLRegexp.MatchString(string(*u)):
 		from, to, isHit = rootPath, hostRoot, true
 
+	case strings.HasPrefix(string(*u), rootPath+"/system/config"):
+		from, to, isHit = rootPath, hostRoot, true
 	default:
 		isHit = false
 	}

--- a/src/auth/authcenter/permit/permit.go
+++ b/src/auth/authcenter/permit/permit.go
@@ -97,8 +97,12 @@ func ShouldSkipAuthorize(rsc *meta.ResourceAttribute) bool {
 		return true
 	case rsc.Type == meta.InstallBK:
 		return true
+<<<<<<< HEAD
 	// all the model instances' read operation is authorized for now
 	case rsc.Type == meta.ModelInstance && IsReadAction(rsc.Action):
+=======
+	case rsc.Type == meta.SystemConfig:
+>>>>>>> feature: add change blueking bussiness flag issue #3633
 		return true
 	default:
 		return false

--- a/src/auth/authcenter/permit/permit.go
+++ b/src/auth/authcenter/permit/permit.go
@@ -97,12 +97,10 @@ func ShouldSkipAuthorize(rsc *meta.ResourceAttribute) bool {
 		return true
 	case rsc.Type == meta.InstallBK:
 		return true
-<<<<<<< HEAD
 	// all the model instances' read operation is authorized for now
 	case rsc.Type == meta.ModelInstance && IsReadAction(rsc.Action):
-=======
+		return true
 	case rsc.Type == meta.SystemConfig:
->>>>>>> feature: add change blueking bussiness flag issue #3633
 		return true
 	default:
 		return false

--- a/src/auth/meta/resource.go
+++ b/src/auth/meta/resource.go
@@ -60,6 +60,7 @@ const (
 	UserCustom               ResourceType = "usercustom"   // 用户自定义
 	SystemBase               ResourceType = "systemBase"
 	InstallBK                ResourceType = "installBK"
+	SystemConfig             ResourceType = "systemConfig" // syste config
 )
 
 const (

--- a/src/auth/parser/host.go
+++ b/src/auth/parser/host.go
@@ -282,6 +282,9 @@ const (
 
 	// 特殊接口，给蓝鲸业务使用
 	hostInstallPattern = "/api/v3/host/install/bk"
+
+	// cc system user config
+	systemUserConfig = "/api/v3/system/config/user_config/blueking_modify"
 )
 
 var (
@@ -707,6 +710,18 @@ func (ps *parseStream) host() *parseStream {
 				Basic: meta.Basic{
 					Type:   meta.InstallBK,
 					Action: meta.Update,
+				},
+			},
+		}
+		return ps
+	}
+
+	if ps.hitPattern(systemUserConfig, http.MethodPost) {
+		ps.Attribute.Resources = []meta.ResourceAttribute{
+			{
+				Basic: meta.Basic{
+					Type:   meta.SystemConfig,
+					Action: meta.FindMany,
 				},
 			},
 		}

--- a/src/common/metadata/adminserver.go
+++ b/src/common/metadata/adminserver.go
@@ -1,0 +1,31 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metadata
+
+// SysUserConfigItem 用户在cc_System表中的用户自定义配置
+type SysUserConfigItem struct {
+	Flag     bool  `json:"flag" bson:"flag"`
+	ExpireAt int64 `json:"expire_at" bson:"expire_at"`
+}
+
+type ResponseSysUserConfigData struct {
+	RowType        string            `json:"type"`
+	BluekingModify SysUserConfigItem `json:"blueking_modify"`
+}
+
+type ReponseSysUserConfig struct {
+	BaseResp `json:",inline"`
+	Data     ResponseSysUserConfigData `json:"data"`
+}
+
+const CCSystemUserConfigSwitch = "user_config_switch"

--- a/src/common/paraparse/app.go
+++ b/src/common/paraparse/app.go
@@ -14,7 +14,6 @@ package params
 
 import (
 	"fmt"
-	"reflect"
 	"regexp"
 	"strings"
 
@@ -43,11 +42,12 @@ func ParseCommonParams(input []metadata.ConditionItem, output map[string]interfa
 	for _, i := range input {
 		switch i.Operator {
 		case common.BKDBEQ:
-			if reflect.TypeOf(i.Value).Kind() == reflect.String {
+			output[i.Field] = i.Value
+			/*if reflect.TypeOf(i.Value).Kind() == reflect.String {
 				output[i.Field] = SpecialCharChange(i.Value.(string))
 			} else {
-				output[i.Field] = i.Value
-			}
+			output[i.Field] = i.Value
+			}*/
 		case common.BKDBLIKE:
 			regex := make(map[string]interface{})
 			regex[common.BKDBLIKE] = i.Value
@@ -75,8 +75,8 @@ func ParseCommonParams(input []metadata.ConditionItem, output map[string]interfa
 			d := make(map[string]interface{})
 			if i.Value == nil {
 				d[i.Operator] = i.Value
-			} else if reflect.TypeOf(i.Value).Kind() == reflect.String {
-				d[i.Operator] = SpecialCharChange(i.Value.(string))
+				/*} else if reflect.TypeOf(i.Value).Kind() == reflect.String {
+				d[i.Operator] = SpecialCharChange(i.Value.(string))*/
 			} else {
 				d[i.Operator] = i.Value
 			}
@@ -88,7 +88,7 @@ func ParseCommonParams(input []metadata.ConditionItem, output map[string]interfa
 
 func SpecialCharChange(targetStr string) string {
 
-	re := regexp.MustCompile("[.()\\\\|\\[\\]\\-\\*{}\\^\\$\\?]")
+	re := regexp.MustCompile("[.()\\\\|\\[\\]\\*{}\\^\\$\\?]")
 	delItems := re.FindAllString(targetStr, -1)
 	tmp := map[string]struct{}{}
 	for _, target := range delItems {

--- a/src/scene_server/admin_server/service/flag.go
+++ b/src/scene_server/admin_server/service/flag.go
@@ -14,13 +14,25 @@ package service
 
 import (
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/emicklei/go-restful"
 
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
+	"configcenter/src/common/errors"
 	"configcenter/src/common/metadata"
 	"configcenter/src/common/util"
+)
+
+var (
+	// 允许用户设置的key
+	userConfigKeyMap = map[string]bool{
+		"blueking_modify": true,
+	}
+	// 过期时间
+	userConfigDefaultExpireHour = 6
 )
 
 // SetSystemConfiguration used for set variable in cc_System table
@@ -48,4 +60,57 @@ func (s *Service) SetSystemConfiguration(req *restful.Request, resp *restful.Res
 		return
 	}
 	resp.WriteEntity(metadata.NewSuccessResp("modify system config success"))
+}
+
+func (s *Service) UserConfigSwitch(req *restful.Request, resp *restful.Response) {
+	rid, _, defErr := s.getCommObject(req.Request.Header)
+
+	canModify := strings.ToLower(req.PathParameter("can"))
+	key := req.PathParameter("key")
+	blCanModify := false
+
+	if _, ok := userConfigKeyMap[key]; !ok {
+		result := &metadata.RespError{
+			Msg: defErr.Errorf(common.CCErrCommParamsIsInvalid, key),
+		}
+		resp.WriteError(http.StatusBadRequest, result)
+		return
+	}
+	switch canModify {
+	case "true":
+		blCanModify = true
+	case "false":
+		blCanModify = false
+	default:
+		result := &metadata.RespError{
+			Msg: defErr.Errorf(common.CCErrCommParamsNeedBool, "can"),
+		}
+		resp.WriteError(http.StatusBadRequest, result)
+		return
+	}
+	cond := map[string]interface{}{
+		"type": metadata.CCSystemUserConfigSwitch,
+	}
+	data := map[string]metadata.SysUserConfigItem{
+		key: metadata.SysUserConfigItem{
+			Flag:     blCanModify,
+			ExpireAt: time.Now().Unix() + int64(userConfigDefaultExpireHour*3600),
+		},
+	}
+
+	err := s.db.Table(common.BKTableNameSystem).Upsert(s.ctx, cond, data)
+	if err != nil {
+		blog.ErrorJSON("UserConfigSwitch set key %s value %s error. err:%s, rid:%s", key, canModify, rid)
+		resp.WriteError(http.StatusBadGateway, defErr.Error(common.CCErrCommDBUpdateFailed))
+		return
+	}
+	resp.WriteEntity(metadata.NewSuccessResp("modify system user config success"))
+
+}
+
+func (s *Service) getCommObject(header http.Header) (ownerID, rid string, defErr errors.DefaultCCErrorIf) {
+	rid = util.GetHTTPCCRequestID(header)
+	defErr = s.CCErr.CreateDefaultCCErrorIf(util.GetLanguage(header))
+	ownerID = common.BKDefaultOwnerID
+	return
 }

--- a/src/scene_server/admin_server/service/service.go
+++ b/src/scene_server/admin_server/service/service.go
@@ -71,6 +71,7 @@ func (s *Service) WebService() *restful.Container {
 	api.Route(api.POST("/authcenter/init").To(s.InitAuthCenter))
 	api.Route(api.POST("/migrate/{distribution}/{ownerID}").To(s.migrate))
 	api.Route(api.POST("/migrate/system/hostcrossbiz/{ownerID}").To(s.SetSystemConfiguration))
+	api.Route(api.POST("/migrate/system/user_config/{key}/{can}").To(s.UserConfigSwitch))
 	api.Route(api.POST("/clear").To(s.clear))
 	api.Route(api.GET("/healthz").To(s.Healthz))
 

--- a/src/scene_server/host_server/logics/module.go
+++ b/src/scene_server/host_server/logics/module.go
@@ -79,7 +79,8 @@ func (lgc *Logics) GetNormalModuleByModuleID(ctx context.Context, appID, moduleI
 func (lgc *Logics) GetModuleIDByCond(ctx context.Context, cond []metadata.ConditionItem) ([]int64, errors.CCError) {
 	condc := make(map[string]interface{})
 	if err := parse.ParseCommonParams(cond, condc); err != nil {
-		blog.Warnf("ParseCommonParams failed, err: %+v, rid: %s", err, lgc.rid)
+		blog.Errorf("ParseCommonParams failed, err: %+v, rid: %s", err, lgc.rid)
+		return nil, lgc.ccErr.Errorf(common.CCErrCommUtilHandleFail, "parse condition", err.Error())
 	}
 
 	query := &metadata.QueryCondition{

--- a/src/scene_server/host_server/logics/special.go
+++ b/src/scene_server/host_server/logics/special.go
@@ -51,6 +51,9 @@ func (lgc *Logics) NewSpecial() SpecialHandle {
 // 4. 进程不存在不报错
 func (s *special) BkSystemInstall(ctx context.Context, appName string, input *metadata.BkSystemInstallRequest) errors.CCError {
 
+	if input.HostInfo == nil {
+		input.HostInfo = make(map[string]interface{}, 0)
+	}
 	// handle host info
 	input.HostInfo[common.BKHostInnerIPField] = input.InnerIP
 	input.HostInfo[common.BKCloudIDField] = input.CloudID
@@ -236,6 +239,9 @@ func (s *special) bkSystemGetInstallModuleID(ctx context.Context, appID int64, s
 	if err != nil {
 		blog.ErrorJSON("bkSystemGetInstallModuleID GetModuleIDByCond error. err:%s, cond:%s, rid:%s", err.Error(), bkModuleCond, s.lgc.rid)
 		return nil, err
+	}
+	if len(moduleIDArr) == 0 {
+		blog.Warnf("bkSystemGetInstallModuleID GetModuleIDByCond not found set. cond:%v, rid:%s", bkModuleCond, s.lgc.rid)
 	}
 	return moduleIDArr, nil
 }

--- a/src/scene_server/host_server/service/service.go
+++ b/src/scene_server/host_server/service/service.go
@@ -162,6 +162,8 @@ func (s *Service) WebService() *restful.Container {
 	// first install use api
 	api.Route(api.POST("/host/install/bk").To(s.BKSystemInstall))
 
+	api.Route(api.POST("/system/config/user_config/blueking_modify").To(s.FindSystemUserConfigBKSwitch))
+
 	container.Add(api)
 
 	healthzAPI := new(restful.WebService).Produces(restful.MIME_JSON)

--- a/src/scene_server/host_server/service/special.go
+++ b/src/scene_server/host_server/service/special.go
@@ -15,6 +15,7 @@ package service
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
@@ -58,8 +59,8 @@ func (s *Service) BKSystemInstall(req *restful.Request, resp *restful.Response) 
 
 	err := srvData.lgc.NewSpecial().BkSystemInstall(srvData.ctx, common.BKAppName, input)
 	if err != nil {
-		blog.Errorf("BkSystemInstall decode handle err: %v, rid:%s", err, srvData.rid)
-		_ = resp.WriteError(http.StatusBadRequest, &meta.RespError{Msg: err})
+		blog.Errorf("BkSystemInstall handle err: %v, rid:%s", err, srvData.rid)
+		_ = resp.WriteError(http.StatusInternalServerError, &meta.RespError{Msg: err})
 		return
 	}
 
@@ -67,4 +68,29 @@ func (s *Service) BKSystemInstall(req *restful.Request, resp *restful.Response) 
 		BaseResp: meta.SuccessBaseResp,
 		Data:     "",
 	})
+}
+
+func (s *Service) FindSystemUserConfigBKSwitch(req *restful.Request, resp *restful.Response) {
+
+	srvData := s.newSrvComm(req.Request.Header)
+
+	// 没有权限校验
+	data, err := srvData.lgc.CoreAPI.CoreService().System().GetUserConfig(srvData.ctx, srvData.header)
+	if err != nil {
+		blog.Errorf("FindSystemUserConfig handle err: %v, rid:%s", err, srvData.rid)
+		_ = resp.WriteError(http.StatusInternalServerError, &meta.RespError{Msg: err})
+		return
+	}
+	canModify := false
+	if data != nil {
+		if data.BluekingModify.Flag == true && data.BluekingModify.ExpireAt > time.Now().Unix() {
+			canModify = true
+		}
+	}
+
+	resp.WriteEntity(meta.Response{
+		BaseResp: meta.SuccessBaseResp,
+		Data:     canModify,
+	})
+
 }

--- a/src/source_controller/coreservice/core/core.go
+++ b/src/source_controller/coreservice/core/core.go
@@ -184,6 +184,7 @@ type Core interface {
 	AuditOperation() AuditOperation
 	ProcessOperation() ProcessOperation
 	LabelOperation() LabelOperation
+	SystemOperation() SystemOperation
 }
 
 // ProcessOperation methods
@@ -238,6 +239,10 @@ type LabelOperation interface {
 	RemoveLabel(ctx ContextParams, tableName string, option selector.LabelRemoveOption) errors.CCErrorCoder
 }
 
+type SystemOperation interface {
+	GetSystemUserConfig(ctx ContextParams) (map[string]interface{}, errors.CCErrorCoder)
+}
+
 type core struct {
 	model           ModelOperation
 	instance        InstanceOperation
@@ -248,12 +253,13 @@ type core struct {
 	audit           AuditOperation
 	process         ProcessOperation
 	label           LabelOperation
+	sys             SystemOperation
 }
 
 // New create core
 func New(model ModelOperation, instance InstanceOperation, association AssociationOperation,
 	dataSynchronize DataSynchronizeOperation, topo TopoOperation, host HostOperation,
-	audit AuditOperation, process ProcessOperation, label LabelOperation) Core {
+	audit AuditOperation, process ProcessOperation, label LabelOperation, sys SystemOperation) Core {
 	return &core{
 		model:           model,
 		instance:        instance,
@@ -264,6 +270,7 @@ func New(model ModelOperation, instance InstanceOperation, association Associati
 		audit:           audit,
 		process:         process,
 		label:           label,
+		sys:             sys,
 	}
 }
 
@@ -301,4 +308,8 @@ func (m *core) ProcessOperation() ProcessOperation {
 
 func (m *core) LabelOperation() LabelOperation {
 	return m.label
+}
+
+func (m *core) SystemOperation() SystemOperation {
+	return m.sys
 }

--- a/src/source_controller/coreservice/core/system/system.go
+++ b/src/source_controller/coreservice/core/system/system.go
@@ -1,0 +1,47 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.,
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the ",License",); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an ",AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system
+
+import (
+	"configcenter/src/common"
+	"configcenter/src/common/blog"
+	"configcenter/src/common/errors"
+	"configcenter/src/common/metadata"
+	"configcenter/src/source_controller/coreservice/core"
+	"configcenter/src/storage/dal"
+)
+
+var _ core.SystemOperation = (*systemManager)(nil)
+
+type systemManager struct {
+	dbProxy dal.RDB
+}
+
+// New create a new instance manager instance
+func New(dbProxy dal.RDB) core.SystemOperation {
+	return &systemManager{
+		dbProxy: dbProxy,
+	}
+}
+
+func (sm *systemManager) GetSystemUserConfig(ctx core.ContextParams) (map[string]interface{}, errors.CCErrorCoder) {
+	cond := map[string]string{"type": metadata.CCSystemUserConfigSwitch}
+	result := make(map[string]interface{}, 0)
+	err := sm.dbProxy.Table(common.BKTableNameSystem).Find(cond).One(ctx, &result)
+	if err != nil && !sm.dbProxy.IsNotFoundError(err) {
+		blog.ErrorJSON("GetSystemUserConfig find error. cond:%s, err:%s, rid:%s", cond, err.Error(), ctx.ReqID)
+		return nil, ctx.Error.CCError(common.CCErrCommDBSelectFailed)
+	}
+
+	return result, nil
+}

--- a/src/source_controller/coreservice/service/service.go
+++ b/src/source_controller/coreservice/service/service.go
@@ -42,6 +42,7 @@ import (
 	"configcenter/src/source_controller/coreservice/core/mainline"
 	"configcenter/src/source_controller/coreservice/core/model"
 	"configcenter/src/source_controller/coreservice/core/process"
+	dbSystem "configcenter/src/source_controller/coreservice/core/system"
 	"configcenter/src/storage/dal"
 	"configcenter/src/storage/dal/mongo/local"
 	"configcenter/src/storage/dal/mongo/remote"
@@ -119,6 +120,7 @@ func (s *coreService) SetConfig(cfg options.Config, engin *backbone.Engine, err 
 		auditlog.New(db),
 		process.New(db, s, cache),
 		label.New(db),
+		dbSystem.New(db),
 	)
 	return nil
 }

--- a/src/source_controller/coreservice/service/service_initfunc.go
+++ b/src/source_controller/coreservice/service/service_initfunc.go
@@ -180,6 +180,10 @@ func (s *coreService) topographics() {
 	s.addAction(http.MethodPost, "/topographics/update", s.UpdateTopoGraphics, nil)
 }
 
+func (s *coreService) ccSystem() {
+	s.addAction(http.MethodPost, "/find/system/user_config", s.GetSystemUserConfig, nil)
+}
+
 func (s *coreService) initService() {
 	s.initModelClassification()
 	s.initModel()
@@ -196,4 +200,5 @@ func (s *coreService) initService() {
 	s.initCloudSync()
 	s.label()
 	s.topographics()
+	s.ccSystem()
 }

--- a/src/source_controller/coreservice/service/system.go
+++ b/src/source_controller/coreservice/service/system.go
@@ -1,0 +1,22 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.,
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the ",License",); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an ",AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"configcenter/src/common/mapstr"
+	"configcenter/src/source_controller/coreservice/core"
+)
+
+func (s *coreService) GetSystemUserConfig(params core.ContextParams, pathParams, queryParams ParamsGetter, data mapstr.MapStr) (interface{}, error) {
+	return s.core.SystemOperation().GetSystemUserConfig(params)
+}


### PR DESCRIPTION
### 新加的功能:
-  删除查询的时候关于字符“-”的转移
- cmdb_adminserver 配置蓝鲸业务可编辑
- cmdb_hostserver 提供查询蓝鲸业务是否可编辑接口 
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
