### PR TITLE
cmdb_operation启动失败bugfix

### DIFF
--- a/src/scene_server/operation_server/app/options/options.go
+++ b/src/scene_server/operation_server/app/options/options.go
@@ -34,6 +34,16 @@ type Config struct {
 	Timer     string
 }
 
+func (c *Config) Ready() bool {
+	if c == nil {
+		return false
+	}
+	if len(c.Timer) == 0 {
+		return false
+	}
+	return true
+}
+
 func NewServerOption() *ServerOption {
 	s := ServerOption{
 		ServConf: config.NewCCAPIConfig(),

--- a/src/scene_server/operation_server/app/server.go
+++ b/src/scene_server/operation_server/app/server.go
@@ -50,15 +50,14 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	}
 	configReady := false
 	for sleepCnt := 0; sleepCnt < common.APPConfigWaitTime; sleepCnt++ {
-		if nil == operationSvr.Config {
-			time.Sleep(time.Second)
-		} else {
+		if operationSvr.Config.Ready() {
 			configReady = true
 			break
 		}
+		time.Sleep(time.Second)
 	}
 	if false == configReady {
-		return fmt.Errorf("configuration item not found")
+		return fmt.Errorf("waiting for configuration timeout, maybe parse configuration failed")
 	}
 	authConf := operationSvr.Config.Auth
 	if err != nil {

--- a/src/scene_server/operation_server/service/service.go
+++ b/src/scene_server/operation_server/service/service.go
@@ -172,7 +172,7 @@ func (o *OperationServer) OnOperationConfigUpdate(previous, current cc.ProcessCo
 
 	o.Config.Auth, err = authcenter.ParseConfigFromKV("auth", current.ConfigMap)
 	if err != nil {
-		blog.Warnf("parse auth center config failed: %v", err)
+		blog.Errorf("parse auth center config failed: %v", err)
 		return
 	}
 


### PR DESCRIPTION
### 修复的问题：
- cmdb_operation解析权限数据失败导致周期性任务无法执行