### PR TITLE
模型名其及字段名增加符合mongo表名及其字段名的限制

### DIFF
--- a/src/source_controller/coreservice/core/model/attribute_curd.go
+++ b/src/source_controller/coreservice/core/model/attribute_curd.go
@@ -144,18 +144,28 @@ func (m *modelAttribute) checkAttributeMustNotEmpty(ctx core.ContextParams, attr
 }
 
 func (m *modelAttribute) checkAttributeValidity(ctx core.ContextParams, attribute metadata.Attribute) error {
-	if common.AttributeIDMaxLength < utf8.RuneCountInString(attribute.PropertyID) {
-		return ctx.Error.Errorf(common.CCErrCommValExceedMaxFailed, ctx.Lang.Language("model_attr_bk_property_id"), common.AttributeIDMaxLength)
-	} else if attribute.PropertyID != "" {
+	if attribute.PropertyID != "" {
+		if common.AttributeIDMaxLength < utf8.RuneCountInString(attribute.PropertyID) {
+			return ctx.Error.Errorf(common.CCErrCommValExceedMaxFailed, ctx.Lang.Language("model_attr_bk_property_id"), common.AttributeIDMaxLength)
+		}
+
+		if !SatisfyMongoFieldLimit(attribute.PropertyID) {
+			blog.Errorf("attribute.PropertyID:%s not SatisfyMongoFieldLimit", attribute.PropertyID)
+			return ctx.Error.Errorf(common.CCErrCommParamsIsInvalid, metadata.AttributeFieldPropertyID)
+		}
+
 		match, err := regexp.MatchString(common.FieldTypeStrictCharRegexp, attribute.PropertyID)
 		if nil != err || !match {
 			return ctx.Error.Errorf(common.CCErrCommParamsIsInvalid, metadata.AttributeFieldPropertyID)
 		}
 	}
 
-	if common.AttributeNameMaxLength < utf8.RuneCountInString(attribute.PropertyName) {
-		return ctx.Error.Errorf(common.CCErrCommValExceedMaxFailed, ctx.Lang.Language("model_attr_bk_property_name"), common.AttributeNameMaxLength)
-	} else if attribute.PropertyName != "" {
+
+	if attribute.PropertyName != "" {
+		if common.AttributeNameMaxLength < utf8.RuneCountInString(attribute.PropertyName) {
+			return ctx.Error.Errorf(common.CCErrCommValExceedMaxFailed, ctx.Lang.Language("model_attr_bk_property_name"), common.AttributeNameMaxLength)
+		}
+
 		attribute.PropertyName = strings.TrimSpace(attribute.PropertyName)
 		match, err := regexp.MatchString(common.FieldTypeSingleCharRegexp, attribute.PropertyName)
 		if nil != err || !match {

--- a/src/source_controller/coreservice/core/model/model.go
+++ b/src/source_controller/coreservice/core/model/model.go
@@ -57,6 +57,11 @@ func (m *modelManager) CreateModel(ctx core.ContextParams, inputParam metadata.C
 		return dataResult, ctx.Error.Errorf(common.CCErrCommParamsNeedSet, metadata.ModelFieldObjectID)
 	}
 
+	if !SatisfyMongoCollLimit(inputParam.Spec.ObjectID) {
+		blog.Errorf("inputParam.Spec.ObjectID:%s not SatisfyMongoCollLimit", inputParam.Spec.ObjectID)
+		return dataResult, ctx.Error.Errorf(common.CCErrCommParamsIsInvalid, metadata.ModelFieldObjectID)
+	}
+
 	// check the input classification ID
 	isValid, err := m.modelClassification.isValid(ctx, inputParam.Spec.ObjCls)
 	if nil != err {

--- a/src/source_controller/coreservice/core/model/validator_util.go
+++ b/src/source_controller/coreservice/core/model/validator_util.go
@@ -1,0 +1,46 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.,
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the ",License",); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an ",AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model
+
+import (
+	"strings"
+)
+
+const (
+	mongoFieldNotAllowed string = "$."
+	// The maximum length of <database>.<collection>) is 120 bytes, so MongoCollMaxLength is 120-len("cmdb.")
+	mongoCollMaxLength int = 115
+)
+
+// 字符格式限制检查
+func satisfyCharLimit(name string) bool {
+	if strings.ContainsAny(name, mongoFieldNotAllowed) {
+		return false
+	}
+	return true
+}
+
+// 考虑到后续按模型拆分collection，需要限制模型名的字符格式，以满足mongo对collection名的限制要求
+// mongo collection名限制可见 https://docs.mongodb.com/manual/reference/limits/#Restriction-on-Collection-Names
+func SatisfyMongoCollLimit(collName string) bool {
+	if len(collName) > mongoCollMaxLength {
+		return false
+	}
+	return satisfyCharLimit(collName)
+}
+
+// 考虑到后续按模型拆分collection，需要限制模型属性名的字符格式，以满足mongo对字段名的限制要求
+// mongo field名限制可见 https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
+func SatisfyMongoFieldLimit(fieldName string) bool {
+	return satisfyCharLimit(fieldName)
+}


### PR DESCRIPTION
### 新加的功能:
- 考虑到后续按模型拆分collection，需要限制模型字段名的字符，以满足mongo对collection名和字段名的限制要求
issue #3698
