### PR TITLE
fix: 模型属性分组为none或“”时，migrate设置为default，更新模型属性不可更新分组

### DIFF
--- a/src/scene_server/admin_server/upgrader/y3.6.201912241627/sort_bk_property_index.go
+++ b/src/scene_server/admin_server/upgrader/y3.6.201912241627/sort_bk_property_index.go
@@ -57,6 +57,9 @@ func updateSortedPropertyIndex(ctx context.Context, db dal.RDB, conf *upgrader.C
 	for _, group := range attrGroups {
 		var index int64
 		for _, attr := range attributes {
+			if attr.PropertyGroup == "none" || attr.PropertyGroup == "" {
+				attr.PropertyGroup = common.BKDefaultField
+			}
 			if attr.PropertyGroup != group.GroupID {
 				continue
 			}

--- a/src/scene_server/topo_server/service/object_attribute.go
+++ b/src/scene_server/topo_server/service/object_attribute.go
@@ -91,8 +91,9 @@ func (s *Service) UpdateObjectAttribute(params types.ContextParams, pathParams, 
 	// TODO: why does remove this????
 	data.Remove(metadata.BKMetadata)
 
-	// UpdateObjectAttribute should not update bk_property_index
+	// UpdateObjectAttribute should not update bk_property_index、bk_property_group
 	data.Remove(common.BKPropertyIndexField)
+	data.Remove(common.BKPropertyGroupField)
 
 	err = s.Core.AttributeOperation().UpdateObjectAttribute(params, data, id)
 


### PR DESCRIPTION
### 修复的问题：
- #3656 

- fix: 模型属性分组为none或“”时，migrate设置为default，更新模型属性不可更新分组
