### PR TITLE
已赋值的实例日期和时间类型字段允许置空

### DIFF
--- a/src/common/metadata/attribute.go
+++ b/src/common/metadata/attribute.go
@@ -168,7 +168,7 @@ func (attribute *Attribute) Validate(ctx context.Context, data interface{}, key 
 func (attribute *Attribute) validTime(ctx context.Context, val interface{}, key string) (rawError errors.RawErrorInfo) {
 
 	rid := util.ExtractRequestIDFromContext(ctx)
-	if nil == val {
+	if nil == val || "" == val {
 		if attribute.IsRequired {
 			blog.Errorf("params can not be null, rid: %s", rid)
 			return errors.RawErrorInfo{
@@ -203,7 +203,7 @@ func (attribute *Attribute) validTime(ctx context.Context, val interface{}, key 
 // validDate valid object Attribute that is date type
 func (attribute *Attribute) validDate(ctx context.Context, val interface{}, key string) (rawError errors.RawErrorInfo) {
 	rid := util.ExtractRequestIDFromContext(ctx)
-	if nil == val {
+	if nil == val || "" == val {
 		if attribute.IsRequired {
 			blog.Errorf("params can not be null, rid: %s", rid)
 			return errors.RawErrorInfo{

--- a/src/source_controller/coreservice/core/instances/validator_attr.go
+++ b/src/source_controller/coreservice/core/instances/validator_attr.go
@@ -28,7 +28,7 @@ import (
 // validTime valid object Attribute that is time type
 func (valid *validator) validTime(ctx context.Context, val interface{}, key string) error {
 	rid := util.ExtractRequestIDFromContext(ctx)
-	if nil == val {
+	if nil == val || "" == val {
 		if valid.require[key] {
 			blog.Errorf("params can not be null, rid: %s", rid)
 			return valid.errif.Errorf(common.CCErrCommParamsNeedSet, key)
@@ -54,7 +54,7 @@ func (valid *validator) validTime(ctx context.Context, val interface{}, key stri
 // validDate valid object Attribute that is date type
 func (valid *validator) validDate(ctx context.Context, val interface{}, key string) error {
 	rid := util.ExtractRequestIDFromContext(ctx)
-	if nil == val {
+	if nil == val || "" == val {
 		if valid.require[key] {
 			blog.Errorf("params key: %s can not be null, rid: %s", key, rid)
 			return valid.errif.Errorf(common.CCErrCommParamsNeedSet, key)


### PR DESCRIPTION
### 修复的问题：
- 无法置空已赋值的实例日期和时间类型字段
