### PR TITLE
进程启动监听地址支持IPV6，zk注册发现地址支持域名

### DIFF
--- a/docs/overview/installation.md
+++ b/docs/overview/installation.md
@@ -276,6 +276,7 @@ drwxrwxr-x 3 1004 1004 4.0K Mar 29 14:45 cmdb_hostcontroller
 |--auth_app_code      | cmdb项目在蓝鲸权限中心的应用编码 | auth_enabled 为真时必填 | bk_cmdb |
 |--auth_app_secret    | cmdb项目在蓝鲸权限中心的应用密钥 | auth_enabled 为真时必填 | xxxxxxx |
 |--log_level          | 日志级别0-9, 9日志最详细 | 否 | 3  |
+|--register_ip        | 进程注册到zookeeper上的IP地址，可以是域名 |  否 | 无 |
 
 **注:init.py 执行成功后会自动生成cmdb各服务进程所需要的配置。**
 
@@ -303,7 +304,8 @@ python init.py  \
   --auth_app_secret    xxxxxxx \
   --full_text_search   off \
   --es_url             http://127.0.0.1:9200 \
-  --log_level          3
+  --log_level          3 \
+  --register_ip         cmdb.domain.com
 ```
 
 

--- a/scripts/init.py
+++ b/scripts/init.py
@@ -16,7 +16,7 @@ def generate_config_file(
         rd_server_v, db_name_v, redis_ip_v, redis_port_v,
         redis_pass_v, mongo_ip_v, mongo_port_v, mongo_user_v, mongo_pass_v,
         cc_url_v, paas_url_v, full_text_search, es_url_v, es_user_v, es_pass_v, auth_address, auth_app_code,
-        auth_app_secret, auth_enabled, auth_scheme, auth_sync_workers, auth_sync_interval_minutes, log_level
+        auth_app_secret, auth_enabled, auth_scheme, auth_sync_workers, auth_sync_interval_minutes, log_level, register_ip
 ):
     output = os.getcwd() + "/cmdb_adminserver/configures/"
     context = dict(
@@ -155,7 +155,6 @@ maxIDleConns = 1000
 address = $auth_address
 appCode = $auth_app_code
 appSecret = $auth_app_secret
-enable = $auth_enabled
 '''
     template = FileTemplate(host_file_template_str)
     result = template.substitute(**context)
@@ -268,6 +267,11 @@ enable = true
 
 [timer]
 spec = 00:30  # 00:00 - 23:59
+
+[auth]
+address = $auth_address
+appCode = $auth_app_code
+appSecret = $auth_app_secret
 '''
     template = FileTemplate(operation_file_template_str)
     result = template.substitute(**context)
@@ -388,7 +392,7 @@ maxIDleConns = 1000
     with open(output + "task.conf", 'w') as tmp_file:
         tmp_file.write(result)
 
-def update_start_script(rd_server, server_ports, enable_auth, log_level):
+def update_start_script(rd_server, server_ports, enable_auth, log_level, register_ip):
     list_dirs = os.walk(os.getcwd()+"/")
     for root, dirs, _ in list_dirs:
         for d in dirs:
@@ -416,8 +420,10 @@ def update_start_script(rd_server, server_ports, enable_auth, log_level):
                     filedata = filedata.replace('rd_server_placeholder', rd_server)
 
                 extend_flag = ''
-                if d in ['cmdb_apiserver', 'cmdb_hostserver', 'cmdb_datacollection', 'cmdb_procserver', 'cmdb_toposerver', 'cmdb_eventserver']:
+                if d in ['cmdb_apiserver', 'cmdb_hostserver', 'cmdb_datacollection', 'cmdb_procserver', 'cmdb_toposerver', 'cmdb_eventserver', 'cmdb_operationserver']:
                     extend_flag += ' --enable-auth=%s ' % enable_auth
+                if register_ip != '':
+                    extend_flag += ' --register-ip=%s ' % register_ip
                 filedata = filedata.replace('extend_flag_placeholder', extend_flag)
 
                 filedata = filedata.replace('log_level_placeholder', log_level)
@@ -454,6 +460,7 @@ def main(argv):
     es_user = ''
     es_pass = ''
     log_level = '3'
+    register_ip = ''
 
     server_ports = {
         "cmdb_adminserver": 60004,
@@ -476,7 +483,7 @@ def main(argv):
         "mongo_user=", "mongo_pass=", "blueking_cmdb_url=",
         "blueking_paas_url=", "listen_port=", "es_url=", "es_user=", "es_pass=", "auth_address=",
         "auth_app_code=", "auth_app_secret=", "auth_enabled=",
-        "auth_scheme=", "auth_sync_workers=", "auth_sync_interval_minutes=", "full_text_search=", "log_level="
+        "auth_scheme=", "auth_sync_workers=", "auth_sync_interval_minutes=", "full_text_search=", "log_level=", "register_ip="
     ]
     usage = '''
     usage:
@@ -502,6 +509,7 @@ def main(argv):
       --es_user            <es_user>              the es user name
       --es_pass            <es_pass>              the es password
       --log_level          <log_level>            log level to start cmdb process, default: 3
+      --register_ip        <register_ip>          the ip address registered on zookeeper, it can be domain
 
 
     demo:
@@ -529,7 +537,8 @@ def main(argv):
       --es_url             http://127.0.0.1:9200 \\
       --es_user            cc \\
       --es_pass            cc \\
-      --log_level          3
+      --log_level          3 \\
+      --register_ip        cmdb.domain.com
     '''
     try:
         opts, _ = getopt.getopt(argv, "hd:D:r:p:x:s:m:P:X:S:u:U:a:l:es:v", arr)
@@ -619,6 +628,9 @@ def main(argv):
         elif opt in("-v","--log_level",):
             log_level = arg
             print('log_level:', log_level)
+        elif opt in("--register_ip",):
+            register_ip = arg
+            print('register_ip:', register_ip)
 
     if 0 == len(rd_server):
         print('please input the ZooKeeper address, eg:127.0.0.1:2181')
@@ -708,9 +720,10 @@ def main(argv):
         es_user_v=es_user,
         es_pass_v=es_pass,
         log_level=log_level,
+        register_ip=register_ip,
         **auth
     )
-    update_start_script(rd_server, server_ports, auth['auth_enabled'], log_level)
+    update_start_script(rd_server, server_ports, auth['auth_enabled'], log_level, register_ip)
     print('initial configurations success, configs could be found at cmdb_adminserver/configures')
 
 

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -4,6 +4,15 @@ set -e
 
 # get local IP.
 localIp=`python ip.py`
-curl -X POST -H 'Content-Type:application/json' -H 'BK_USER:migrate' -H 'HTTP_BLUEKING_SUPPLIER_ID:0' http://${localIp}:admin_port_placeholer/migrate/v3/migrate/community/0
+
+# 判断是否为IPV6，是则在地址两端加中括号
+result=$(echo ${localIp} | grep ":")
+if [[ "$result" != "" ]]
+then
+  localIp="[${localIp}]"
+fi
+echo "localIp:${localIp}"
+
+curl -X POST -H 'Content-Type:application/json' -H 'BK_USER:migrate' -H 'HTTP_BLUEKING_SUPPLIER_ID:0' http://${localIp}:60004/migrate/v3/migrate/community/0
 
 echo ""

--- a/src/apimachinery/discovery/discovery.go
+++ b/src/apimachinery/discovery/discovery.go
@@ -140,5 +140,5 @@ func (d *discover) TaskServer() Interface {
 
 // IsMaster check whether current is master
 func (d *discover) IsMaster() bool {
-	return d.servers[common.GetIdentification()].IsMaster(common.GetServerInfo().Address())
+	return d.servers[common.GetIdentification()].IsMaster(common.GetServerInfo().RegisterAddress())
 }

--- a/src/apimachinery/discovery/server.go
+++ b/src/apimachinery/discovery/server.go
@@ -131,12 +131,12 @@ func (s *server) updateServer(svrs []string) {
 			continue
 		}
 
-		if len(server.IP) == 0 {
+		if len(server.RegisterIP) == 0 {
 			blog.Errorf("invalid ip with zk path: %s", s.path)
 			continue
 		}
 
-		host := server.Address()
+		host := server.RegisterAddress()
 		newSvr = append(newSvr, host)
 	}
 

--- a/src/apiserver/app/options/options.go
+++ b/src/apiserver/app/options/options.go
@@ -37,5 +37,6 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ServConf.AddrPort, "addrport", "127.0.0.1:50001", "The ip address and port for the serve on")
 	fs.StringVar(&s.ServConf.RegDiscover, "regdiscv", "", "hosts of register and discover server. e.g: 127.0.0.1:2181")
 	fs.StringVar(&s.ServConf.ExConfig, "config", "", "The config path. e.g ")
+	fs.StringVar(&s.ServConf.RegisterIP, "register-ip", "", "the ip address registered on zookeeper, it can be domain")
 	fs.Var(auth.EnableAuthFlag, "enable-auth", "The auth center enable status, true for enabled, false for disabled")
 }

--- a/src/apiserver/app/server.go
+++ b/src/apiserver/app/server.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"configcenter/src/apimachinery/util"
@@ -28,14 +27,12 @@ import (
 	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/types"
-	"configcenter/src/common/version"
-
 	"github.com/emicklei/go-restful"
 )
 
 // Run main loop function
 func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOption) error {
-	svrInfo, err := newServerInfo(op)
+	svrInfo, err := types.NewServerInfo(op.ServConf)
 	if err != nil {
 		return fmt.Errorf("wrap server info failed, err: %v", err)
 	}
@@ -117,31 +114,4 @@ func (h *APIServer) CheckForReadiness() error {
 		return nil
 	}
 	return errors.New("wait for api server configuration timeout")
-}
-
-func newServerInfo(op *options.ServerOption) (*types.ServerInfo, error) {
-	ip, err := op.ServConf.GetAddress()
-	if err != nil {
-		return nil, err
-	}
-
-	port, err := op.ServConf.GetPort()
-	if err != nil {
-		return nil, err
-	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, err
-	}
-
-	info := &types.ServerInfo{
-		IP:       ip,
-		Port:     port,
-		HostName: hostname,
-		Scheme:   "http",
-		Version:  version.GetVersion(),
-		Pid:      os.Getpid(),
-	}
-	return info, nil
 }

--- a/src/common/backbone/backbone.go
+++ b/src/common/backbone/backbone.go
@@ -98,7 +98,6 @@ func validateParameter(input *BackboneParameter) error {
 	if input.SrvInfo.Port <= 0 || input.SrvInfo.Port > 65535 {
 		return fmt.Errorf("addrport port must be 1-65535")
 	}
-
 	if input.ConfigUpdate == nil {
 		return fmt.Errorf("service config change funcation can not be emtpy")
 	}

--- a/src/common/backbone/register.go
+++ b/src/common/backbone/register.go
@@ -43,7 +43,7 @@ type serviceRegister struct {
 }
 
 func (s *serviceRegister) Register(path string, c types.ServerInfo) error {
-	if c.IP == "0.0.0.0" {
+	if c.RegisterIP == "0.0.0.0" {
 		return errors.New("register ip can not be 0.0.0.0")
 	}
 

--- a/src/common/core/cc/config/config.go
+++ b/src/common/core/cc/config/config.go
@@ -1,15 +1,15 @@
 /*
  * Tencent is pleased to support the open source community by making 蓝鲸 available.
  * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
- * Licensed under the MIT License (the "License"); you may not use this file except 
+ * Licensed under the MIT License (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  * http://opensource.org/licenses/MIT
  * Unless required by applicable law or agreed to in writing, software distributed under
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific language governing permissions and 
+ * either express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package config
 
 import (
@@ -22,9 +22,10 @@ import (
 type CCAPIConfig struct {
 	AddrPort    string
 	RegDiscover string
+	RegisterIP  string
 	ExConfig    string
-	Qps int64
-	Burst int64
+	Qps         int64
+	Burst       int64
 }
 
 // NewCCAPIConfig create ccapi config object
@@ -32,32 +33,76 @@ func NewCCAPIConfig() *CCAPIConfig {
 	return &CCAPIConfig{
 		AddrPort:    "127.0.0.1:8081",
 		RegDiscover: "",
-		Qps: 1000,
-		Burst: 2000,
+		RegisterIP:  "",
+		Qps:         1000,
+		Burst:       2000,
 	}
 }
 
+// IPV6 addr port, like ::1:80
+// IPV4 addr port, like 127.0.0.1:80
 // GetAddress get the address
 func (conf *CCAPIConfig) GetAddress() (string, error) {
-	arr := strings.Split(conf.AddrPort, ":")
-	if len(arr) < 2 {
-		return "", fmt.Errorf("the value of flag[AddrPort: %s] is wrong", conf.AddrPort)
+	addrPort := strings.TrimSpace(conf.AddrPort)
+	if err := checkAddrPort(addrPort); err != nil {
+		return "", err
 	}
-
-	return arr[0], nil
+	if isIPV6(addrPort) {
+		return getIPV6Adrr(addrPort)
+	}
+	return getIPV4Adrr(addrPort)
 }
 
 // GetPort get the port
 func (conf *CCAPIConfig) GetPort() (uint, error) {
-	arr := strings.Split(conf.AddrPort, ":")
-	if len(arr) < 2 {
-		return 0, fmt.Errorf("the value of flag[AddrPort: %s] is wrong", conf.AddrPort)
+	addrPort := strings.TrimSpace(conf.AddrPort)
+	if err := checkAddrPort(addrPort); err != nil {
+		return uint(0), err
 	}
+	if isIPV6(addrPort) {
+		return getIPV6Port(addrPort)
+	}
+	return getIPV4Port(addrPort)
+}
 
-	port, err := strconv.ParseUint(arr[1], 10, 0)
+func checkAddrPort(addrPort string) error {
+	if strings.Count(addrPort, ":") == 0 {
+		return fmt.Errorf("the value of flag[AddrPort: %s] is wrong", addrPort)
+	}
+	return nil
+}
+
+func isIPV6(addrPort string) bool {
+	return strings.Count(addrPort, ":") > 1
+}
+
+func getIPV6Adrr(addrPort string) (string, error) {
+	idx := strings.LastIndex(addrPort, ":")
+	return addrPort[:idx], nil
+}
+
+func getIPV4Adrr(addrPort string) (string, error) {
+	idx := strings.LastIndex(addrPort, ":")
+	return addrPort[:idx], nil
+}
+
+func getIPV6Port(addrPort string) (uint, error) {
+	return getPortFunc(addrPort)
+}
+
+func getIPV4Port(addrPort string) (uint, error) {
+	return getPortFunc(addrPort)
+}
+
+func getPortFunc(addrPort string) (uint, error) {
+	idx := strings.LastIndex(addrPort, ":")
+	// the port can't be empty, len(":port") can't less than 2
+	if len(addrPort[idx:]) < 2 {
+		return 0, fmt.Errorf("the value of flag[AddrPort: %s] is wrong", addrPort)
+	}
+	port, err := strconv.ParseUint(addrPort[idx+1:], 10, 0)
 	if err != nil {
-		return 0, err
+		return uint(0), err
 	}
-
 	return uint(port), nil
 }

--- a/src/common/types/serverInfo.go
+++ b/src/common/types/serverInfo.go
@@ -14,14 +14,18 @@ package types
 
 import (
 	"fmt"
+	"os"
+
+	"configcenter/src/common/core/cc/config"
+	"configcenter/src/common/version"
 )
 
 // zk path
 const (
-	CC_SERV_BASEPATH      = "/cc/services/endpoints"
-	CC_SERVCONF_BASEPATH  = "/cc/services/config"
-	CC_SERVERROR_BASEPATH = "/cc/services/errors"
-	CC_SERVLANG_BASEPATH  = "/cc/services/language"
+	CC_SERV_BASEPATH       = "/cc/services/endpoints"
+	CC_SERVCONF_BASEPATH   = "/cc/services/config"
+	CC_SERVERROR_BASEPATH  = "/cc/services/errors"
+	CC_SERVLANG_BASEPATH   = "/cc/services/language"
 	CC_SERVNOTICE_BASEPATH = "/cc/services/notice"
 
 	CC_DISCOVERY_PREFIX = "cc_"
@@ -72,12 +76,48 @@ const (
 
 // ServerInfo define base server information
 type ServerInfo struct {
-	IP       string `json:"ip"`
-	Port     uint   `json:"port"`
-	HostName string `json:"hostname"`
-	Scheme   string `json:"scheme"`
-	Version  string `json:"version"`
-	Pid      int    `json:"pid"`
+	IP         string `json:"ip"`
+	Port       uint   `json:"port"`
+	RegisterIP string `json:"registerip"`
+	HostName   string `json:"hostname"`
+	Scheme     string `json:"scheme"`
+	Version    string `json:"version"`
+	Pid        int    `json:"pid"`
+}
+
+// NewServerInfo new a ServerInfo object
+func NewServerInfo(conf *config.CCAPIConfig) (*ServerInfo, error) {
+	ip, err := conf.GetAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	port, err := conf.GetPort()
+	if err != nil {
+		return nil, err
+	}
+
+	registerIP := conf.RegisterIP
+	// if no registerIP is set, default to be the ip
+	if registerIP == "" {
+		registerIP = ip
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+
+	info := &ServerInfo{
+		IP:         ip,
+		Port:       port,
+		RegisterIP: registerIP,
+		HostName:   hostname,
+		Scheme:     "http",
+		Version:    version.GetVersion(),
+		Pid:        os.Getpid(),
+	}
+	return info, nil
 }
 
 // APIServerServInfo apiserver informaiton
@@ -146,11 +186,11 @@ type EventServInfo struct {
 }
 
 // Address convert struct to host address
-func (s *ServerInfo) Address() string {
+func (s *ServerInfo) RegisterAddress() string {
 	if s == nil {
 		return ""
 	}
-	return fmt.Sprintf("%s://%s:%d", s.Scheme, s.IP, s.Port)
+	return fmt.Sprintf("%s://%s:%d", s.Scheme, s.RegisterIP, s.Port)
 }
 
 func (s *ServerInfo) Instance() string {

--- a/src/scene_server/admin_server/app/options/options.go
+++ b/src/scene_server/admin_server/app/options/options.go
@@ -39,6 +39,7 @@ func NewServerOption() *ServerOption {
 func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ServConf.AddrPort, "addrport", "127.0.0.1:60005", "The ip address and port for the serve on")
 	fs.StringVar(&s.ServConf.ExConfig, "config", "conf/api.conf", "The config path. e.g conf/api.conf")
+	fs.StringVar(&s.ServConf.RegisterIP, "register-ip", "", "the ip address registered on zookeeper, it can be domain")
 	fs.Var(auth.EnableAuthFlag, "enable-auth", "The auth center enable status, true for enabled, false for disabled")
 }
 

--- a/src/scene_server/admin_server/app/server.go
+++ b/src/scene_server/admin_server/app/server.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -27,7 +26,6 @@ import (
 	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/types"
-	"configcenter/src/common/version"
 	"configcenter/src/scene_server/admin_server/app/options"
 	"configcenter/src/scene_server/admin_server/authsynchronizer"
 	"configcenter/src/scene_server/admin_server/configures"
@@ -39,7 +37,7 @@ import (
 )
 
 func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOption) error {
-	svrInfo, err := newServerInfo(op)
+	svrInfo, err := types.NewServerInfo(op.ServConf)
 	if err != nil {
 		return fmt.Errorf("wrap server info failed, err: %v", err)
 	}
@@ -165,31 +163,4 @@ func (h *MigrateServer) onHostConfigUpdate(previous, current cc.ProcessConfig) {
 			blog.Errorf("parse authcenter error: %v, config: %+v", err, current.ConfigMap)
 		}
 	}
-}
-
-func newServerInfo(op *options.ServerOption) (*types.ServerInfo, error) {
-	ip, err := op.ServConf.GetAddress()
-	if err != nil {
-		return nil, err
-	}
-
-	port, err := op.ServConf.GetPort()
-	if err != nil {
-		return nil, err
-	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, err
-	}
-
-	info := &types.ServerInfo{
-		IP:       ip,
-		Port:     port,
-		HostName: hostname,
-		Scheme:   "http",
-		Version:  version.GetVersion(),
-		Pid:      os.Getpid(),
-	}
-	return info, nil
 }

--- a/src/scene_server/datacollection/app/options/options.go
+++ b/src/scene_server/datacollection/app/options/options.go
@@ -40,6 +40,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&s.ServConf.RegDiscover, "regdiscv", "", "hosts of register and discover server. e.g: 127.0.0.1:2181")
 	fs.StringVar(&s.ServConf.ExConfig, "config", "", "The config path. e.g conf/api.conf")
+	fs.StringVar(&s.ServConf.RegisterIP, "register-ip", "", "the ip address registered on zookeeper, it can be domain")
 	fs.Var(auth.EnableAuthFlag, "enable-auth", "The auth center enable status, true for enabled, false for disabled")
 }
 

--- a/src/scene_server/datacollection/app/server.go
+++ b/src/scene_server/datacollection/app/server.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -28,7 +27,6 @@ import (
 	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/types"
-	"configcenter/src/common/version"
 	"configcenter/src/scene_server/datacollection/app/options"
 	"configcenter/src/scene_server/datacollection/datacollection"
 	"configcenter/src/scene_server/datacollection/logics"
@@ -45,7 +43,7 @@ import (
 )
 
 func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOption) error {
-	svrInfo, err := newServerInfo(op)
+	svrInfo, err := types.NewServerInfo(op.ServConf)
 	if err != nil {
 		return fmt.Errorf("wrap server info failed, err: %v", err)
 	}
@@ -215,31 +213,4 @@ func (h *DCServer) onHostConfigUpdate(previous, current cc.ProcessConfig) {
 			blog.Fatalf("auth config invalid, err: %+v", err)
 		}
 	}
-}
-
-func newServerInfo(op *options.ServerOption) (*types.ServerInfo, error) {
-	ip, err := op.ServConf.GetAddress()
-	if err != nil {
-		return nil, err
-	}
-
-	port, err := op.ServConf.GetPort()
-	if err != nil {
-		return nil, err
-	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, err
-	}
-
-	info := &types.ServerInfo{
-		IP:       ip,
-		Port:     port,
-		HostName: hostname,
-		Scheme:   "http",
-		Version:  version.GetVersion(),
-		Pid:      os.Getpid(),
-	}
-	return info, nil
 }

--- a/src/scene_server/event_server/app/options/options.go
+++ b/src/scene_server/event_server/app/options/options.go
@@ -43,6 +43,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	// fs.UintVar(&s.ServConf.Port, "port", 60009, "The port for the serve on")
 	fs.StringVar(&s.ServConf.ExConfig, "config", "", "The config path. e.g conf/api.conf")
 	fs.StringVar(&s.ServConf.RegDiscover, "regdiscv", "", "hosts of register and discover server. e.g: 127.0.0.1:2181")
+	fs.StringVar(&s.ServConf.RegisterIP, "register-ip", "", "the ip address registered on zookeeper, it can be domain")
 	fs.Var(auth.EnableAuthFlag, "enable-auth", "The auth center enable status, true for enabled, false for disabled")
 }
 

--- a/src/scene_server/event_server/app/server.go
+++ b/src/scene_server/event_server/app/server.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -26,7 +25,6 @@ import (
 	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/types"
-	"configcenter/src/common/version"
 	"configcenter/src/scene_server/event_server/app/options"
 	"configcenter/src/scene_server/event_server/distribution"
 	svc "configcenter/src/scene_server/event_server/service"
@@ -39,7 +37,7 @@ import (
 )
 
 func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOption) error {
-	svrInfo, err := newServerInfo(op)
+	svrInfo, err := types.NewServerInfo(op.ServConf)
 	if err != nil {
 		return fmt.Errorf("wrap server info failed, err: %v", err)
 	}
@@ -163,31 +161,4 @@ func (h *EventServer) onHostConfigUpdate(previous, current cc.ProcessConfig) {
 			blog.Errorf("parse auth center config failed: %v", err)
 		}
 	}
-}
-
-func newServerInfo(op *options.ServerOption) (*types.ServerInfo, error) {
-	ip, err := op.ServConf.GetAddress()
-	if err != nil {
-		return nil, err
-	}
-
-	port, err := op.ServConf.GetPort()
-	if err != nil {
-		return nil, err
-	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, err
-	}
-
-	info := &types.ServerInfo{
-		IP:       ip,
-		Port:     port,
-		HostName: hostname,
-		Scheme:   "http",
-		Version:  version.GetVersion(),
-		Pid:      os.Getpid(),
-	}
-	return info, nil
 }

--- a/src/scene_server/host_server/app/options/options.go
+++ b/src/scene_server/host_server/app/options/options.go
@@ -40,6 +40,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ServConf.AddrPort, "addrport", "127.0.0.1:60002", "The ip address and port for the serve on")
 	fs.StringVar(&s.ServConf.RegDiscover, "regdiscv", "", "hosts of register and discover server. e.g: 127.0.0.1:2181")
 	fs.StringVar(&s.ServConf.ExConfig, "config", "", "The config path. e.g conf/api.conf")
+	fs.StringVar(&s.ServConf.RegisterIP, "register-ip", "", "the ip address registered on zookeeper, it can be domain")
 	fs.Var(auth.EnableAuthFlag, "enable-auth", "The auth center enable status, true for enabled, false for disabled")
 }
 

--- a/src/scene_server/host_server/app/server.go
+++ b/src/scene_server/host_server/app/server.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"configcenter/src/auth"
@@ -27,7 +26,6 @@ import (
 	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/types"
-	"configcenter/src/common/version"
 	"configcenter/src/scene_server/host_server/app/options"
 	hostsvc "configcenter/src/scene_server/host_server/service"
 	"configcenter/src/storage/dal/redis"
@@ -36,7 +34,7 @@ import (
 )
 
 func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOption) error {
-	svrInfo, err := newServerInfo(op)
+	svrInfo, err := types.NewServerInfo(op.ServConf)
 	if err != nil {
 		blog.Errorf("wrap server info failed, err: %v", err)
 		return fmt.Errorf("wrap server info failed, err: %v", err)
@@ -127,31 +125,4 @@ func (h *HostServer) onHostConfigUpdate(previous, current cc.ProcessConfig) {
 	if err != nil {
 		blog.Warnf("parse auth center config failed: %v", err)
 	}
-}
-
-func newServerInfo(op *options.ServerOption) (*types.ServerInfo, error) {
-	ip, err := op.ServConf.GetAddress()
-	if err != nil {
-		return nil, err
-	}
-
-	port, err := op.ServConf.GetPort()
-	if err != nil {
-		return nil, err
-	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, err
-	}
-
-	info := &types.ServerInfo{
-		IP:       ip,
-		Port:     port,
-		HostName: hostname,
-		Scheme:   "http",
-		Version:  version.GetVersion(),
-		Pid:      os.Getpid(),
-	}
-	return info, nil
 }

--- a/src/scene_server/operation_server/app/options/options.go
+++ b/src/scene_server/operation_server/app/options/options.go
@@ -56,5 +56,6 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ServConf.AddrPort, "addrport", "127.0.0.1:60021", "The ip address and port for the serve on")
 	fs.StringVar(&s.ServConf.RegDiscover, "regdiscv", "127.0.0.1:2181", "hosts of register and discover server. e.g: 127.0.0.1:2181")
 	fs.StringVar(&s.ServConf.ExConfig, "config", "", "The config path. e.g conf/api.conf")
+	fs.StringVar(&s.ServConf.RegisterIP, "register-ip", "", "the ip address registered on zookeeper, it can be domain")
 	fs.Var(auth.EnableAuthFlag, "enable-auth", "The auth center enable status, true for enabled, false for disabled")
 }

--- a/src/scene_server/operation_server/app/server.go
+++ b/src/scene_server/operation_server/app/server.go
@@ -15,7 +15,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"configcenter/src/auth"
@@ -24,13 +23,12 @@ import (
 	"configcenter/src/common/backbone"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/types"
-	"configcenter/src/common/version"
 	"configcenter/src/scene_server/operation_server/app/options"
 	"configcenter/src/scene_server/operation_server/service"
 )
 
 func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOption) error {
-	svrInfo, err := newServerInfo(op)
+	svrInfo, err := types.NewServerInfo(op.ServConf)
 	if err != nil {
 		blog.Errorf("fail to new server information. err: %s", err.Error())
 		return fmt.Errorf("make server information failed, err:%v", err)
@@ -83,32 +81,4 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	}
 
 	return nil
-}
-
-func newServerInfo(op *options.ServerOption) (*types.ServerInfo, error) {
-	ip, err := op.ServConf.GetAddress()
-	if err != nil {
-		return nil, err
-	}
-
-	port, err := op.ServConf.GetPort()
-	if err != nil {
-		return nil, err
-	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, err
-	}
-
-	svrInfo := &types.ServerInfo{
-		IP:       ip,
-		Port:     port,
-		HostName: hostname,
-		Scheme:   "http",
-		Version:  version.GetVersion(),
-		Pid:      os.Getpid(),
-	}
-
-	return svrInfo, nil
 }

--- a/src/scene_server/proc_server/app/options/options.go
+++ b/src/scene_server/proc_server/app/options/options.go
@@ -40,6 +40,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	// fs.UintVar(&s.ServConf.Port, "port", 60003, "The port for the serve on")
 	fs.StringVar(&s.ServConf.RegDiscover, "regdiscv", "", "hosts of register and discover server. e.g: 127.0.0.1:2181")
 	fs.StringVar(&s.ServConf.ExConfig, "config", "", "The config path. e.g conf/api.conf")
+	fs.StringVar(&s.ServConf.RegisterIP, "register-ip", "", "the ip address registered on zookeeper, it can be domain")
 	fs.Var(auth.EnableAuthFlag, "enable-auth", "The auth center enable status, true for enabled, false for disabled")
 }
 

--- a/src/scene_server/proc_server/app/server.go
+++ b/src/scene_server/proc_server/app/server.go
@@ -15,7 +15,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"configcenter/src/auth"
@@ -25,7 +24,6 @@ import (
 	"configcenter/src/common/backbone"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/types"
-	"configcenter/src/common/version"
 	"configcenter/src/scene_server/proc_server/app/options"
 	"configcenter/src/scene_server/proc_server/logics"
 	"configcenter/src/scene_server/proc_server/service"
@@ -35,7 +33,7 @@ import (
 
 func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOption) error {
 
-	svrInfo, err := newServerInfo(op)
+	svrInfo, err := types.NewServerInfo(op.ServConf)
 	if err != nil {
 		blog.Errorf("fail to new server information. err: %s", err.Error())
 		return fmt.Errorf("make server information failed, err:%v", err)
@@ -99,32 +97,4 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	}
 
 	return nil
-}
-
-func newServerInfo(op *options.ServerOption) (*types.ServerInfo, error) {
-	ip, err := op.ServConf.GetAddress()
-	if err != nil {
-		return nil, err
-	}
-
-	port, err := op.ServConf.GetPort()
-	if err != nil {
-		return nil, err
-	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, err
-	}
-
-	svrInfo := &types.ServerInfo{
-		IP:       ip,
-		Port:     port,
-		HostName: hostname,
-		Scheme:   "http",
-		Version:  version.GetVersion(),
-		Pid:      os.Getpid(),
-	}
-
-	return svrInfo, nil
 }

--- a/src/scene_server/synchronize_server/app/options/options.go
+++ b/src/scene_server/synchronize_server/app/options/options.go
@@ -38,6 +38,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ServConf.AddrPort, "addrport", "127.0.0.1:60006", "The ip address and port for the serve on")
 	fs.StringVar(&s.ServConf.RegDiscover, "regdiscv", "", "hosts of register and discover server. e.g: 127.0.0.1:2181")
 	fs.StringVar(&s.ServConf.ExConfig, "config", "", "The config path. e.g conf/api.conf")
+	fs.StringVar(&s.ServConf.RegisterIP, "register-ip", "", "the ip address registered on zookeeper, it can be domain")
 	fs.Var(auth.EnableAuthFlag, "enable-auth", "The auth center enable status, true for enabled, false for disabled")
 }
 

--- a/src/scene_server/synchronize_server/app/server.go
+++ b/src/scene_server/synchronize_server/app/server.go
@@ -15,7 +15,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -26,7 +25,6 @@ import (
 	cc "configcenter/src/common/backbone/configcenter"
 	//"configcenter/src/common/blog"
 	"configcenter/src/common/types"
-	"configcenter/src/common/version"
 	"configcenter/src/scene_server/synchronize_server/app/options"
 	synchronizeService "configcenter/src/scene_server/synchronize_server/service"
 	//"configcenter/src/storage/dal/redis"
@@ -35,7 +33,7 @@ import (
 )
 
 func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOption) error {
-	svrInfo, err := newServerInfo(op)
+	svrInfo, err := types.NewServerInfo(op.ServConf)
 	if err != nil {
 		return fmt.Errorf("wrap server info failed, err: %v", err)
 	}
@@ -169,31 +167,4 @@ func SplitFilter(s, sep string) []string {
 		strArr = append(strArr, item)
 	}
 	return strArr
-}
-
-func newServerInfo(op *options.ServerOption) (*types.ServerInfo, error) {
-	ip, err := op.ServConf.GetAddress()
-	if err != nil {
-		return nil, err
-	}
-
-	port, err := op.ServConf.GetPort()
-	if err != nil {
-		return nil, err
-	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, err
-	}
-
-	info := &types.ServerInfo{
-		IP:       ip,
-		Port:     port,
-		HostName: hostname,
-		Scheme:   "http",
-		Version:  version.GetVersion(),
-		Pid:      os.Getpid(),
-	}
-	return info, nil
 }

--- a/src/scene_server/task_server/app/options/options.go
+++ b/src/scene_server/task_server/app/options/options.go
@@ -38,6 +38,7 @@ func NewServerOption() *ServerOption {
 func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ServConf.AddrPort, "addrport", "127.0.0.1:60002", "The ip address and port for the serve on")
 	fs.StringVar(&s.ServConf.RegDiscover, "regdiscv", "", "hosts of register and discover server. e.g: 127.0.0.1:2181")
+	fs.StringVar(&s.ServConf.RegisterIP, "register-ip", "", "the ip address registered on zookeeper, it can be domain")
 	fs.StringVar(&s.ServConf.ExConfig, "config", "", "The config path. e.g conf/api.conf")
 }
 

--- a/src/scene_server/task_server/app/server.go
+++ b/src/scene_server/task_server/app/server.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -26,7 +25,6 @@ import (
 	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/types"
-	"configcenter/src/common/version"
 	"configcenter/src/scene_server/task_server/app/options"
 	tasksvc "configcenter/src/scene_server/task_server/service"
 	"configcenter/src/storage/dal/mongo"
@@ -36,7 +34,7 @@ import (
 )
 
 func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOption) error {
-	svrInfo, err := newServerInfo(op)
+	svrInfo, err := types.NewServerInfo(op.ServConf)
 	if err != nil {
 		blog.Errorf("wrap server info failed, err: %v", err)
 		return fmt.Errorf("wrap server info failed, err: %v", err)
@@ -157,31 +155,4 @@ func (h *TaskServer) onHostConfigUpdate(previous, current cc.ProcessConfig) {
 		h.taskQueue[name] = task
 	}
 
-}
-
-func newServerInfo(op *options.ServerOption) (*types.ServerInfo, error) {
-	ip, err := op.ServConf.GetAddress()
-	if err != nil {
-		return nil, err
-	}
-
-	port, err := op.ServConf.GetPort()
-	if err != nil {
-		return nil, err
-	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, err
-	}
-
-	info := &types.ServerInfo{
-		IP:       ip,
-		Port:     port,
-		HostName: hostname,
-		Scheme:   "http",
-		Version:  version.GetVersion(),
-		Pid:      os.Getpid(),
-	}
-	return info, nil
 }

--- a/src/scene_server/topo_server/app/options/options.go
+++ b/src/scene_server/topo_server/app/options/options.go
@@ -46,5 +46,6 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ServConf.AddrPort, "addrport", "127.0.0.1:60001", "The ip address and port for the serve on")
 	fs.StringVar(&s.ServConf.RegDiscover, "regdiscv", "", "hosts of register and discover server. e.g: 127.0.0.1:2181")
 	fs.StringVar(&s.ServConf.ExConfig, "config", "", "The config path. e.g conf/api.conf")
+	fs.StringVar(&s.ServConf.RegisterIP, "register-ip", "", "the ip address registered on zookeeper, it can be domain")
 	fs.Var(auth.EnableAuthFlag, "enable-auth", "The auth center enable status, true for enabled, false for disabled")
 }

--- a/src/scene_server/topo_server/app/server.go
+++ b/src/scene_server/topo_server/app/server.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"time"
 
@@ -27,7 +26,6 @@ import (
 	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/types"
-	"configcenter/src/common/version"
 	"configcenter/src/scene_server/topo_server/app/options"
 	"configcenter/src/scene_server/topo_server/core"
 	"configcenter/src/scene_server/topo_server/service"
@@ -76,7 +74,7 @@ func (t *TopoServer) onTopoConfigUpdate(previous, current cc.ProcessConfig) {
 
 // Run main function
 func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOption) error {
-	svrInfo, err := newServerInfo(op)
+	svrInfo, err := types.NewServerInfo(op.ServConf)
 	if err != nil {
 		return fmt.Errorf("wrap server info failed, err: %v", err)
 	}
@@ -165,31 +163,4 @@ func (t *TopoServer) CheckForReadiness() error {
 		return nil
 	}
 	return errors.New("wait for topology server configuration timeout")
-}
-
-func newServerInfo(op *options.ServerOption) (*types.ServerInfo, error) {
-	ip, err := op.ServConf.GetAddress()
-	if err != nil {
-		return nil, err
-	}
-
-	port, err := op.ServConf.GetPort()
-	if err != nil {
-		return nil, err
-	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, err
-	}
-
-	info := &types.ServerInfo{
-		IP:       ip,
-		Port:     port,
-		HostName: hostname,
-		Scheme:   "http",
-		Version:  version.GetVersion(),
-		Pid:      os.Getpid(),
-	}
-	return info, nil
 }

--- a/src/source_controller/coreservice/app/options/options.go
+++ b/src/source_controller/coreservice/app/options/options.go
@@ -44,5 +44,6 @@ func NewServerOption() *ServerOption {
 func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ServConf.AddrPort, "addrport", "127.0.0.1:60001", "The ip address and port for the serve on")
 	fs.StringVar(&s.ServConf.RegDiscover, "regdiscv", "", "hosts of register and discover server. e.g: 127.0.0.1:2181")
+	fs.StringVar(&s.ServConf.RegisterIP, "register-ip", "", "the ip address registered on zookeeper, it can be domain")
 	fs.StringVar(&s.ServConf.ExConfig, "config", "", "The config path. e.g conf/api.conf")
 }

--- a/src/source_controller/coreservice/app/server.go
+++ b/src/source_controller/coreservice/app/server.go
@@ -15,7 +15,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"configcenter/src/common"
@@ -23,7 +22,6 @@ import (
 	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/types"
-	"configcenter/src/common/version"
 	"configcenter/src/source_controller/coreservice/app/options"
 	coresvr "configcenter/src/source_controller/coreservice/service"
 	"configcenter/src/storage/dal/mongo"
@@ -48,7 +46,7 @@ func (t *CoreServer) onCoreServiceConfigUpdate(previous, current cc.ProcessConfi
 
 // Run main function
 func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOption) error {
-	svrInfo, err := newServerInfo(op)
+	svrInfo, err := types.NewServerInfo(op.ServConf)
 	if err != nil {
 		return fmt.Errorf("wrap server info failed, err: %v", err)
 	}
@@ -99,31 +97,4 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	case <-ctx.Done():
 	}
 	return nil
-}
-
-func newServerInfo(op *options.ServerOption) (*types.ServerInfo, error) {
-	ip, err := op.ServConf.GetAddress()
-	if err != nil {
-		return nil, err
-	}
-
-	port, err := op.ServConf.GetPort()
-	if err != nil {
-		return nil, err
-	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, err
-	}
-
-	info := &types.ServerInfo{
-		IP:       ip,
-		Port:     port,
-		HostName: hostname,
-		Scheme:   "http",
-		Version:  version.GetVersion(),
-		Pid:      os.Getpid(),
-	}
-	return info, nil
 }

--- a/src/storage/tmserver/app/options/options.go
+++ b/src/storage/tmserver/app/options/options.go
@@ -39,6 +39,7 @@ func NewServerOption() *ServerOption {
 func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ServConf.AddrPort, "addrport", "127.0.0.1:50010", "The ip address and port for the serve on")
 	fs.StringVar(&s.ServConf.RegDiscover, "regdiscv", "", "hosts of register and discover server. e.g: 127.0.0.1:2181")
+	fs.StringVar(&s.ServConf.RegisterIP, "register-ip", "", "the ip address registered on zookeeper, it can be domain")
 	fs.StringVar(&s.ServConf.ExConfig, "config", "", "The config path. e.g conf/api.conf")
 }
 

--- a/src/storage/tmserver/app/run.go
+++ b/src/storage/tmserver/app/run.go
@@ -19,6 +19,7 @@ import (
 
 	"configcenter/src/common/backbone"
 	"configcenter/src/common/blog"
+	"configcenter/src/common/types"
 	mgo "configcenter/src/storage/mongodb/driver"
 	"configcenter/src/storage/tmserver/app/options"
 	"configcenter/src/storage/tmserver/service"
@@ -28,7 +29,7 @@ import (
 
 // Run main goroute
 func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOption) error {
-	svrInfo, err := newServerInfo(op)
+	svrInfo, err := types.NewServerInfo(op.ServConf)
 	if err != nil {
 		return fmt.Errorf("wrap server info failed, err: %v", err)
 	}

--- a/src/storage/tmserver/app/server.go
+++ b/src/storage/tmserver/app/server.go
@@ -13,13 +13,10 @@
 package app
 
 import (
-	"os"
 	"sync"
 
 	"configcenter/src/common/backbone"
 	cc "configcenter/src/common/backbone/configcenter"
-	"configcenter/src/common/types"
-	"configcenter/src/common/version"
 	"configcenter/src/storage/dal/mongo"
 	"configcenter/src/storage/tmserver/app/options"
 	"configcenter/src/storage/tmserver/service"
@@ -50,31 +47,3 @@ func (s *Server) onConfigUpdate(previous, current cc.ProcessConfig) {
 	}
 }
 
-func newServerInfo(op *options.ServerOption) (*types.ServerInfo, error) {
-
-	ip, err := op.ServConf.GetAddress()
-	if err != nil {
-		return nil, err
-	}
-
-	port, err := op.ServConf.GetPort()
-	if err != nil {
-		return nil, err
-	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, err
-	}
-
-	info := &types.ServerInfo{
-		IP:       ip,
-		Port:     port,
-		HostName: hostname,
-		Scheme:   "http",
-		Version:  version.GetVersion(),
-		Pid:      os.Getpid(),
-	}
-
-	return info, nil
-}

--- a/src/web_server/app/options/options.go
+++ b/src/web_server/app/options/options.go
@@ -36,6 +36,7 @@ func NewServerOption() *ServerOption {
 func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ServConf.AddrPort, "addrport", "", "The ip address and port for the serve on")
 	fs.StringVar(&s.ServConf.RegDiscover, "regdiscv", "", "hosts of register and discover server. e.g: 127.0.0.1:2181")
+	fs.StringVar(&s.ServConf.RegisterIP, "register-ip", "", "the ip address registered on zookeeper, it can be domain")
 	fs.StringVar(&s.ServConf.ExConfig, "config", "", "The config path. e.g conf/ccapi.conf")
 }
 

--- a/src/web_server/app/server.go
+++ b/src/web_server/app/server.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"plugin"
 	"strings"
 	"time"
@@ -24,12 +23,11 @@ import (
 	"configcenter/src/common"
 	"configcenter/src/common/backbone"
 	cc "configcenter/src/common/backbone/configcenter"
-	"configcenter/src/common/types"
-	"configcenter/src/common/version"
 	"configcenter/src/storage/dal/redis"
 	"configcenter/src/web_server/app/options"
 	"configcenter/src/web_server/logics"
 	websvc "configcenter/src/web_server/service"
+	"configcenter/src/common/types"
 
 	"github.com/holmeswang/contrib/sessions"
 )
@@ -40,7 +38,7 @@ type WebServer struct {
 
 func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOption) error {
 
-	svrInfo, err := newServerInfo(op)
+	svrInfo, err := types.NewServerInfo(op.ServConf)
 	if err != nil {
 		return fmt.Errorf("wrap server info failed, err: %v", err)
 	}
@@ -178,29 +176,3 @@ func (ccWeb *WebServer) Stop() error {
 	return nil
 }
 
-func newServerInfo(op *options.ServerOption) (*types.ServerInfo, error) {
-	ip, err := op.ServConf.GetAddress()
-	if err != nil {
-		return nil, err
-	}
-
-	port, err := op.ServConf.GetPort()
-	if err != nil {
-		return nil, err
-	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, err
-	}
-
-	info := &types.ServerInfo{
-		IP:       ip,
-		Port:     port,
-		HostName: hostname,
-		Scheme:   "http",
-		Version:  version.GetVersion(),
-		Pid:      os.Getpid(),
-	}
-	return info, nil
-}


### PR DESCRIPTION
### 新加的功能:
- (1)进程注册的地址需要支持可以是域名
- (2)进程启动监听的地址可以支持绑IPV6地址。
