### PR TITLE
fix: 修复url有参数拼接时，metrics会采集多个不同url的问题 #3722

### DIFF
--- a/src/apimachinery/coreservice/hostapplyrule/api.go
+++ b/src/apimachinery/coreservice/hostapplyrule/api.go
@@ -14,7 +14,6 @@ package hostapplyrule
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"configcenter/src/common/blog"
@@ -27,12 +26,11 @@ func (p *hostApplyRule) CreateHostApplyRule(ctx context.Context, header http.Hea
 		metadata.BaseResp `json:",inline"`
 		Data              metadata.HostApplyRule `json:"data"`
 	}{}
-	subPath := fmt.Sprintf("/create/host_apply_rule/bk_biz_id/%d/", bizID)
 
 	err := p.client.Post().
 		WithContext(ctx).
 		Body(option).
-		SubResource(subPath).
+		SubResourcef("/create/host_apply_rule/bk_biz_id/%d/", bizID).
 		WithHeaders(header).
 		Do().
 		Into(&ret)
@@ -53,12 +51,11 @@ func (p *hostApplyRule) UpdateHostApplyRule(ctx context.Context, header http.Hea
 		metadata.BaseResp `json:",inline"`
 		Data              metadata.HostApplyRule `json:"data"`
 	}{}
-	subPath := fmt.Sprintf("/update/host_apply_rule/%d/bk_biz_id/%d/", ruleID, bizID)
 
 	err := p.client.Put().
 		WithContext(ctx).
 		Body(option).
-		SubResource(subPath).
+		SubResourcef("/update/host_apply_rule/%d/bk_biz_id/%d/", ruleID, bizID).
 		WithHeaders(header).
 		Do().
 		Into(&ret)
@@ -78,12 +75,11 @@ func (p *hostApplyRule) DeleteHostApplyRule(ctx context.Context, header http.Hea
 	ret := struct {
 		metadata.BaseResp `json:",inline"`
 	}{}
-	subPath := fmt.Sprintf("/deletemany/host_apply_rule/bk_biz_id/%d/", bizID)
 
 	err := p.client.Delete().
 		WithContext(ctx).
 		Body(option).
-		SubResource(subPath).
+		SubResourcef("/deletemany/host_apply_rule/bk_biz_id/%d/", bizID).
 		WithHeaders(header).
 		Do().
 		Into(&ret)
@@ -104,11 +100,10 @@ func (p *hostApplyRule) GetHostApplyRule(ctx context.Context, header http.Header
 		metadata.BaseResp `json:",inline"`
 		Data              metadata.HostApplyRule `json:"data"`
 	}{}
-	subPath := fmt.Sprintf("/find/host_apply_rule/%d/bk_biz_id/%d/", ruleID, bizID)
 
 	err := p.client.Get().
 		WithContext(ctx).
-		SubResource(subPath).
+		SubResourcef("/find/host_apply_rule/%d/bk_biz_id/%d/", ruleID, bizID).
 		WithHeaders(header).
 		Do().
 		Into(&ret)
@@ -129,12 +124,11 @@ func (p *hostApplyRule) ListHostApplyRule(ctx context.Context, header http.Heade
 		metadata.BaseResp
 		Data metadata.MultipleHostApplyRuleResult `json:"data"`
 	}{}
-	subPath := fmt.Sprintf("/findmany/host_apply_rule/bk_biz_id/%d/", bizID)
 
 	err := p.client.Post().
 		WithContext(ctx).
 		Body(option).
-		SubResource(subPath).
+		SubResourcef("/findmany/host_apply_rule/bk_biz_id/%d/", bizID).
 		WithHeaders(header).
 		Do().
 		Into(&ret)
@@ -155,12 +149,11 @@ func (p *hostApplyRule) BatchUpdateHostApplyRule(ctx context.Context, header htt
 		metadata.BaseResp
 		Data metadata.BatchCreateOrUpdateHostApplyRuleResult `json:"data"`
 	}{}
-	subPath := fmt.Sprintf("/updatemany/host_apply_rule/bk_biz_id/%d/", bizID)
 
 	err := p.client.Post().
 		WithContext(ctx).
 		Body(option).
-		SubResource(subPath).
+		SubResourcef("/updatemany/host_apply_rule/bk_biz_id/%d/", bizID).
 		WithHeaders(header).
 		Do().
 		Into(&ret)
@@ -181,12 +174,11 @@ func (p *hostApplyRule) GenerateApplyPlan(ctx context.Context, header http.Heade
 		metadata.BaseResp
 		Data metadata.HostApplyPlanResult `json:"data"`
 	}{}
-	subPath := fmt.Sprintf("/findmany/host_apply_plan/bk_biz_id/%d/", bizID)
 
 	err := p.client.Post().
 		WithContext(ctx).
 		Body(option).
-		SubResource(subPath).
+		SubResourcef("/findmany/host_apply_plan/bk_biz_id/%d/", bizID).
 		WithHeaders(header).
 		Do().
 		Into(&ret)
@@ -210,12 +202,11 @@ func (p *hostApplyRule) SearchRuleRelatedModules(ctx context.Context, header htt
 		BaseResp: metadata.BaseResp{},
 		Data:     make([]metadata.Module, 0),
 	}
-	subPath := fmt.Sprintf("/findmany/modules/bk_biz_id/%d/host_apply_rule_related", bizID)
 
 	err := p.client.Post().
 		WithContext(ctx).
 		Body(option).
-		SubResource(subPath).
+		SubResourcef("/findmany/modules/bk_biz_id/%d/host_apply_rule_related", bizID).
 		WithHeaders(header).
 		Do().
 		Into(&ret)
@@ -236,12 +227,11 @@ func (p *hostApplyRule) RunHostApplyOnHosts(ctx context.Context, header http.Hea
 		metadata.BaseResp
 		Data metadata.MultipleHostApplyResult `json:"data"`
 	}{}
-	subPath := fmt.Sprintf("/updatemany/host/bk_biz_id/%d/update_by_host_apply", bizID)
 
 	err := p.client.Put().
 		WithContext(ctx).
 		Body(option).
-		SubResource(subPath).
+		SubResourcef("/updatemany/host/bk_biz_id/%d/update_by_host_apply", bizID).
 		WithHeaders(header).
 		Do().
 		Into(&ret)

--- a/src/test/host_server/host_apply_test.go
+++ b/src/test/host_server/host_apply_test.go
@@ -33,7 +33,6 @@ var _ = Describe("host abnormal test", func() {
 	Describe("test host apply", func() {
 
 		It("1. CreateBusiness", func() {
-			subPath := fmt.Sprintf("/biz/%s", supplierAccount)
 
 			input := map[string]interface{}{
 				"bk_biz_name":       util.RandSeq(16),
@@ -51,7 +50,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef("/biz/%s", supplierAccount).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -78,7 +77,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -110,7 +109,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -142,7 +141,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -173,7 +172,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -202,7 +201,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Put().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -230,7 +229,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Put().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -273,7 +272,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -314,7 +313,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -355,7 +354,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -386,7 +385,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -413,7 +412,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Put().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -440,7 +439,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Put().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -467,7 +466,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -499,7 +498,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -538,7 +537,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -583,7 +582,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -610,7 +609,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -637,7 +636,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -669,7 +668,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -713,7 +712,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -749,7 +748,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -792,7 +791,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -837,7 +836,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Post().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)
@@ -866,7 +865,7 @@ var _ = Describe("host abnormal test", func() {
 			err := apiServerClient.Client().Delete().
 				WithContext(ctx).
 				Body(input).
-				SubResource(subPath).
+				SubResourcef(subPath).
 				WithHeaders(header).
 				Do().Into(&rsp)
 			util.RegisterResponse(rsp)


### PR DESCRIPTION
### 修复的问题：
- 修复url有参数拼接时，metrics会采集多个不同url的问题 #3722
