### PR TITLE
fix: 增加模型关联类型的英文翻译 issue #3783

### DIFF
--- a/src/common/metadata/result.go
+++ b/src/common/metadata/result.go
@@ -196,6 +196,12 @@ type QueryModelClassificationDataResult struct {
 	Info  []Classification `json:"info"`
 }
 
+// SearchAssociationKindResult search association kind result definition
+type SearchAssociationKindResult struct {
+	Count uint64            `json:"count"`
+	Info  []AssociationKind `json:"info"`
+}
+
 // ReadModelAttrResult  read model attribute api http response return result struct
 type ReadModelAttrResult struct {
 	BaseResp `json:",inline"`

--- a/src/source_controller/coreservice/core/association/kind.go
+++ b/src/source_controller/coreservice/core/association/kind.go
@@ -259,20 +259,17 @@ func (m *associationKind) CascadeDeleteAssociationKind(ctx core.ContextParams, i
 	return &metadata.DeletedCount{Count: uint64(len(associationKindItems))}, nil
 }
 
-func (m *associationKind) SearchAssociationKind(ctx core.ContextParams, inputParam metadata.QueryCondition) (*metadata.QueryResult, error) {
-	associationKindItems, err := m.searchAssociationKind(ctx, inputParam)
+func (m *associationKind) SearchAssociationKind(ctx core.ContextParams, inputParam metadata.QueryCondition) (*metadata.SearchAssociationKindResult, error) {
+	dataResult := &metadata.SearchAssociationKindResult{}
+	var err error
+	dataResult.Info, err = m.searchAssociationKind(ctx, inputParam)
 	if nil != err {
-		return &metadata.QueryResult{}, err
+		return &metadata.SearchAssociationKindResult{}, err
 	}
 
-	dataResult := &metadata.QueryResult{}
 	dataResult.Count, err = m.countInstanceAssociation(ctx, inputParam.Condition)
-	dataResult.Info = make([]mapstr.MapStr, 0)
 	if nil != err {
-		return &metadata.QueryResult{}, err
-	}
-	for _, item := range associationKindItems {
-		dataResult.Info = append(dataResult.Info, mapstr.NewFromStruct(item, "field"))
+		return &metadata.SearchAssociationKindResult{}, err
 	}
 
 	return dataResult, nil

--- a/src/source_controller/coreservice/core/core.go
+++ b/src/source_controller/coreservice/core/core.go
@@ -98,7 +98,7 @@ type AssociationKind interface {
 	UpdateAssociationKind(ctx ContextParams, inputParam metadata.UpdateOption) (*metadata.UpdatedCount, error)
 	DeleteAssociationKind(ctx ContextParams, inputParam metadata.DeleteOption) (*metadata.DeletedCount, error)
 	CascadeDeleteAssociationKind(ctx ContextParams, inputParam metadata.DeleteOption) (*metadata.DeletedCount, error)
-	SearchAssociationKind(ctx ContextParams, inputParam metadata.QueryCondition) (*metadata.QueryResult, error)
+	SearchAssociationKind(ctx ContextParams, inputParam metadata.QueryCondition) (*metadata.SearchAssociationKindResult, error)
 }
 
 // ModelAssociation manager model association

--- a/src/source_controller/coreservice/service/association.go
+++ b/src/source_controller/coreservice/service/association.go
@@ -87,7 +87,15 @@ func (s *coreService) SearchAssociationKind(params core.ContextParams, pathParam
 	if err := data.MarshalJSONInto(&inputData); nil != err {
 		return nil, err
 	}
-	return s.core.AssociationOperation().SearchAssociationKind(params, inputData)
+	result, err := s.core.AssociationOperation().SearchAssociationKind(params, inputData)
+	if err != nil {
+		return result, err
+	}
+	// translate
+	for idx := range result.Info {
+		s.TranslateAssociationType(params.Lang, &result.Info[idx])
+	}
+	return result, nil
 }
 
 func (s *coreService) CreateModelAssociation(params core.ContextParams, pathParams, queryParams ParamsGetter, data mapstr.MapStr) (interface{}, error) {

--- a/src/source_controller/coreservice/service/translate.go
+++ b/src/source_controller/coreservice/service/translate.go
@@ -70,3 +70,9 @@ func (s *coreService) TranslatePropertyGroupName(defLang language.DefaultCCLangu
 func (s *coreService) TranslateClassificationName(defLang language.DefaultCCLanguageIf, att *metadata.Classification) string {
 	return util.FirstNotEmptyString(defLang.Language("classification_"+att.ClassificationID), att.ClassificationName, att.ClassificationID)
 }
+
+func (s *coreService) TranslateAssociationType(defLang language.DefaultCCLanguageIf, assKind *metadata.AssociationKind) {
+	assKind.AssociationKindName = util.FirstNotEmptyString(defLang.Language("unique_kind_name_"+assKind.AssociationKindID), assKind.AssociationKindName)
+	assKind.SourceToDestinationNote = util.FirstNotEmptyString(defLang.Language("unique_kind_src_to_dest_"+assKind.AssociationKindID), assKind.SourceToDestinationNote)
+	assKind.DestinationToSourceNote = util.FirstNotEmptyString(defLang.Language("unique_kind_dest_to_src_"+assKind.AssociationKindID), assKind.DestinationToSourceNote)
+}


### PR DESCRIPTION
### 修复的问题：
- 英文版的模型关联类型字段值仍然显示为中文