### PR TITLE
修复get_biz_internal_module接口bson的tag缺双引号导致json序列化ModuleName错误的问题

### DIFF
--- a/src/common/metadata/object.go
+++ b/src/common/metadata/object.go
@@ -187,7 +187,7 @@ type ObjectClsDes struct {
 
 type InnerModule struct {
 	ModuleID         int64  `field:"bk_module_id" json:"bk_module_id" bson:"bk_module_id" mapstructure:"bk_module_id"`
-	ModuleName       string `field:"bk_module_name" bson:"bk_module_name json:"bk_module_name" mapstructure:"bk_module_name"`
+	ModuleName       string `field:"bk_module_name" bson:"bk_module_name" json:"bk_module_name" mapstructure:"bk_module_name"`
 	Default          int64  `field:"default" bson:"default" json:"default" mapstructure:"default"`
 	HostApplyEnabled bool   `field:"host_apply_enabled" bson:"host_apply_enabled" json:"host_apply_enabled" mapstructure:"host_apply_enabled"`
 }


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
