### PR TITLE
更新模型属性接口添加模型分组是否存在的校验

### DIFF
--- a/src/auth/parser/topology.go
+++ b/src/auth/parser/topology.go
@@ -1600,7 +1600,12 @@ func (ps *parseStream) objectAttribute() *parseStream {
 			return ps
 		}
 
-		objectID := gjson.GetBytes(ps.RequestCtx.Body, common.BKObjIDField).String()
+		attrs, err := ps.getModelAttribute(mapstr.MapStr{metadata.AttributeFieldID: attrID})
+		if err != nil {
+			ps.err = err
+			return ps
+		}
+		objectID := attrs[0].ObjectID
 		model, err := ps.getModel(mapstr.MapStr{common.BKObjIDField: objectID})
 		if err != nil {
 			ps.err = err
@@ -1633,7 +1638,12 @@ func (ps *parseStream) objectAttribute() *parseStream {
 			return ps
 		}
 
-		objectID := gjson.GetBytes(ps.RequestCtx.Body, common.BKObjIDField).String()
+		attrs, err := ps.getModelAttribute(mapstr.MapStr{metadata.AttributeFieldID: attrID})
+		if err != nil {
+			ps.err = err
+			return ps
+		}
+		objectID := attrs[0].ObjectID
 		model, err := ps.getModel(mapstr.MapStr{common.BKObjIDField: objectID})
 		if err != nil {
 			ps.err = err

--- a/src/source_controller/coreservice/core/model/attribute_curd.go
+++ b/src/source_controller/coreservice/core/model/attribute_curd.go
@@ -351,8 +351,31 @@ func (m *modelAttribute) checkUpdate(ctx core.ContextParams, data mapstr.MapStr,
 	data.Remove(metadata.AttributeFieldCreateTime)
 	data.Set(metadata.AttributeFieldLastTime, time.Now())
 
-	if grp, exists := data.Get(metadata.AttributeFieldPropertyGroup); exists && (grp == "") {
-		data.Remove(metadata.AttributeFieldPropertyGroup)
+	if grp, exists := data.Get(metadata.AttributeFieldPropertyGroup); exists {
+		if grp == "" {
+			data.Remove(metadata.AttributeFieldPropertyGroup)
+		}
+		// check if property group exists in object
+		objIDs := make([]string, 0)
+		for _, dbAttribute := range dbAttributeArr {
+			objIDs = append(objIDs, dbAttribute.ObjectID)
+		}
+		objIDs = util.StrArrayUnique(objIDs)
+		cond := map[string]interface{}{
+			common.BKObjIDField: map[string]interface{}{
+				common.BKDBIN: objIDs,
+			},
+			common.BKPropertyGroupIDField: grp,
+		}
+		cnt, err := m.dbProxy.Table(common.BKTableNamePropertyGroup).Find(cond).Count(ctx)
+		if err != nil {
+			blog.ErrorJSON("property group count failed, err: %s, condition: %s, rid: %s", err, cond, ctx.ReqID)
+			return changeRow, err
+		}
+		if cnt != uint64(len(objIDs)) {
+			blog.Errorf("property group invalid, objIDs: %s have %d property groups, rid: %s", objIDs, cnt, ctx.ReqID)
+			return changeRow, ctx.Error.Errorf(common.CCErrCommParamsInvalid, metadata.AttributeFieldPropertyGroup)
+		}
 	}
 
 	attribute := metadata.Attribute{}


### PR DESCRIPTION
### 优化的功能:
- 更新模型属性接口添加模型分组是否存在的校验
### 修复的问题：
- 更新和删除模型属性接口权限解析中获取objectID方式错误
