### PR TITLE
add build parameter

### DIFF
--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -10,7 +10,7 @@
     "dev": "webpack-dev-server --inline --progress --config build/webpack.dev.conf.js",
     "start": "npm run dev",
     "lint": "eslint --ext .js,.vue src",
-    "build": "node build/build.js",
+    "build": "node --max-old-space-size=2048 build/build.js",
     "sync-magicbox": "node build/sync-magicbox.js"
   },
   "dependencies": {


### PR DESCRIPTION
handle the build failure .


FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory

<--- Last few GCs --->

[88:0x522c9f0]   205791 ms: Mark-sweep 976.6 (1013.5) -> 973.7 (1015.3) MB, 1531.1 / 0.0 ms  (average mu = 0.105, current mu = 0.025) allocation failure GC in old space requested
[88:0x522c9f0]   207362 ms: Mark-sweep 976.1 (1015.3) -> 974.4 (1016.5) MB, 1541.9 / 0.0 ms  (average mu = 0.062, current mu = 0.018) allocation failure GC in old space requested


### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
