### PR TITLE
统一运营分析url规范化

### DIFF
--- a/src/apimachinery/coreservice/operation/api.go
+++ b/src/apimachinery/coreservice/operation/api.go
@@ -9,7 +9,7 @@ import (
 
 func (s *operation) SearchInstCount(ctx context.Context, h http.Header, data interface{}) (resp *metadata.CoreUint64Response, err error) {
 	resp = new(metadata.CoreUint64Response)
-	subPath := "read/operation/inst/count"
+	subPath := "/find/operation/inst/count"
 
 	err = s.client.Post().
 		WithContext(ctx).
@@ -23,7 +23,7 @@ func (s *operation) SearchInstCount(ctx context.Context, h http.Header, data int
 
 func (s *operation) SearchChartDataCommon(ctx context.Context, h http.Header, data metadata.ChartConfig) (resp *metadata.Response, err error) {
 	resp = new(metadata.Response)
-	subPath := "/read/operation/chart/data/common"
+	subPath := "/find/operation/chart/data/common"
 
 	err = s.client.Post().
 		WithContext(ctx).
@@ -63,9 +63,9 @@ func (s *operation) DeleteOperationChart(ctx context.Context, h http.Header, id 
 	return
 }
 
-func (s *operation) SearchOperationChart(ctx context.Context, h http.Header, data interface{}) (resp *metadata.SearchChartResponse, err error) {
+func (s *operation) SearchOperationCharts(ctx context.Context, h http.Header, data interface{}) (resp *metadata.SearchChartResponse, err error) {
 	resp = new(metadata.SearchChartResponse)
-	subPath := "/search/operation/chart"
+	subPath := "/findmany/operation/chart"
 
 	err = s.client.Post().
 		WithContext(ctx).
@@ -93,7 +93,7 @@ func (s *operation) UpdateOperationChart(ctx context.Context, h http.Header, dat
 
 func (s *operation) SearchTimerChartData(ctx context.Context, h http.Header, data interface{}) (resp *metadata.Response, err error) {
 	resp = new(metadata.Response)
-	subPath := "/search/operation/chart/data"
+	subPath := "/find/operation/chart/data"
 
 	err = s.client.Post().
 		WithContext(ctx).
@@ -121,7 +121,7 @@ func (s *operation) UpdateChartPosition(ctx context.Context, h http.Header, data
 
 func (s *operation) SearchChartCommon(ctx context.Context, h http.Header, data interface{}) (resp *metadata.SearchChartCommon, err error) {
 	resp = new(metadata.SearchChartCommon)
-	subPath := "/search/operation/chart/common"
+	subPath := "/find/operation/chart/common"
 
 	err = s.client.Post().
 		WithContext(ctx).

--- a/src/apimachinery/coreservice/operation/api.go
+++ b/src/apimachinery/coreservice/operation/api.go
@@ -21,9 +21,9 @@ func (s *operation) SearchInstCount(ctx context.Context, h http.Header, data int
 	return
 }
 
-func (s *operation) SearchChartDataCommon(ctx context.Context, h http.Header, data metadata.ChartConfig) (resp *metadata.Response, err error) {
+func (s *operation) SearchChartData(ctx context.Context, h http.Header, data metadata.ChartConfig) (resp *metadata.Response, err error) {
 	resp = new(metadata.Response)
-	subPath := "/find/operation/chart/data/common"
+	subPath := "/find/operation/chart/data"
 
 	err = s.client.Post().
 		WithContext(ctx).
@@ -93,7 +93,7 @@ func (s *operation) UpdateOperationChart(ctx context.Context, h http.Header, dat
 
 func (s *operation) SearchTimerChartData(ctx context.Context, h http.Header, data interface{}) (resp *metadata.Response, err error) {
 	resp = new(metadata.Response)
-	subPath := "/find/operation/chart/data"
+	subPath := "/find/operation/timer/chart/data"
 
 	err = s.client.Post().
 		WithContext(ctx).

--- a/src/apimachinery/coreservice/operation/operation.go
+++ b/src/apimachinery/coreservice/operation/operation.go
@@ -9,7 +9,7 @@ import (
 )
 
 type OperationClientInterface interface {
-	SearchChartDataCommon(ctx context.Context, h http.Header, data metadata.ChartConfig) (resp *metadata.Response, err error)
+	SearchChartData(ctx context.Context, h http.Header, data metadata.ChartConfig) (resp *metadata.Response, err error)
 	SearchInstCount(ctx context.Context, h http.Header, data interface{}) (resp *metadata.CoreUint64Response, err error)
 	CreateOperationChart(ctx context.Context, h http.Header, data interface{}) (resp *metadata.CoreUint64Response, err error)
 	SearchOperationCharts(ctx context.Context, h http.Header, data interface{}) (resp *metadata.SearchChartResponse, err error)

--- a/src/apimachinery/coreservice/operation/operation.go
+++ b/src/apimachinery/coreservice/operation/operation.go
@@ -12,7 +12,7 @@ type OperationClientInterface interface {
 	SearchChartDataCommon(ctx context.Context, h http.Header, data metadata.ChartConfig) (resp *metadata.Response, err error)
 	SearchInstCount(ctx context.Context, h http.Header, data interface{}) (resp *metadata.CoreUint64Response, err error)
 	CreateOperationChart(ctx context.Context, h http.Header, data interface{}) (resp *metadata.CoreUint64Response, err error)
-	SearchOperationChart(ctx context.Context, h http.Header, data interface{}) (resp *metadata.SearchChartResponse, err error)
+	SearchOperationCharts(ctx context.Context, h http.Header, data interface{}) (resp *metadata.SearchChartResponse, err error)
 	DeleteOperationChart(ctx context.Context, h http.Header, data string) (resp *metadata.Response, err error)
 	UpdateOperationChart(ctx context.Context, h http.Header, data interface{}) (resp *metadata.Response, err error)
 	SearchTimerChartData(ctx context.Context, h http.Header, data interface{}) (resp *metadata.Response, err error)

--- a/src/auth/parser/operationstatistics.go
+++ b/src/auth/parser/operationstatistics.go
@@ -57,7 +57,7 @@ var OperationStatisticAuthConfigs = []AuthConfig{
 	{
 		Name:           "SearchOperationStatisticChartRegex",
 		Description:    "查看运营统计图表配置",
-		Regex:          regexp.MustCompile(`^/api/v3/search/operation/chart/?$`),
+		Regex:          regexp.MustCompile(`^/api/v3/findmany/operation/chart/?$`),
 		HTTPMethod:     http.MethodGet,
 		BizIDGetter:    nil,
 		ResourceType:   meta.OperationStatistic,
@@ -66,7 +66,7 @@ var OperationStatisticAuthConfigs = []AuthConfig{
 	{
 		Name:           "SearchOperationStatisticDataRegex",
 		Description:    "查看运营统计数据",
-		Regex:          regexp.MustCompile(`^/api/v3/search/operation/chart/data/?$`),
+		Regex:          regexp.MustCompile(`^/api/v3/find/operation/chart/data/?$`),
 		HTTPMethod:     http.MethodPost,
 		BizIDGetter:    nil,
 		ResourceType:   meta.OperationStatistic,

--- a/src/scene_server/operation_server/service/operation.go
+++ b/src/scene_server/operation_server/service/operation.go
@@ -164,7 +164,7 @@ func (o *OperationServer) SearchChartData(ctx *rest.Contexts) {
 		return
 	}
 
-	result, err := o.CoreAPI.CoreService().Operation().SearchChartDataCommon(ctx.Kit.Ctx, ctx.Kit.Header, chart.Data.Info)
+	result, err := o.CoreAPI.CoreService().Operation().SearchChartData(ctx.Kit.Ctx, ctx.Kit.Header, chart.Data.Info)
 	if err != nil {
 		ctx.RespErrorCodeOnly(common.CCErrOperationGetChartDataFail, "search chart data fail, cond: %v, err: %v, rid: %v", chart.Data.Info, err, ctx.Kit.Rid)
 		return

--- a/src/scene_server/operation_server/service/operation.go
+++ b/src/scene_server/operation_server/service/operation.go
@@ -94,7 +94,7 @@ func (o *OperationServer) DeleteOperationChart(ctx *rest.Contexts) {
 func (o *OperationServer) SearchOperationChart(ctx *rest.Contexts) {
 	opt := make(map[string]interface{})
 
-	result, err := o.Engine.CoreAPI.CoreService().Operation().SearchOperationChart(ctx.Kit.Ctx, ctx.Kit.Header, opt)
+	result, err := o.Engine.CoreAPI.CoreService().Operation().SearchOperationCharts(ctx.Kit.Ctx, ctx.Kit.Header, opt)
 	if err != nil {
 		ctx.RespErrorCodeOnly(common.CCErrOperationSearchChartFail, "search operation chart fail, err: %v, rid: %v", err, ctx.Kit.Rid)
 		return

--- a/src/scene_server/operation_server/service/service.go
+++ b/src/scene_server/operation_server/service/service.go
@@ -110,8 +110,8 @@ func (o *OperationServer) newOperationService(web *restful.WebService) {
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/create/operation/chart", Handler: o.CreateOperationChart})
 	utility.AddHandler(rest.Action{Verb: http.MethodDelete, Path: "/delete/operation/chart/{id}", Handler: o.DeleteOperationChart})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/update/operation/chart", Handler: o.UpdateOperationChart})
-	utility.AddHandler(rest.Action{Verb: http.MethodGet, Path: "/search/operation/chart", Handler: o.SearchOperationChart})
-	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/search/operation/chart/data", Handler: o.SearchChartData})
+	utility.AddHandler(rest.Action{Verb: http.MethodGet, Path: "/findmany/operation/chart", Handler: o.SearchOperationChart})
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/operation/chart/data", Handler: o.SearchChartData})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/update/operation/chart/position", Handler: o.UpdateChartPosition})
 
 	utility.AddToRestfulWebService(web)

--- a/src/source_controller/coreservice/core/core.go
+++ b/src/source_controller/coreservice/core/core.go
@@ -177,7 +177,7 @@ type AuditOperation interface {
 
 type StatisticOperation interface {
 	SearchInstCount(ctx ContextParams, inputParam mapstr.MapStr) (uint64, error)
-	SearchChartDataCommon(ctx ContextParams, inputParam metadata.ChartConfig) (interface{}, error)
+	SearchChartData(ctx ContextParams, inputParam metadata.ChartConfig) (interface{}, error)
 	SearchOperationChart(ctx ContextParams, inputParam interface{}) (*metadata.ChartClassification, error)
 	CreateOperationChart(ctx ContextParams, inputParam metadata.ChartConfig) (uint64, error)
 	UpdateChartPosition(ctx ContextParams, inputParam interface{}) (interface{}, error)

--- a/src/source_controller/coreservice/core/operation/operation.go
+++ b/src/source_controller/coreservice/core/operation/operation.go
@@ -49,7 +49,7 @@ func (m *operationManager) SearchInstCount(ctx core.ContextParams, inputParam ma
 	return count, nil
 }
 
-func (m *operationManager) SearchChartDataCommon(ctx core.ContextParams, inputParam metadata.ChartConfig) (interface{}, error) {
+func (m *operationManager) SearchChartData(ctx core.ContextParams, inputParam metadata.ChartConfig) (interface{}, error) {
 	switch inputParam.ReportType {
 	case common.HostCloudChart:
 		data, err := m.HostCloudChartData(ctx, inputParam)

--- a/src/source_controller/coreservice/service/operation.go
+++ b/src/source_controller/coreservice/service/operation.go
@@ -35,14 +35,14 @@ func (s *coreService) SearchInstCount(params core.ContextParams, pathParams, que
 	return count, nil
 }
 
-func (s *coreService) SearchChartDataCommon(params core.ContextParams, pathParams, queryParams ParamsGetter, data mapstr.MapStr) (interface{}, error) {
+func (s *coreService) SearchChartData(params core.ContextParams, pathParams, queryParams ParamsGetter, data mapstr.MapStr) (interface{}, error) {
 	condition := metadata.ChartConfig{}
 	if err := data.MarshalJSONInto(&condition); err != nil {
 		blog.Errorf("search chart data fail, marshal chart config fail, err: %v, rid: %v", err, params.ReqID)
 		return nil, err
 	}
 
-	result, err := s.core.StatisticOperation().SearchChartDataCommon(params, condition)
+	result, err := s.core.StatisticOperation().SearchChartData(params, condition)
 	if err != nil {
 		return nil, err
 	}

--- a/src/source_controller/coreservice/service/service_initfunc.go
+++ b/src/source_controller/coreservice/service/service_initfunc.go
@@ -173,15 +173,15 @@ func (s *coreService) audit() {
 
 func (s *coreService) initOperation() {
 	s.addAction(http.MethodPost, "/create/operation/chart", s.CreateOperationChart, nil)
-	s.addAction(http.MethodPost, "/search/operation/chart", s.SearchChartWithPosition, nil)
+	s.addAction(http.MethodPost, "/findmany/operation/chart", s.SearchChartWithPosition, nil)
 	s.addAction(http.MethodPost, "/update/operation/chart", s.UpdateOperationChart, nil)
 	s.addAction(http.MethodDelete, "/delete/operation/chart/{id}", s.DeleteOperationChart, nil)
-	s.addAction(http.MethodPost, "/search/operation/chart/common", s.SearchChartCommon, nil)
+	s.addAction(http.MethodPost, "/find/operation/chart/common", s.SearchChartCommon, nil)
 
-	s.addAction(http.MethodPost, "/read/operation/inst/count", s.SearchInstCount, nil)
-	s.addAction(http.MethodPost, "/read/operation/chart/data/common", s.SearchChartDataCommon, nil)
+	s.addAction(http.MethodPost, "/find/operation/inst/count", s.SearchInstCount, nil)
+	s.addAction(http.MethodPost, "/find/operation/chart/data/common", s.SearchChartDataCommon, nil)
 	s.addAction(http.MethodPost, "/update/operation/chart/position", s.UpdateChartPosition, nil)
-	s.addAction(http.MethodPost, "/search/operation/chart/data", s.SearchTimerChartData, nil)
+	s.addAction(http.MethodPost, "/find/operation/chart/data", s.SearchTimerChartData, nil)
 	s.addAction(http.MethodPost, "/start/operation/chart/timer", s.TimerFreshData, nil)
 }
 

--- a/src/source_controller/coreservice/service/service_initfunc.go
+++ b/src/source_controller/coreservice/service/service_initfunc.go
@@ -179,9 +179,9 @@ func (s *coreService) initOperation() {
 	s.addAction(http.MethodPost, "/find/operation/chart/common", s.SearchChartCommon, nil)
 
 	s.addAction(http.MethodPost, "/find/operation/inst/count", s.SearchInstCount, nil)
-	s.addAction(http.MethodPost, "/find/operation/chart/data/common", s.SearchChartDataCommon, nil)
+	s.addAction(http.MethodPost, "/find/operation/chart/data", s.SearchChartData, nil)
 	s.addAction(http.MethodPost, "/update/operation/chart/position", s.UpdateChartPosition, nil)
-	s.addAction(http.MethodPost, "/find/operation/chart/data", s.SearchTimerChartData, nil)
+	s.addAction(http.MethodPost, "/find/operation/timer/chart/data", s.SearchTimerChartData, nil)
 	s.addAction(http.MethodPost, "/start/operation/chart/timer", s.TimerFreshData, nil)
 }
 

--- a/src/ui/src/store/modules/api/operation-chart.js
+++ b/src/ui/src/store/modules/api/operation-chart.js
@@ -28,7 +28,7 @@ const actions = {
      * @return {promises} promises 对象
      */
     getCountedCharts ({ commit, state, dispatch }, { params, config }) {
-        return $http.get(`search/operation/chart`, params, config)
+        return $http.get(`findmany/operation/chart`, params, config)
     },
 
     /**
@@ -40,7 +40,7 @@ const actions = {
      * @return {promises} promises 对象
      */
     getCountedChartsData ({ commit, state, dispatch }, { params, config }) {
-        return $http.post(`search/operation/chart/data`, params, config)
+        return $http.post(`find/operation/chart/data`, params, config)
     },
 
     /**


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- 命名规范，此次将operator（运营统计）部分的url从以前的“search“或”read”更正为“find”
### 修复的问题：
- xxxx
