### PR TITLE
在backbone里对无值的registerip设默认值

### DIFF
--- a/src/common/backbone/backbone.go
+++ b/src/common/backbone/backbone.go
@@ -101,7 +101,10 @@ func validateParameter(input *BackboneParameter) error {
 	if input.ConfigUpdate == nil {
 		return fmt.Errorf("service config change funcation can not be emtpy")
 	}
-
+	// to prevent other components which doesn't set it from failing
+	if input.SrvInfo.RegisterIP == "" {
+		input.SrvInfo.RegisterIP = input.SrvInfo.IP
+	}
 	return nil
 }
 


### PR DESCRIPTION
修复的问题：
- 其他第三方组件创建backbone实例时的srvinfo参数里没有设置registerip导致服务不可用

close issue #3955 