### PR TITLE
fix: 修复操作审计中选择模型下拉列表没有主机选项的bug

### DIFF
--- a/src/ui/src/views/audit/index.vue
+++ b/src/ui/src/views/audit/index.vue
@@ -164,7 +164,15 @@
                                 name: this.$t('Hosts["模块"]')
                             }]
                         })
-                    } else if (classify['bk_classification_id'] !== 'bk_host_manage') {
+                    } else if (classify['bk_classification_id'] === 'bk_host_manage') {
+                        classifications.push({
+                            name: classify['bk_classification_name'],
+                            children: [{
+                                id: 'host',
+                                name: this.$t('Hosts["主机"]')
+                            }]
+                        })
+                    } else {
                         if (classify['bk_objects'].length) {
                             let children = []
                             classify['bk_objects'].map(({bk_obj_id: bkObjId, bk_obj_name: bkObjName}) => {


### PR DESCRIPTION
### 修复的问题：
- 修复操作审计中选择模型下拉列表没有主机选项的bug
- #3970 
