### PR TITLE
fix: migrate bk enable port time encode error issue #3973

### DIFF
--- a/src/scene_server/admin_server/upgrader/y3.7.202002231026/add_bk_port_enable_property.go
+++ b/src/scene_server/admin_server/upgrader/y3.7.202002231026/add_bk_port_enable_property.go
@@ -12,14 +12,15 @@
 package y3_7_202002231026
 
 import (
-    "context"
-    "fmt"
-    "time"
+	"context"
+	"fmt"
+	"time"
 
-    "configcenter/src/common"
-    "configcenter/src/common/blog"
-    "configcenter/src/scene_server/admin_server/upgrader"
-    "configcenter/src/storage/dal"
+	"configcenter/src/common"
+	"configcenter/src/common/blog"
+	"configcenter/src/common/metadata"
+	"configcenter/src/scene_server/admin_server/upgrader"
+	"configcenter/src/storage/dal"
 )
 
 func addProcEnablePortProperty(ctx context.Context, db dal.RDB, conf *upgrader.Config) error {
@@ -63,8 +64,8 @@ func addProcEnablePortProperty(ctx context.Context, db dal.RDB, conf *upgrader.C
 		Option:        true,
 		Description:   "",
 		Creator:       common.CCSystemOperatorUserName,
-		LastTime:      &Time{Time: time.Now()},
-		CreateTime:    &Time{Time: time.Now()},
+		LastTime:      &metadata.Time{Time: time.Now()},
+		CreateTime:    &metadata.Time{Time: time.Now()},
 	}
 
 	err = db.Table(common.BKTableNameObjAttDes).Insert(ctx, addPortEnable)
@@ -141,13 +142,9 @@ type Attribute struct {
 	Option            interface{} `field:"option" json:"option" bson:"option"`
 	Description       string      `field:"description" json:"description" bson:"description"`
 
-	Creator    string `field:"creator" json:"creator" bson:"creator"`
-	CreateTime *Time  `json:"create_time" bson:"create_time"`
-	LastTime   *Time  `json:"last_time" bson:"last_time"`
-}
-
-type Time struct {
-	time.Time `bson:",inline" json:",inline"`
+	Creator    string         `field:"creator" json:"creator" bson:"creator"`
+	CreateTime *metadata.Time `json:"create_time" bson:"create_time"`
+	LastTime   *metadata.Time `json:"last_time" bson:"last_time"`
 }
 
 // Metadata  used to define the metadata for the resources


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- migrate  bk_enable_port的时候time类型字段encode错误
