### PR TITLE
删除业务自定义拓扑的同时删除集群同步状态

### DIFF
--- a/src/scene_server/topo_server/core/operation/types.go
+++ b/src/scene_server/topo_server/core/operation/types.go
@@ -75,6 +75,7 @@ type CommonInstTopoV2 struct {
 
 type deletedInst struct {
 	instID int64
+	bizID  int64
 	obj    model.Object
 }
 


### PR DESCRIPTION
### 修复的问题：
- 删除自定义业务拓扑层级后，集群模板中仍可见被删除节点下的集群实例

close  #4021