### PR TITLE
修复同步服务模版时的异常

### DIFF
--- a/src/common/metadata/process.go
+++ b/src/common/metadata/process.go
@@ -818,7 +818,7 @@ func (pt *ProcessTemplate) ExtractChangeInfo(i *Process) (mapstr.MapStr, bool) {
 			process["auto_time_gap"] = *t.AutoTimeGapSeconds.Value
 			changed = true
 		} else if t.AutoTimeGapSeconds.Value == nil && i.AutoTimeGap != nil {
-			process["auto_time_gap"] = *t.AutoTimeGapSeconds.Value
+			process["auto_time_gap"] = nil
 			changed = true
 		} else if t.AutoTimeGapSeconds.Value != nil && i.AutoTimeGap != nil && *t.AutoTimeGapSeconds.Value != *i.AutoTimeGap {
 			process["auto_time_gap"] = *t.AutoTimeGapSeconds.Value


### PR DESCRIPTION
### 修复的问题：
- 将服务模版字段清空后进行同步出现异常，实际是拉起间隔字段的空指针异常导致的问题