### PR TITLE
主机模块关系接口调整参数为空时的返回错误

### DIFF
--- a/src/scene_server/host_server/logics/host.go
+++ b/src/scene_server/host_server/logics/host.go
@@ -294,7 +294,7 @@ func (lgc *Logics) DeleteHostBusinessAttributes(ctx context.Context, hostIDArr [
 func (lgc *Logics) GetHostModuleRelation(ctx context.Context, cond metadata.HostModuleRelationRequest) (*metadata.HostConfigData, errors.CCErrorCoder) {
 
 	if cond.Empty() {
-		return nil, lgc.ccErr.CCErrorf(common.CCErrCommParamsNeedSet, common.BKAppIDField)
+		return nil, lgc.ccErr.CCError(common.CCErrCommHTTPBodyEmpty)
 	}
 
 	if cond.Page.IsIllegal() {


### PR DESCRIPTION
### 优化的功能:
- 该接口业务id可以不传，因此当接口参数传入为空时，报相应的错误