### PR TITLE
查找主机的高级筛选里支持集群、模块等模型属性值忽略大小写的模糊匹配

### DIFF
--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -144,6 +144,10 @@ const (
 	// BKDBLIKE the db operator
 	BKDBLIKE = "$regex"
 
+	// BKDBOPTIONS the db operator,used with $regex
+	// detail to see https://docs.mongodb.com/manual/reference/operator/query/regex/#op._S_options
+	BKDBOPTIONS = "$options"
+
 	// BKDBEQ the db operator
 	BKDBEQ = "$eq"
 
@@ -889,7 +893,7 @@ const (
 	//BKHTTPOwnerID = "HTTP_BLUEKING_OWNERID"
 	BKHTTPCookieLanugageKey = "blueking_language"
 	//BKSessionLanugageKey = "language"
-	BKHTTPSupplierID = "bk_supplier_id"
+	BKHTTPSupplierID     = "bk_supplier_id"
 	BKHTTPRequestAppCode = "Bk-App-Code"
 
 	// BKHTTPCCRequestID cc request id cc_request_id

--- a/src/common/paraparse/app.go
+++ b/src/common/paraparse/app.go
@@ -42,6 +42,8 @@ func ParseCommonParams(input []metadata.ConditionItem, output map[string]interfa
 		case common.BKDBLIKE:
 			regex := make(map[string]interface{})
 			regex[common.BKDBLIKE] = i.Value
+			// Case insensitivity to match upper and lower cases
+			regex[common.BKDBOPTIONS] = "i"
 			output[i.Field] = regex
 
 		case common.BKDBMULTIPLELike:
@@ -55,7 +57,7 @@ func ParseCommonParams(input []metadata.ConditionItem, output map[string]interfa
 				if !ok {
 					return fmt.Errorf("operator %s only support for string array", common.BKDBMULTIPLELike)
 				}
-				fields = append(fields, mapstr.MapStr{i.Field: mapstr.MapStr{common.BKDBLIKE: mstr}})
+				fields = append(fields, mapstr.MapStr{i.Field: mapstr.MapStr{common.BKDBLIKE: mstr, common.BKDBOPTIONS: "i"}})
 			}
 			if len(fields) != 0 {
 				// only when the fields is none empty, then the fields is valid.

--- a/src/scene_server/topo_server/service/inst_business.go
+++ b/src/scene_server/topo_server/service/inst_business.go
@@ -391,7 +391,7 @@ func handleSpecialBusinessFieldSearchCond(input map[string]interface{}, userFiel
 				output[common.BKDBOR] = exactOr
 			} else {
 				attrVal := gparams.SpecialCharChange(targetStr)
-				output[i] = map[string]interface{}{"$regex": attrVal, "$options": "i"}
+				output[i] = map[string]interface{}{common.BKDBLIKE: attrVal, common.BKDBOPTIONS: "i"}
 			}
 		default:
 			output[i] = j

--- a/src/web_server/service/object.go
+++ b/src/web_server/service/object.go
@@ -351,7 +351,7 @@ func (s *Service) SearchBusiness(c *gin.Context) {
 			query.Condition[k] = mapstr.MapStr{
 				common.BKDBLIKE: params.SpecialCharChange(field),
 				// insensitive with the character case.
-				"$options": "i",
+				common.BKDBOPTIONS: "i",
 			}
 		}
 	}


### PR DESCRIPTION
### 新加的功能:
- 查找主机的高级筛选里支持集群、模块等模型属性值忽略大小写的模糊匹配
