### PR TITLE
查询服务实例时，如果服务实例列表为空，则不进行查询

### DIFF
--- a/src/source_controller/coreservice/core/process/service_template.go
+++ b/src/source_controller/coreservice/core/process/service_template.go
@@ -290,7 +290,7 @@ func (p *processOperation) ListServiceTemplates(ctx core.ContextParams, option m
 		}
 	}
 
-	if option.ServiceTemplateIDs != nil {
+	if option.ServiceTemplateIDs != nil && len(option.ServiceTemplateIDs) != 0{
 		filter[common.BKFieldID] = map[string][]int64{
 			common.BKDBIN: option.ServiceTemplateIDs,
 		}


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- 查询服务实例时，如果服务实例列表为空，则不进行查询。 
### 修复的问题：
- xxxx
