### PR TITLE
删除主机查询时的重复操作，调整集成测试用例

### DIFF
--- a/src/scene_server/host_server/logics/hostsearch.go
+++ b/src/scene_server/host_server/logics/hostsearch.go
@@ -728,16 +728,6 @@ func (sh *searchHost) searchByHostConds() errors.CCError {
 	sh.searchedHostIDs = util.IntArrayUnique(sh.searchedHostIDs)
 	sh.searchCloudIDs = util.IntArrayUnique(sh.searchCloudIDs)
 
-	for _, host := range gResult.Data.Info {
-		hostID, err := util.GetInt64ByInterface(host[common.BKHostIDField])
-		if err != nil {
-			return err
-		}
-		sh.hostInfoArr = append(sh.hostInfoArr, hostInfoStruct{
-			hostID:   hostID,
-			hostInfo: host,
-		})
-	}
 	return nil
 }
 

--- a/src/test/host_server/host_abnormal_test.go
+++ b/src/test/host_server/host_abnormal_test.go
@@ -2142,7 +2142,7 @@ func clearData() {
 					HostIDs:       hostIds,
 				}
 				rsp1, err := hostServerClient.MoveHost2EmptyModule(context.Background(), header, input1)
-				util.RegisterResponse(rsp)
+				util.RegisterResponse(rsp1)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(rsp1.Result).To(Equal(true))
 
@@ -2152,7 +2152,7 @@ func clearData() {
 					HostIDs:       hostIds,
 				}
 				rsp2, err := hostServerClient.MoveHostToResourcePool(context.Background(), header, input2)
-				util.RegisterResponse(rsp)
+				util.RegisterResponse(rsp2)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(rsp2.Result).To(Equal(true))
 			}
@@ -2175,7 +2175,7 @@ func clearData() {
 			},
 		}
 		rsp3, err := hostServerClient.SearchHost(context.Background(), header, input3)
-		util.RegisterResponse(rsp)
+		util.RegisterResponse(rsp3)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rsp3.Result).To(Equal(true))
 		// By(fmt.Sprintf("*********bid:%v, data:%+v*******", bizId, rsp3.Data))

--- a/src/test/host_server/host_test.go
+++ b/src/test/host_server/host_test.go
@@ -1277,7 +1277,12 @@ var _ = Describe("list_hosts_topo test", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rsp.Result).To(Equal(true))
 		j, err := json.Marshal(rsp.Data)
-		Expect(j).To(MatchRegexp(fmt.Sprintf(`\{"count":2,"info":\[\{"host":\{.*"bk_host_id":%d.*\},"topo":\[\{"bk_set_id":%d,"bk_set_name":"cc_set","module":\[\{"bk_module_id":%d,"bk_module_name":"cc_module"\},\{"bk_module_id":%d,"bk_module_name":"cc_module1"\}\]\}\]\},\{"host":\{.*"bk_host_id":%d.*\}\]\}`, hostId1, setId, moduleId1, moduleId2, hostId2)))
+		Expect(j).To(MatchRegexp(`.*"count":2.*`))
+		Expect(j).To(MatchRegexp(fmt.Sprintf(`.*"bk_host_id":%d.*`, hostId1)))
+		Expect(j).To(MatchRegexp(fmt.Sprintf(`.*"bk_host_id":%d.*`, hostId2)))
+		Expect(j).To(MatchRegexp(fmt.Sprintf(`.*"bk_set_id":%d.*`, setId)))
+		Expect(j).To(MatchRegexp(fmt.Sprintf(`.*"bk_module_id":%d.*`, moduleId1)))
+		Expect(j).To(MatchRegexp(fmt.Sprintf(`.*"bk_module_id":%d.*`, moduleId2)))
 	})
 })
 


### PR DESCRIPTION
### 修复的问题：
- 删除主机查询时的重复操作,以去掉返回结果里的重复数据
- 调整主机topo集成测试用例，防止偶发的因序列化后的结构体成员顺序不同，而和正则不匹配错误