### PR TITLE
查询主机列表的接口支持传入host 的字段列表，只返回列表里的字段数

### DIFF
--- a/src/apimachinery/coreservice/host/api.go
+++ b/src/apimachinery/coreservice/host/api.go
@@ -423,10 +423,10 @@ func (h *host) GetHostModulesIDs(ctx context.Context, header http.Header, dat *m
 	return
 }
 
-func (h *host) ListHosts(ctx context.Context, header http.Header, option metadata.ListHosts) (metadata.ListHostResult, error) {
+func (h *host) ListHosts(ctx context.Context, header http.Header, option *metadata.ListHosts) (*metadata.ListHostResult, error) {
 	type Result struct {
 		metadata.BaseResp `json:",inline"`
-		Data              metadata.ListHostResult `json:"data"`
+		Data              *metadata.ListHostResult `json:"data"`
 	}
 	result := Result{}
 	subPath := "/findmany/hosts/list_hosts"

--- a/src/apimachinery/coreservice/host/host.go
+++ b/src/apimachinery/coreservice/host/host.go
@@ -59,7 +59,7 @@ type HostClientInterface interface {
 	GetHostModulesIDs(ctx context.Context, h http.Header, dat *metadata.ModuleHostConfigParams) (resp *metadata.GetHostModuleIDsResult, err error)
 
 	// search host
-	ListHosts(ctx context.Context, header http.Header, option metadata.ListHosts) (resp metadata.ListHostResult, err error)
+	ListHosts(ctx context.Context, header http.Header, option *metadata.ListHosts) (resp *metadata.ListHostResult, err error)
 
 	// update host's cloud area field
 	UpdateHostCloudAreaField(ctx context.Context, header http.Header, option metadata.UpdateHostCloudAreaFieldOption) errors.CCErrorCoder

--- a/src/common/metadata/hostserver.go
+++ b/src/common/metadata/hostserver.go
@@ -121,12 +121,48 @@ type ListHostsParameter struct {
 	SetCond            []ConditionItem           `json:"set_cond"`
 	ModuleIDs          []int64                   `json:"bk_module_ids"`
 	HostPropertyFilter *querybuilder.QueryFilter `json:"host_property_filter"`
+	HostPropertyList   []string                  `json:"host_property_list"`
 	Page               BasePage                  `json:"page"`
+}
+
+func (option ListHostsParameter) Validate() (string, error) {
+	if key, err := option.Page.Validate(false); err != nil {
+		return fmt.Sprintf("page.%s", key), err
+	}
+
+	if option.HostPropertyFilter != nil {
+		if key, err := option.HostPropertyFilter.Validate(); err != nil {
+			return fmt.Sprintf("host_property_filter.%s", key), err
+		}
+		if option.HostPropertyFilter.GetDeep() > querybuilder.HostSearchMaxDeep {
+			return "host_property_filter.rules", fmt.Errorf("exceed max query condition deepth: %d", querybuilder.HostSearchMaxDeep)
+		}
+	}
+
+	return "", nil
 }
 
 type ListHostsWithNoBizParameter struct {
 	HostPropertyFilter *querybuilder.QueryFilter `json:"host_property_filter"`
+	HostPropertyList   []string                  `json:"host_property_list"`
 	Page               BasePage                  `json:"page"`
+}
+
+func (option ListHostsWithNoBizParameter) Validate() (string, error) {
+	if key, err := option.Page.Validate(false); err != nil {
+		return fmt.Sprintf("page.%s", key), err
+	}
+
+	if option.HostPropertyFilter != nil {
+		if key, err := option.HostPropertyFilter.Validate(); err != nil {
+			return fmt.Sprintf("host_property_filter.%s", key), err
+		}
+		if option.HostPropertyFilter.GetDeep() > querybuilder.HostSearchMaxDeep {
+			return "host_property_filter.rules", fmt.Errorf("exceed max query condition deepth: %d", querybuilder.HostSearchMaxDeep)
+		}
+	}
+
+	return "", nil
 }
 
 type TimeRange struct {
@@ -139,11 +175,12 @@ type ListHosts struct {
 	SetIDs             []int64                   `json:"bk_set_ids"`
 	ModuleIDs          []int64                   `json:"bk_module_ids"`
 	HostPropertyFilter *querybuilder.QueryFilter `json:"host_property_filter"`
+	HostPropertyList   []string                  `json:"host_property_list"`
 	Page               BasePage                  `json:"page"`
 }
 
 func (option ListHosts) Validate() (string, error) {
-	if key, err := option.Page.Validate(); err != nil {
+	if key, err := option.Page.Validate(false); err != nil {
 		return fmt.Sprintf("page.%s", key), err
 	}
 

--- a/src/common/metadata/hostserver.go
+++ b/src/common/metadata/hostserver.go
@@ -121,7 +121,7 @@ type ListHostsParameter struct {
 	SetCond            []ConditionItem           `json:"set_cond"`
 	ModuleIDs          []int64                   `json:"bk_module_ids"`
 	HostPropertyFilter *querybuilder.QueryFilter `json:"host_property_filter"`
-	HostPropertyList   []string                  `json:"host_property_list"`
+	Fields             []string                  `json:"fields"`
 	Page               BasePage                  `json:"page"`
 }
 
@@ -134,8 +134,8 @@ func (option ListHostsParameter) Validate() (string, error) {
 		if key, err := option.HostPropertyFilter.Validate(); err != nil {
 			return fmt.Sprintf("host_property_filter.%s", key), err
 		}
-		if option.HostPropertyFilter.GetDeep() > querybuilder.HostSearchMaxDeep {
-			return "host_property_filter.rules", fmt.Errorf("exceed max query condition deepth: %d", querybuilder.HostSearchMaxDeep)
+		if option.HostPropertyFilter.GetDeep() > querybuilder.MaxDeep {
+			return "host_property_filter.rules", fmt.Errorf("exceed max query condition deepth: %d", querybuilder.MaxDeep)
 		}
 	}
 
@@ -144,7 +144,7 @@ func (option ListHostsParameter) Validate() (string, error) {
 
 type ListHostsWithNoBizParameter struct {
 	HostPropertyFilter *querybuilder.QueryFilter `json:"host_property_filter"`
-	HostPropertyList   []string                  `json:"host_property_list"`
+	Fields             []string                  `json:"fields"`
 	Page               BasePage                  `json:"page"`
 }
 
@@ -157,8 +157,8 @@ func (option ListHostsWithNoBizParameter) Validate() (string, error) {
 		if key, err := option.HostPropertyFilter.Validate(); err != nil {
 			return fmt.Sprintf("host_property_filter.%s", key), err
 		}
-		if option.HostPropertyFilter.GetDeep() > querybuilder.HostSearchMaxDeep {
-			return "host_property_filter.rules", fmt.Errorf("exceed max query condition deepth: %d", querybuilder.HostSearchMaxDeep)
+		if option.HostPropertyFilter.GetDeep() > querybuilder.MaxDeep {
+			return "host_property_filter.rules", fmt.Errorf("exceed max query condition deepth: %d", querybuilder.MaxDeep)
 		}
 	}
 
@@ -175,7 +175,7 @@ type ListHosts struct {
 	SetIDs             []int64                   `json:"bk_set_ids"`
 	ModuleIDs          []int64                   `json:"bk_module_ids"`
 	HostPropertyFilter *querybuilder.QueryFilter `json:"host_property_filter"`
-	HostPropertyList   []string                  `json:"host_property_list"`
+	Fields             []string                  `json:"fields"`
 	Page               BasePage                  `json:"page"`
 }
 

--- a/src/common/metadata/page.go
+++ b/src/common/metadata/page.go
@@ -34,9 +34,11 @@ type BasePage struct {
 	Start int    `json:"start"`
 }
 
-func (page BasePage) Validate() (string, error) {
+func (page BasePage) Validate(allowNoLimit bool) (string, error) {
 	if page.Limit > common.BKMaxPageSize {
-		return "limit", fmt.Errorf("exceed max page size: %d", common.BKMaxPageSize)
+		if page.Limit != common.BKNoLimit || allowNoLimit != true {
+			return "limit", fmt.Errorf("exceed max page size: %d", common.BKMaxPageSize)
+		}
 	}
 	return "", nil
 }

--- a/src/common/querybuilder/types.go
+++ b/src/common/querybuilder/types.go
@@ -333,6 +333,7 @@ type CombinedRule struct {
 var (
 	// 嵌套层级的深度按树的高度计算，查询条件最大深度为3即最多嵌套2层
 	MaxDeep = 3
+	HostSearchMaxDeep = 3
 )
 
 func (r CombinedRule) GetDeep() int {

--- a/src/common/querybuilder/types.go
+++ b/src/common/querybuilder/types.go
@@ -126,12 +126,12 @@ var SupportOperators = map[Operator]bool{
 	OperatorIsNull:    false,
 	OperatorIsNotNull: false,
 
-	OperatorExist:    false,
+	OperatorExist:    true,
 	OperatorNotExist: false,
 }
 
 func (op Operator) Validate() error {
-	if support, ok := SupportOperators[op]; support == false || ok == false {
+	if support, ok := SupportOperators[op]; !support || !ok {
 		return fmt.Errorf("unsupported operator: %s", op)
 	}
 	return nil
@@ -163,11 +163,11 @@ func (r AtomRule) Validate() (string, error) {
 
 var (
 	// TODO: should we support dot field separator here?
-	ValidFieldPattern = regexp.MustCompile(`^[a-zA-Z][\d\w\-_.]*$`)
+	ValidFieldPattern = regexp.MustCompile(`^[a-zA-Z0-9][\d\w\-_.]*$`)
 )
 
 func (r AtomRule) validateField() error {
-	if ValidFieldPattern.MatchString(r.Field) == false {
+	if !ValidFieldPattern.MatchString(r.Field) {
 		return fmt.Errorf("invalid field: %s", r.Field)
 	}
 	return nil
@@ -332,8 +332,7 @@ type CombinedRule struct {
 
 var (
 	// 嵌套层级的深度按树的高度计算，查询条件最大深度为3即最多嵌套2层
-	MaxDeep = 3
-	HostSearchMaxDeep = 3
+	MaxDeep           = 3
 )
 
 func (r CombinedRule) GetDeep() int {
@@ -354,9 +353,6 @@ func (r CombinedRule) Validate() (string, error) {
 	if r.Rules == nil || len(r.Rules) == 0 {
 		return "rules", fmt.Errorf("combined rules shouldn't be empty")
 	}
-	if r.GetDeep() > MaxDeep {
-		return "rules", fmt.Errorf("exceed max query condition deepth: %d", MaxDeep)
-	}
 	for idx, rule := range r.Rules {
 		if key, err := rule.Validate(); err != nil {
 			return fmt.Sprintf("rules[%d].%s", idx, key), err
@@ -371,9 +367,6 @@ func (r CombinedRule) ToMgo() (mgoFilter map[string]interface{}, key string, err
 	}
 	if r.Rules == nil || len(r.Rules) == 0 {
 		return nil, "rules", fmt.Errorf("combined rules shouldn't be empty")
-	}
-	if r.GetDeep() > MaxDeep {
-		return nil, "rules", fmt.Errorf("exceed max query condition deepth: %d", MaxDeep)
 	}
 	filters := make([]map[string]interface{}, 0)
 	for idx, rule := range r.Rules {

--- a/src/scene_server/host_server/service/findhost.go
+++ b/src/scene_server/host_server/service/findhost.go
@@ -66,7 +66,7 @@ func (s *Service) ListBizHosts(req *restful.Request, resp *restful.Response) {
 		return
 	}
 	if key, err := parameter.Validate(); err != nil {
-		blog.ErrorJSON("ListBizHosts failed, decode body failed,parameter:%s, err: %#v, rid:%s", parameter, err, srvData.rid)
+		blog.ErrorJSON("ListBizHosts failed, Validate failed,parameter:%s, err: %s, rid:%s", parameter, err, srvData.rid)
 		ccErr := srvData.ccErr.CCErrorf(common.CCErrCommParamsInvalid, key)
 		_ = resp.WriteError(http.StatusBadRequest, &meta.RespError{Msg: ccErr})
 		return
@@ -125,7 +125,7 @@ func (s *Service) listBizHosts(header http.Header, bizID int64, parameter meta.L
 		SetIDs:             setIDs,
 		ModuleIDs:          parameter.ModuleIDs,
 		HostPropertyFilter: parameter.HostPropertyFilter,
-		HostPropertyList:   parameter.HostPropertyList,
+		Fields:             parameter.Fields,
 		Page:               parameter.Page,
 	}
 	hostResult, err := s.CoreAPI.CoreService().Host().ListHosts(ctx, header, option)
@@ -158,7 +158,7 @@ func (s *Service) ListHostsWithNoBiz(req *restful.Request, resp *restful.Respons
 	}
 	option := &meta.ListHosts{
 		HostPropertyFilter: parameter.HostPropertyFilter,
-		HostPropertyList:   parameter.HostPropertyList,
+		Fields:             parameter.Fields,
 		Page:               parameter.Page,
 	}
 	host, err := s.CoreAPI.CoreService().Host().ListHosts(ctx, header, option)
@@ -187,7 +187,7 @@ func (s *Service) ListBizHostsTopo(req *restful.Request, resp *restful.Response)
 		return
 	}
 	if key, err := parameter.Validate(); err != nil {
-		blog.ErrorJSON("ListHostByTopoNode failed, decode body failed,parameter:%s, err: %#v, rid:%s", parameter, err, srvData.rid)
+		blog.ErrorJSON("ListHostByTopoNode failed, Validate failed,parameter:%s, err: %s, rid:%s", parameter, err, srvData.rid)
 		ccErr := srvData.ccErr.CCErrorf(common.CCErrCommParamsInvalid, key)
 		_ = resp.WriteError(http.StatusBadRequest, &meta.RespError{Msg: ccErr})
 		return
@@ -212,7 +212,7 @@ func (s *Service) ListBizHostsTopo(req *restful.Request, resp *restful.Response)
 	option := &meta.ListHosts{
 		BizID:              bizID,
 		HostPropertyFilter: parameter.HostPropertyFilter,
-		HostPropertyList:   parameter.HostPropertyList,
+		Fields:             parameter.Fields,
 		Page:               parameter.Page,
 	}
 	hosts, err := s.CoreAPI.CoreService().Host().ListHosts(ctx, header, option)
@@ -277,7 +277,7 @@ func (s *Service) ListBizHostsTopo(req *restful.Request, resp *restful.Response)
 	}
 	sets, err := s.CoreAPI.CoreService().Instance().ReadInstance(ctx, header, common.BKInnerObjIDSet, query)
 	if err != nil {
-		blog.ErrorJSON("get set by condition: %s failed, err: %+v, rid: %s", cond.ToMapStr(), err, rid)
+		blog.ErrorJSON("get set by condition: %s failed, err: %s, rid: %s", cond.ToMapStr(), err, rid)
 		_ = resp.WriteError(http.StatusInternalServerError, &meta.RespError{Msg: err})
 		return
 	}
@@ -306,7 +306,7 @@ func (s *Service) ListBizHostsTopo(req *restful.Request, resp *restful.Response)
 	}
 	modules, err := s.CoreAPI.CoreService().Instance().ReadInstance(ctx, header, common.BKInnerObjIDModule, query)
 	if err != nil {
-		blog.ErrorJSON("get module by condition: %s failed, err: %+v, rid: %s", cond.ToMapStr(), err, rid)
+		blog.ErrorJSON("get module by condition: %s failed, err: %s, rid: %s", cond.ToMapStr(), err, rid)
 		_ = resp.WriteError(http.StatusInternalServerError, &meta.RespError{Msg: err})
 		return
 	}

--- a/src/source_controller/coreservice/core/host/searcher/searcher.go
+++ b/src/source_controller/coreservice/core/host/searcher/searcher.go
@@ -36,11 +36,6 @@ func New(db dal.RDB, cache *redis.Client) Searcher {
 	}
 }
 
-// host properties which must return
-var hostPropertiesNeed = map[string]bool{
-	common.BKHostIDField: true,
-}
-
 // ListHosts search host with topo node info and host property
 func (s *Searcher) ListHosts(ctx context.Context, option metadata.ListHosts) (searchResult *metadata.ListHostResult, err error) {
 	rid := util.ExtractRequestIDFromContext(ctx)
@@ -113,23 +108,7 @@ func (s *Searcher) ListHosts(ctx context.Context, option metadata.ListHosts) (se
 
 	limit := uint64(option.Page.Limit)
 	start := uint64(option.Page.Start)
-	query := s.DbProxy.Table(common.BKTableNameBaseHost).Find(finalFilter).Limit(limit).Start(start)
-
-	fields := option.HostPropertyList
-	if len(fields) != 0 {
-		// add host properties which must return if not exist in request param
-		fieldsMap := map[string]bool{}
-		for _, property := range fields {
-			fieldsMap[property] = true
-		}
-		for property := range hostPropertiesNeed {
-			if _, ok := fieldsMap[property]; !ok {
-				fields = append(fields, property)
-			}
-		}
-	}
-	query.Fields(fields...)
-
+	query := s.DbProxy.Table(common.BKTableNameBaseHost).Find(finalFilter).Limit(limit).Start(start).Fields(option.Fields...)
 	if len(option.Page.Sort) > 0 {
 		query = query.Sort(option.Page.Sort)
 	} else {

--- a/src/test/host_server/host_abnormal_test.go
+++ b/src/test/host_server/host_abnormal_test.go
@@ -951,7 +951,7 @@ var _ = Describe("host abnormal test", func() {
 				},
 			}
 			rsp1, err := hostServerClient.SearchHost(context.Background(), header, input1)
-			util.RegisterResponse(rsp)
+			util.RegisterResponse(rsp1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rsp1.Result).To(Equal(true))
 			Expect(rsp1.Data.Count).To(Equal(1))
@@ -996,7 +996,7 @@ var _ = Describe("host abnormal test", func() {
 				},
 			}
 			rsp1, err := hostServerClient.SearchHost(context.Background(), header, input1)
-			util.RegisterResponse(rsp)
+			util.RegisterResponse(rsp1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rsp1.Result).To(Equal(true))
 			Expect(rsp1.Data.Count).To(Equal(2))
@@ -1039,7 +1039,7 @@ var _ = Describe("host abnormal test", func() {
 				},
 			}
 			rsp1, err := hostServerClient.SearchHost(context.Background(), header, input1)
-			util.RegisterResponse(rsp)
+			util.RegisterResponse(rsp1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rsp1.Result).To(Equal(true))
 			Expect(rsp1.Data.Count).To(Equal(0))
@@ -1282,7 +1282,7 @@ var _ = Describe("host abnormal test", func() {
 				},
 			}
 			rsp1, err := hostServerClient.SearchHost(context.Background(), header, input1)
-			util.RegisterResponse(rsp)
+			util.RegisterResponse(rsp1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rsp1.Result).To(Equal(true))
 			Expect(rsp1.Data.Count).To(Equal(2))
@@ -1394,7 +1394,7 @@ var _ = Describe("host abnormal test", func() {
 				},
 			}
 			rsp1, err := hostServerClient.SearchHost(context.Background(), header, input1)
-			util.RegisterResponse(rsp)
+			util.RegisterResponse(rsp1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rsp1.Result).To(Equal(true))
 			Expect(rsp1.Data.Count).To(Equal(2))
@@ -1433,7 +1433,7 @@ var _ = Describe("host abnormal test", func() {
 				},
 			}
 			rsp1, err := hostServerClient.SearchHost(context.Background(), header, input1)
-			util.RegisterResponse(rsp)
+			util.RegisterResponse(rsp1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rsp1.Result).To(Equal(true))
 			Expect(rsp1.Data.Count).To(Equal(3))
@@ -1723,7 +1723,7 @@ var _ = Describe("host abnormal test", func() {
 				},
 			}
 			rsp1, err := hostServerClient.SearchHost(context.Background(), header, input1)
-			util.RegisterResponse(rsp)
+			util.RegisterResponse(rsp1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rsp1.Result).To(Equal(true))
 			Expect(rsp1.Data.Count).To(Equal(2))
@@ -1906,7 +1906,7 @@ var _ = Describe("host abnormal test", func() {
 			Expect(rsp.Result).To(Equal(true))
 
 			rsp1, err := hostServerClient.GetHostInstanceProperties(context.Background(), "0", strconv.FormatInt(hostId1, 10), header)
-			util.RegisterResponse(rsp)
+			util.RegisterResponse(rsp1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rsp1.Result).To(Equal(true))
 			for _, data := range rsp1.Data {
@@ -1961,7 +1961,7 @@ var _ = Describe("host abnormal test", func() {
 			Expect(rsp.Result).To(Equal(false))
 
 			rsp1, err := hostServerClient.GetHostInstanceProperties(context.Background(), "0", strconv.FormatInt(hostId4, 10), header)
-			util.RegisterResponse(rsp)
+			util.RegisterResponse(rsp1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rsp1.Result).To(Equal(true))
 		})
@@ -1977,7 +1977,7 @@ var _ = Describe("host abnormal test", func() {
 			Expect(rsp.Result).To(Equal(false))
 
 			rsp1, err := hostServerClient.GetHostInstanceProperties(context.Background(), "0", strconv.FormatInt(hostId4, 10), header)
-			util.RegisterResponse(rsp)
+			util.RegisterResponse(rsp1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rsp1.Result).To(Equal(false))
 		})
@@ -2012,7 +2012,7 @@ func prepareData() {
 		},
 	}
 	rsp1, err := hostServerClient.SearchHost(context.Background(), header, input1)
-	util.RegisterResponse(rsp)
+	util.RegisterResponse(rsp1)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(rsp1.Result).To(Equal(true))
 	Expect(rsp1.Data.Count).To(Equal(2))
@@ -2034,7 +2034,7 @@ func prepareData() {
 		},
 	}
 	rsp2, err := hostServerClient.AddHost(context.Background(), header, input2)
-	util.RegisterResponse(rsp)
+	util.RegisterResponse(rsp2)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(rsp2.Result).To(Equal(true))
 
@@ -2045,7 +2045,7 @@ func prepareData() {
 		},
 	}
 	rsp3, err := hostServerClient.SearchHost(context.Background(), header, input3)
-	util.RegisterResponse(rsp)
+	util.RegisterResponse(rsp3)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(rsp3.Result).To(Equal(true))
 	Expect(rsp3.Data.Count).To(Equal(2))
@@ -2061,10 +2061,10 @@ func prepareData() {
 			},
 		},
 	}
-	rs4, err := hostServerClient.AddHost(context.Background(), header, input4)
-	util.RegisterResponse(rsp)
+	rsp4, err := hostServerClient.AddHost(context.Background(), header, input4)
+	util.RegisterResponse(rsp4)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(rs4.Result).To(Equal(true))
+	Expect(rsp4.Result).To(Equal(true))
 
 	//查看资源池中的主机数量
 	input5 := &params.HostCommonSearch{
@@ -2087,7 +2087,7 @@ func prepareData() {
 		},
 	}
 	rsp5, err := hostServerClient.SearchHost(context.Background(), header, input5)
-	util.RegisterResponse(rsp)
+	util.RegisterResponse(rsp5)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(rsp5.Result).To(Equal(true))
 	data := rsp5.Data.Info[0]["host"].(map[string]interface{})
@@ -2126,7 +2126,7 @@ func clearData() {
 					HostID:        hostIds,
 				}
 				rsp1, err := hostServerClient.MoveHost2EmptyModule(context.Background(), header, input1)
-				util.RegisterResponse(rsp)
+				util.RegisterResponse(rsp1)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(rsp1.Result).To(Equal(true))
 
@@ -2136,7 +2136,7 @@ func clearData() {
 					HostID:        hostIds,
 				}
 				rsp2, err := hostServerClient.MoveHostToResourcePool(context.Background(), header, input2)
-				util.RegisterResponse(rsp)
+				util.RegisterResponse(rsp2)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(rsp2.Result).To(Equal(true))
 			}
@@ -2146,7 +2146,7 @@ func clearData() {
 			}
 			//By(fmt.Sprintf("*********DeleteHostBatch bid:%v, input4:%+v*******", bizId, input4))
 			rsp4, err := hostServerClient.DeleteHostBatch(context.Background(), header, input4)
-			util.RegisterResponse(rsp)
+			util.RegisterResponse(rsp4)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rsp4.Result).To(Equal(true))
 		}
@@ -2159,7 +2159,7 @@ func clearData() {
 			},
 		}
 		rsp3, err := hostServerClient.SearchHost(context.Background(), header, input3)
-		util.RegisterResponse(rsp)
+		util.RegisterResponse(rsp3)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rsp3.Result).To(Equal(true))
 		//By(fmt.Sprintf("*********bid:%v, data:%+v*******", bizId, rsp3.Data))

--- a/src/test/host_server/host_test.go
+++ b/src/test/host_server/host_test.go
@@ -1247,7 +1247,12 @@ var _ = Describe("list_hosts_topo test", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rsp.Result).To(Equal(true))
 		j, err := json.Marshal(rsp.Data)
-		Expect(j).To(MatchRegexp(fmt.Sprintf(`\{"count":2,"info":\[\{"host":\{.*"bk_host_id":%d.*\},"topo":\[\{"bk_set_id":%d,"bk_set_name":"cc_set","module":\[\{"bk_module_id":%d,"bk_module_name":"cc_module"\},\{"bk_module_id":%d,"bk_module_name":"cc_module1"\}\]\}\]\},\{"host":\{.*"bk_host_id":%d.*\}\]\}`, hostId1, setId, moduleId1, moduleId2, hostId2)))
+		Expect(j).To(MatchRegexp(`.*"count":2.*`))
+		Expect(j).To(MatchRegexp(fmt.Sprintf(`.*"bk_host_id":%d.*`, hostId1)))
+		Expect(j).To(MatchRegexp(fmt.Sprintf(`.*"bk_host_id":%d.*`, hostId2)))
+		Expect(j).To(MatchRegexp(fmt.Sprintf(`.*"bk_set_id":%d.*`, setId)))
+		Expect(j).To(MatchRegexp(fmt.Sprintf(`.*"bk_module_id":%d.*`, moduleId1)))
+		Expect(j).To(MatchRegexp(fmt.Sprintf(`.*"bk_module_id":%d.*`, moduleId2)))
 	})
 })
 


### PR DESCRIPTION
### 优化的功能:
- 查询主机列表的接口支持传入host 的字段列表，只返回列表里的字段数,以加速接口请求和减少网络流量传输

close issue #4136 