### PR TITLE
find_host_by_module接口支持传入host 的字段列表，只返回列表里的字段数

### DIFF
--- a/src/common/metadata/hostserver.go
+++ b/src/common/metadata/hostserver.go
@@ -113,6 +113,7 @@ type HostModuleFind struct {
 	ModuleIDS []int64   `json:"bk_module_ids"`
 	Metadata  *Metadata `json:"metadata"`
 	AppID     int64     `json:"bk_biz_id"`
+	Fields    []string  `json:"fields"`
 	Page      BasePage  `json:"page"`
 }
 

--- a/src/scene_server/host_server/logics/findhost.go
+++ b/src/scene_server/host_server/logics/findhost.go
@@ -27,6 +27,7 @@ func (lgc *Logics) FindHostByModuleIDs(ctx context.Context, data *metadata.HostM
 	hostSearchParam := new(metadata.HostCommonSearch)
 	hostSearchParam.Page = data.Page
 
+	hostFindCond := metadata.SearchCondition{ObjectID: common.BKInnerObjIDHost, Condition: []metadata.ConditionItem{}, Fields: data.Fields}
 	condItem := metadata.ConditionItem{Field: common.BKModuleIDField, Operator: common.BKDBIN, Value: data.ModuleIDS}
 	moduleFindCond := metadata.SearchCondition{ObjectID: common.BKInnerObjIDModule, Condition: []metadata.ConditionItem{condItem}, Fields: []string{}}
 	setFindCond := metadata.SearchCondition{ObjectID: common.BKInnerObjIDSet, Condition: []metadata.ConditionItem{}, Fields: []string{}}
@@ -45,7 +46,7 @@ func (lgc *Logics) FindHostByModuleIDs(ctx context.Context, data *metadata.HostM
 	}
 	hostSearchParam.AppID = bizID
 
-	hostSearchParam.Condition = []metadata.SearchCondition{moduleFindCond, setFindCond, bizFindCond}
+	hostSearchParam.Condition = []metadata.SearchCondition{hostFindCond, moduleFindCond, setFindCond, bizFindCond}
 
 	findHostInst := NewSearchHost(ctx, lgc, hostSearchParam)
 	findHostInst.ParseCondition()


### PR DESCRIPTION
### 优化的功能:
- find_host_by_module接口支持传入host 的字段列表，只返回列表里的字段数,加速接口请求和减少网络流量传输