### PR TITLE
datacollection 新加默认业务名配置

### DIFF
--- a/scripts/init.py
+++ b/scripts/init.py
@@ -147,6 +147,9 @@ agent_app_url = ${agent_url}/console/?app=bk_agent_setup
 authscheme = $auth_scheme
 [login]
 version=$loginVersion
+
+[biz]
+default_app_name=蓝鲸
     '''
 
     template = FileTemplate(common_file_template_str)

--- a/src/scene_server/datacollection/app/options/options.go
+++ b/src/scene_server/datacollection/app/options/options.go
@@ -52,4 +52,5 @@ type Config struct {
 	NetCollectRedis redis.Config
 	Esb             esbutil.EsbConfig
 	AuthConfig      authcenter.AuthConfig
+	DefaultAppName  string
 }

--- a/src/scene_server/datacollection/app/server.go
+++ b/src/scene_server/datacollection/app/server.go
@@ -21,6 +21,7 @@ import (
 
 	"configcenter/src/auth"
 	"configcenter/src/auth/extensions"
+	"configcenter/src/common"
 	enableauth "configcenter/src/common/auth"
 	"configcenter/src/common/backbone"
 	cc "configcenter/src/common/backbone/configcenter"
@@ -107,7 +108,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 
 		process.Service.SetDB(mgoCli)
 		process.Service.Logics = logics.NewLogics(ctx, service.Engine, mgoCli, esb)
-		datacollection := datacollection.NewDataCollection(ctx, process.Core, mgoCli, engine.Metric().Registry())
+		datacollection := datacollection.NewDataCollection(ctx, process.Core, mgoCli, engine.Metric().Registry(), process.Config.DefaultAppName)
 
 		blog.Infof("[data-collection][RUN]connecting to cc redis %+v", process.Config.CCRedis)
 		redisCli, err := redis.NewFromConfig(process.Config.CCRedis)
@@ -198,5 +199,9 @@ func (h *DCServer) onHostConfigUpdate(previous, current cc.ProcessConfig) {
 		h.Config.Esb.Addrs = current.ConfigMap[esbPrefix+".addr"]
 		h.Config.Esb.AppCode = current.ConfigMap[esbPrefix+".appCode"]
 		h.Config.Esb.AppSecret = current.ConfigMap[esbPrefix+".appSecret"]
+		h.Config.DefaultAppName = current.ConfigMap["biz.default_app_name"]
+		if h.Config.DefaultAppName == "" {
+			h.Config.DefaultAppName = common.BKAppName
+		}
 	}
 }

--- a/src/scene_server/datacollection/datacollection/datacollection.go
+++ b/src/scene_server/datacollection/datacollection/datacollection.go
@@ -34,14 +34,15 @@ import (
 
 type DataCollection struct {
 	*backbone.Engine
-	db          dal.RDB
-	ctx         context.Context
-	registry    prometheus.Registerer
-	AuthManager extensions.AuthManager
+	db             dal.RDB
+	ctx            context.Context
+	registry       prometheus.Registerer
+	AuthManager    extensions.AuthManager
+	DefaultAppName string
 }
 
-func NewDataCollection(ctx context.Context, backbone *backbone.Engine, db dal.RDB, registry prometheus.Registerer) *DataCollection {
-	return &DataCollection{ctx: ctx, Engine: backbone, db: db, registry: registry}
+func NewDataCollection(ctx context.Context, backbone *backbone.Engine, db dal.RDB, registry prometheus.Registerer, defaultAppName string) *DataCollection {
+	return &DataCollection{ctx: ctx, Engine: backbone, db: db, registry: registry, DefaultAppName: defaultAppName}
 }
 
 func (d *DataCollection) Run(redisCli, snapCli, disCli, netCli *redis.Client) error {
@@ -101,7 +102,7 @@ func (d *DataCollection) getSnapChanName(defaultAppID string) []string {
 }
 
 func (d *DataCollection) getDefaultAppID(ctx context.Context) (defaultAppID string, err error) {
-	condition := map[string]interface{}{common.BKAppNameField: common.BKAppName}
+	condition := map[string]interface{}{common.BKAppNameField: d.DefaultAppName}
 	results := make([]map[string]interface{}, 0)
 
 	if err = d.db.Table(common.BKTableNameBaseApp).Find(condition).All(ctx, &results); err != nil {


### PR DESCRIPTION
### 新加的功能:
- datacollection 新加配置文件配置，可以指定所使用的业务名，用该业务名查对应的业务ID，不指定，默认是"蓝鲸"
