### PR TITLE
fix：目前导出主机excel时，未包含自定义添加的业务拓扑层级的信息

### DIFF
--- a/src/apimachinery/toposerver/association/apis.go
+++ b/src/apimachinery/toposerver/association/apis.go
@@ -12,6 +12,7 @@
 package association
 
 import (
+	"configcenter/src/common/mapstr"
 	"context"
 	"net/http"
 
@@ -32,6 +33,7 @@ type AssociationInterface interface {
 	CreateInst(ctx context.Context, h http.Header, request *metadata.CreateAssociationInstRequest) (resp *metadata.CreateAssociationInstResult, err error)
 	DeleteInst(ctx context.Context, h http.Header, assoID int64) (resp *metadata.DeleteAssociationInstResult, err error)
 	SearchObjectAssoWithAssoKindList(ctx context.Context, h http.Header, assoKindIDs metadata.AssociationKindIDs) (resp *metadata.ListAssociationsWithAssociationKindResult, err error)
+	SearchBusinessTopo(ctx context.Context, h http.Header, bizID int64, s mapstr.MapStr) (resp *metadata.SearchBusinessTopoResult, err error)
 }
 
 func NewAssociationInterface(client rest.ClientInterface) AssociationInterface {

--- a/src/apimachinery/toposerver/association/association.go
+++ b/src/apimachinery/toposerver/association/association.go
@@ -12,6 +12,7 @@
 package association
 
 import (
+	"configcenter/src/common/mapstr"
 	"context"
 	"fmt"
 	"net/http"
@@ -186,6 +187,25 @@ func (asst *Association) SearchObjectAssoWithAssoKindList(ctx context.Context, h
 	err = asst.client.Post().
 		WithContext(ctx).
 		Body(assoKindIDs).
+		SubResource(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	return
+}
+
+func (asst *Association) SearchBusinessTopo(ctx context.Context, h http.Header, bizID int64, s mapstr.MapStr) (resp *metadata.SearchBusinessTopoResult, err error) {
+	if s == nil {
+		s := make(mapstr.MapStr)
+		s["requestID"] = "getInstTopo"
+	}
+	resp = new(metadata.SearchBusinessTopoResult)
+	subPath := fmt.Sprintf("/find/topoinst/biz/%d", bizID)
+
+	err = asst.client.Post().
+		WithContext(ctx).
+		Body(s).
 		SubResource(subPath).
 		WithHeaders(h).
 		Do().

--- a/src/common/metadata/association.go
+++ b/src/common/metadata/association.go
@@ -148,6 +148,11 @@ type ListAssociationsWithAssociationKindResult struct {
 	Data     AssociationList `json:"data"`
 }
 
+type SearchBusinessTopoResult struct {
+	BaseResp `json:",inline"`
+	Data     []*TopoInstRst `json:"data"`
+}
+
 type AssociationList struct {
 	Associations []AssociationDetail `json:"associations"`
 }


### PR DESCRIPTION
### 修复的问题：
主机信息导出时，未包含自定义添加的业务拓扑层级的信息，比如业务拓扑为四层：业务-环境-集群-模块，主机导出时没有包含环境信息。
close #4180 