### PR TITLE
ui: 修复query为空时不会调用立即执行的RouterQuery.watch的问题

### DIFF
--- a/src/ui/src/components/hosts/table/index.vue
+++ b/src/ui/src/components/hosts/table/index.vue
@@ -262,7 +262,7 @@
         },
         async created () {
             try {
-                this.unwatch = RouterQuery.watch(['ip', 'scope', 'exact', 'page', 'limit', 'condition', '_t'], ({
+                this.unwatch = RouterQuery.watch('*', ({
                     scope = '1',
                     page = 1,
                     limit = this.table.pagination.limit

--- a/src/ui/src/views/business-topology/index.vue
+++ b/src/ui/src/views/business-topology/index.vue
@@ -92,7 +92,7 @@
             }
         },
         async created () {
-            this.unwatch = RouterQuery.watch('tab', value => {
+            this.unwatch = RouterQuery.watch('tab', (value = 'hostList') => {
                 this.activeTab = value
             })
             try {


### PR DESCRIPTION
### 修复的问题：
- 修复query为空时不会调用立即执行的RouterQuery.watch的问题
