### PR TITLE
主机身份事件推送使用coreservice的cache

### DIFF
--- a/src/apimachinery/coreservice/cache/api.go
+++ b/src/apimachinery/coreservice/cache/api.go
@@ -25,6 +25,10 @@ type Interface interface {
 	SearchTopologyTree(ctx context.Context, h http.Header, opt *topo_tree.SearchOption) ([]topo_tree.Topology, error)
 	SearchHostWithInnerIP(ctx context.Context, h http.Header, opt *metadata.SearchHostWithInnerIPOption) (jsonString string, err error)
 	SearchHostWithHostID(ctx context.Context, h http.Header, opt *metadata.SearchHostWithIDOption) (jsonString string, err error)
+	SearchBusiness(ctx context.Context, h http.Header, bizID int64) (jsonString string, err error)
+	SearchSet(ctx context.Context, h http.Header, setID int64) (jsonString string, err error)
+	SearchModule(ctx context.Context, h http.Header, moduleID int64) (jsonString string, err error)
+	SearchCustomLayer(ctx context.Context, h http.Header, objID string, instID int64) (jsonString string, err error)
 }
 
 func NewCacheClient(client rest.ClientInterface) Interface {

--- a/src/apimachinery/coreservice/cache/cache.go
+++ b/src/apimachinery/coreservice/cache/cache.go
@@ -13,8 +13,8 @@
 package cache
 
 import (
-	"net/http"
 	"context"
+	"net/http"
 
 	"configcenter/src/common"
 	"configcenter/src/common/errors"
@@ -88,5 +88,73 @@ func (b *baseCache) SearchHostWithHostID(ctx context.Context, h http.Header, opt
 		return "", errors.New(resp.Code, resp.ErrMsg)
 	}
 
+	return resp.Data, nil
+}
+
+func (b *baseCache) SearchBusiness(ctx context.Context, h http.Header, bizID int64) (string, error) {
+	resp, err := b.client.Post().
+		WithContext(ctx).
+		Body(nil).
+		SubResourcef("/find/cache/biz/%d", bizID).
+		WithHeaders(h).
+		Do().
+		IntoJsonString()
+	if err != nil {
+		return "", errors.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
+	}
+	if !resp.Result {
+		return "", errors.New(resp.Code, resp.ErrMsg)
+	}
+	return resp.Data, nil
+}
+
+func (b *baseCache) SearchSet(ctx context.Context, h http.Header, setID int64) (string, error) {
+	resp, err := b.client.Post().
+		WithContext(ctx).
+		Body(nil).
+		SubResourcef("/find/cache/set/%d", setID).
+		WithHeaders(h).
+		Do().
+		IntoJsonString()
+	if err != nil {
+		return "", errors.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
+	}
+	if !resp.Result {
+		return "", errors.New(resp.Code, resp.ErrMsg)
+	}
+	return resp.Data, nil
+}
+
+func (b *baseCache) SearchModule(ctx context.Context, h http.Header, moduleID int64) (string, error) {
+	resp, err := b.client.Post().
+		WithContext(ctx).
+		Body(nil).
+		SubResourcef("/find/cache/module/%d", moduleID).
+		WithHeaders(h).
+		Do().
+		IntoJsonString()
+	if err != nil {
+		return "", errors.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
+	}
+	if !resp.Result {
+		return "", errors.New(resp.Code, resp.ErrMsg)
+	}
+	return resp.Data, nil
+}
+
+func (b *baseCache) SearchCustomLayer(ctx context.Context, h http.Header, objID string, instID int64) (string, error) {
+	resp, err := b.client.Post().
+		WithContext(ctx).
+		Body(nil).
+		SubResourcef("/find/cache/%s/%d", objID, instID).
+		WithHeaders(h).
+		Do().
+		IntoJsonString()
+	if err != nil {
+		return "", errors.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
+	}
+	if !resp.Result {
+		return "", errors.New(resp.Code, resp.ErrMsg)
+	}
 	return resp.Data, nil
 }

--- a/src/scene_server/event_server/app/server.go
+++ b/src/scene_server/event_server/app/server.go
@@ -105,7 +105,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 		}()
 
 		go func() {
-			errCh <- distribution.Start(ctx, cache, db)
+			errCh <- distribution.Start(ctx, cache, db, engine.CoreAPI)
 		}()
 
 		break

--- a/src/scene_server/event_server/distribution/start.go
+++ b/src/scene_server/event_server/distribution/start.go
@@ -15,13 +15,14 @@ package distribution
 import (
 	"context"
 
+	"configcenter/src/apimachinery"
 	"configcenter/src/scene_server/event_server/identifier"
 	"configcenter/src/storage/dal"
 
 	"gopkg.in/redis.v5"
 )
 
-func Start(ctx context.Context, cache *redis.Client, db dal.RDB) error {
+func Start(ctx context.Context, cache *redis.Client, db dal.RDB, clientSet apimachinery.ClientSetInterface) error {
 	chErr := make(chan error, 1)
 
 	eh := &EventHandler{cache: cache}
@@ -34,7 +35,7 @@ func Start(ctx context.Context, cache *redis.Client, db dal.RDB) error {
 		chErr <- dh.StartDistribute()
 	}()
 
-	ih := identifier.NewIdentifierHandler(ctx, cache, db)
+	ih := identifier.NewIdentifierHandler(ctx, cache, db, clientSet)
 	go func() {
 		chErr <- ih.Run()
 	}()

--- a/src/scene_server/event_server/identifier/hostcache.go
+++ b/src/scene_server/event_server/identifier/hostcache.go
@@ -15,129 +15,159 @@ package identifier
 import (
 	"context"
 
-	"gopkg.in/redis.v5"
-
+	"configcenter/src/apimachinery"
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/condition"
 	"configcenter/src/common/metadata"
 	"configcenter/src/common/util"
 	"configcenter/src/storage/dal"
+
+	"gopkg.in/redis.v5"
 )
 
-func fillIdentifier(identifier *metadata.HostIdentifier, ctx context.Context, cache *redis.Client, db dal.RDB) (*metadata.HostIdentifier, error) {
+func fillIdentifier(identifier *metadata.HostIdentifier, ctx context.Context, cache *redis.Client, clientSet apimachinery.ClientSetInterface, db dal.RDB) (*metadata.HostIdentifier, error) {
 	// fill cloudName
-	cloud, err := getCache(ctx, cache, db, common.BKInnerObjIDPlat, identifier.CloudID, false)
+	cloud, err := getCache(ctx, cache, clientSet, db, common.BKInnerObjIDPlat, identifier.CloudID)
 	if err != nil {
 		blog.Errorf("identifier: getCache for %s %d error %s", common.BKInnerObjIDPlat, identifier.CloudID, err.Error())
 		return nil, err
 	}
 	identifier.CloudName = getString(cloud.data[common.BKCloudNameField])
 
+	customLayers, err := getCustomLayers(ctx, db, identifier.SupplierAccount)
+	if err != nil {
+		blog.ErrorJSON("identifier: getCustomLayers error %s", err)
+		return nil, err
+	}
 	// fill module
 	for _, hostIdentModule := range identifier.HostIdentModule {
-		biz, err := getCache(ctx, cache, db, common.BKInnerObjIDApp, hostIdentModule.BizID, false)
+		err = fillModule(identifier, hostIdentModule, customLayers, ctx, cache, clientSet, db)
 		if err != nil {
-			blog.Errorf("identifier: getCache for %s %d error %s", common.BKInnerObjIDApp, hostIdentModule.BizID, err.Error())
+			blog.ErrorJSON("identifier: fillModule error %s, hostIdentModule: %s", err, hostIdentModule)
 			return nil, err
 		}
-		hostIdentModule.BizName = getString(biz.data[common.BKAppNameField])
-		identifier.SupplierAccount = getString(biz.data[common.BKOwnerIDField])
-		identifier.SupplierID, err = getInt(biz.data, common.BKSupplierIDField)
-		if err != nil {
-			blog.Errorf("identifier: convert instID failed the raw is %+v", biz.data[common.BKSupplierIDField])
-			return nil, err
-		}
-
-		set, err := getCache(ctx, cache, db, common.BKInnerObjIDSet, hostIdentModule.SetID, false)
-		if err != nil {
-			blog.Errorf("identifier: getCache for %s %d error %s", common.BKInnerObjIDSet, hostIdentModule.SetID, err.Error())
-			return nil, err
-		}
-		hostIdentModule.SetName = getString(set.data[common.BKSetNameField])
-		hostIdentModule.SetEnv = getString(set.data[common.BKSetEnvField])
-		hostIdentModule.SetStatus = getString(set.data[common.BKSetStatusField])
-
-		module, err := getCache(ctx, cache, db, common.BKInnerObjIDModule, hostIdentModule.ModuleID, false)
-		if err != nil {
-			blog.Errorf("identifier: getCache for %s %d error %s", common.BKInnerObjIDModule, hostIdentModule.ModuleID, err.Error())
-			return nil, err
-		}
-		hostIdentModule.ModuleName = getString(module.data[common.BKModuleNameField])
-
-		// fill host layer info
-		asstMap := make(map[string]string)
-		asstArr := make([]metadata.Association, 0)
-		cond := condition.CreateCondition().Field(common.AssociationKindIDField).Eq(common.AssociationKindMainline)
-		condMap := util.SetQueryOwner(cond.ToMapStr().ToMapInterface(), identifier.SupplierAccount)
-		err = db.Table(common.BKTableNameObjAsst).Find(condMap).All(ctx, &asstArr)
-		if err != nil {
-			blog.ErrorJSON("findHostLayerInfo query mainline association info error. condition:%s", condMap)
-			return nil, err
-		}
-		for _, asst := range asstArr {
-			asstMap[asst.ObjectID] = asst.AsstObjID
-		}
-
-		parentID, err := getInt(set.data, common.BKParentIDField)
-		if err != nil {
-			blog.Errorf("identifier: convert set bk_parent_id failed, the raw is %+v", set.data[common.BKParentIDField])
-			return nil, err
-		}
-
-		curObj, ok := asstMap[common.BKInnerObjIDSet]
-		if !ok {
-			continue
-		}
-
-		var layer *metadata.Layer
-		for curObj != "" && curObj != common.BKInnerObjIDApp {
-			// TODO: add event for layer to use cache, right now data are obtained from db
-			objLayer, err := getCache(ctx, cache, db, curObj, parentID, true)
-			if err != nil {
-				blog.Errorf("identifier: getCache for %s %d error %s", curObj, parentID, err.Error())
-				return nil, err
-			}
-
-			instID, err := getInt(objLayer.data, common.BKInstIDField)
-			if err != nil {
-				blog.Errorf("identifier: convert %s bk_inst_id failed, the raw is %+v", curObj, objLayer.data[common.BKInstIDField])
-				return nil, err
-			}
-
-			layer = &metadata.Layer{
-				InstID:   instID,
-				InstName: getString(objLayer.data[common.BKInstNameField]),
-				ObjID:    curObj,
-				Child:    layer,
-			}
-
-			curObj = asstMap[curObj]
-			parentID, err = getInt(objLayer.data, common.BKParentIDField)
-			if err != nil {
-				blog.Errorf("identifier: convert set bk_parent_id failed, the raw is %+v", set.data[common.BKParentIDField])
-				return nil, err
-			}
-		}
-		hostIdentModule.Layer = layer
 	}
 
 	// fill process
-	for procIndex := range identifier.Process {
-		process := &identifier.Process[procIndex]
-		proc, err := getCache(ctx, cache, db, common.BKInnerObjIDProc, process.ProcessID, false)
+	for _, process := range identifier.Process {
+		err = fillProcess(&process, ctx, cache, clientSet, db)
 		if err != nil {
-			blog.Errorf("identifier: getCache for %s %d error %s", common.BKInnerObjIDProc, process.ProcessID, err.Error())
+			blog.ErrorJSON("identifier: fillProcess error %s, process: %s", err, process)
 			return nil, err
 		}
-		process.ProcessName = getString(proc.data[common.BKProcessNameField])
-		process.FuncID = getString(proc.data[common.BKFuncIDField])
-		process.FuncName = getString(proc.data[common.BKFuncName])
-		process.BindIP = getString(proc.data[common.BKBindIP])
-		process.Protocol = getString(proc.data[common.BKProtocol])
-		process.Port = getString(proc.data[common.BKPort])
-		process.StartParamRegex = getString(proc.data[common.BKStartParamRegex])
 	}
 
 	return identifier, nil
+}
+
+func fillProcess(process *metadata.HostIdentProcess, ctx context.Context, cache *redis.Client, clientSet apimachinery.ClientSetInterface, db dal.RDB) error {
+	proc, err := getCache(ctx, cache, clientSet, db, common.BKInnerObjIDProc, process.ProcessID)
+	if err != nil {
+		blog.Errorf("identifier: getCache for %s %d error %s", common.BKInnerObjIDProc, process.ProcessID, err.Error())
+		return err
+	}
+	process.ProcessName = getString(proc.data[common.BKProcessNameField])
+	process.FuncID = getString(proc.data[common.BKFuncIDField])
+	process.FuncName = getString(proc.data[common.BKFuncName])
+	process.BindIP = getString(proc.data[common.BKBindIP])
+	process.Protocol = getString(proc.data[common.BKProtocol])
+	process.Port = getString(proc.data[common.BKPort])
+	process.StartParamRegex = getString(proc.data[common.BKStartParamRegex])
+	return nil
+}
+
+func fillModule(identifier *metadata.HostIdentifier, hostIdentModule *metadata.HostIdentModule, customLayers []string,
+	ctx context.Context, cache *redis.Client, clientSet apimachinery.ClientSetInterface, db dal.RDB) error {
+	biz, err := getCache(ctx, cache, clientSet, db, common.BKInnerObjIDApp, hostIdentModule.BizID)
+	if err != nil {
+		blog.Errorf("identifier: getCache for %s %d error %s", common.BKInnerObjIDApp, hostIdentModule.BizID, err.Error())
+		return err
+	}
+	hostIdentModule.BizName = getString(biz.data[common.BKAppNameField])
+	identifier.SupplierAccount = getString(biz.data[common.BKOwnerIDField])
+	identifier.SupplierID, err = getInt(biz.data, common.BKSupplierIDField)
+	if err != nil {
+		blog.Errorf("identifier: convert SupplierID failed the raw is %+v", biz.data[common.BKSupplierIDField])
+		return err
+	}
+
+	set, err := getCache(ctx, cache, clientSet, db, common.BKInnerObjIDSet, hostIdentModule.SetID)
+	if err != nil {
+		blog.Errorf("identifier: getCache for %s %d error %s", common.BKInnerObjIDSet, hostIdentModule.SetID, err.Error())
+		return err
+	}
+	hostIdentModule.SetName = getString(set.data[common.BKSetNameField])
+	hostIdentModule.SetEnv = getString(set.data[common.BKSetEnvField])
+	hostIdentModule.SetStatus = getString(set.data[common.BKSetStatusField])
+
+	module, err := getCache(ctx, cache, clientSet, db, common.BKInnerObjIDModule, hostIdentModule.ModuleID)
+	if err != nil {
+		blog.Errorf("identifier: getCache for %s %d error %s", common.BKInnerObjIDModule, hostIdentModule.ModuleID, err.Error())
+		return err
+	}
+	hostIdentModule.ModuleName = getString(module.data[common.BKModuleNameField])
+
+	// fill host layer info
+	parentID, err := getInt(set.data, common.BKParentIDField)
+	if err != nil {
+		blog.Errorf("identifier: convert set bk_parent_id failed, the raw is %+v", set.data[common.BKParentIDField])
+		return err
+	}
+	if len(customLayers) == 0 {
+		customLayers, err = getCustomLayers(ctx, db, identifier.SupplierAccount)
+		if err != nil {
+			blog.ErrorJSON("identifier: getCustomLayers error %s", err)
+			return err
+		}
+	}
+	var layer *metadata.Layer
+	for _, curObj := range customLayers {
+		objLayer, err := getCache(ctx, cache, clientSet, db, curObj, parentID)
+		if err != nil {
+			blog.Errorf("identifier: getCache for %s %d error %s", curObj, parentID, err.Error())
+			return err
+		}
+
+		instID, err := getInt(objLayer.data, common.BKInstIDField)
+		if err != nil {
+			blog.Errorf("identifier: convert %s bk_inst_id failed, the raw is %+v", curObj, objLayer.data[common.BKInstIDField])
+			return err
+		}
+
+		layer = &metadata.Layer{
+			InstID:   instID,
+			InstName: getString(objLayer.data[common.BKInstNameField]),
+			ObjID:    curObj,
+			Child:    layer,
+		}
+		parentID, err = getInt(objLayer.data, common.BKParentIDField)
+		if err != nil {
+			blog.Errorf("identifier: convert set bk_parent_id failed, the raw is %+v", set.data[common.BKParentIDField])
+			return err
+		}
+	}
+	hostIdentModule.Layer = layer
+	return nil
+}
+
+// get custom layer objects TODO use cache when it supports refreshing
+func getCustomLayers(ctx context.Context, db dal.RDB, supplierAccount string) ([]string, error) {
+	asstMap := make(map[string]string)
+	asstArr := make([]metadata.Association, 0)
+	cond := condition.CreateCondition().Field(common.AssociationKindIDField).Eq(common.AssociationKindMainline)
+	condMap := util.SetQueryOwner(cond.ToMapStr().ToMapInterface(), supplierAccount)
+	err := db.Table(common.BKTableNameObjAsst).Find(condMap).All(ctx, &asstArr)
+	if err != nil {
+		blog.ErrorJSON("findHostLayerInfo query mainline association info error. condition:%s", condMap)
+		return nil, err
+	}
+	for _, asst := range asstArr {
+		asstMap[asst.ObjectID] = asst.AsstObjID
+	}
+	customLayers := make([]string, 0)
+	for obj := asstMap[common.BKInnerObjIDSet]; obj != "" && obj != common.BKInnerObjIDApp; obj = asstMap[obj] {
+		customLayers = append(customLayers, obj)
+	}
+	return customLayers, err
 }

--- a/src/source_controller/coreservice/cache/business/client.go
+++ b/src/source_controller/coreservice/cache/business/client.go
@@ -75,7 +75,7 @@ func (c *Client) GetBusiness(bizID int64) (string, error) {
 		lockKey:        bizKey.detailLockKey(bizID),
 		expireKey:      bizKey.detailExpireKey(bizID),
 		expireDuration: bizKey.detailExpireDuration,
-		getDetail:      c.getModuleDetailFromMongo,
+		getDetail:      c.getBusinessFromMongo,
 	})
 
 	if exist {
@@ -179,7 +179,7 @@ func (c *Client) GetSet(setID int64) (string, error) {
 		getDetail:      c.getSetDetailFromMongo,
 	})
 
-	set, err := c.rds.Get(moduleKey.detailKey(setID)).Result()
+	set, err := c.rds.Get(setKey.detailKey(setID)).Result()
 	if err == nil && len(set) != 0 {
 		return set, nil
 	}

--- a/src/source_controller/coreservice/cache/business/client_logic.go
+++ b/src/source_controller/coreservice/cache/business/client_logic.go
@@ -493,7 +493,7 @@ func (c *Client) getCustomLevelDetail(objID string, instID int64) (string, error
 		common.BKInstIDField: instID,
 	}
 	instance := make(map[string]interface{})
-	err := c.db.Table(common.BKTableNameBaseInst).Find(filter).All(context.Background(), &instance)
+	err := c.db.Table(common.BKTableNameBaseInst).Find(filter).One(context.Background(), &instance)
 	if err != nil {
 		blog.Errorf("get custom level object: %s, inst: %d from mongodb failed, err: %v", objID, instID, err)
 		return "", err

--- a/src/source_controller/coreservice/cache/cache.go
+++ b/src/source_controller/coreservice/cache/cache.go
@@ -38,6 +38,7 @@ func NewCache(rds *redis.Client, db dal.DB, event reflector.Interface) (*ClientS
 	cache := &ClientSet{
 		Topology: topo_tree.NewTopologyTree(bizClient),
 		Host:     hostClient,
+		Business: bizClient,
 	}
 	return cache, nil
 }
@@ -45,4 +46,5 @@ func NewCache(rds *redis.Client, db dal.DB, event reflector.Interface) (*ClientS
 type ClientSet struct {
 	Topology *topo_tree.TopologyTree
 	Host     *host.Client
+	Business *business.Client
 }

--- a/src/source_controller/coreservice/service/cache.go
+++ b/src/source_controller/coreservice/service/cache.go
@@ -13,6 +13,8 @@
 package service
 
 import (
+	"strconv"
+
 	"configcenter/src/common"
 	"configcenter/src/common/http/rest"
 	"configcenter/src/common/metadata"
@@ -70,4 +72,45 @@ func (s *coreService) SearchHostWithHostIDInCache(ctx *rest.Contexts) {
 		return
 	}
 	ctx.RespString(host)
+}
+
+func (s *coreService) SearchBusinessInCache(ctx *rest.Contexts) {
+	bizID, err := strconv.ParseInt(ctx.Request.PathParameter(common.BKAppIDField), 10, 64)
+	biz, err := s.cacheSet.Business.GetBusiness(bizID)
+	if err != nil {
+		ctx.RespErrorCodeOnly(common.CCErrCommDBSelectFailed, "search biz with id in cache, but get biz failed, err: %v", err)
+		return
+	}
+	ctx.RespString(biz)
+}
+
+func (s *coreService) SearchSetInCache(ctx *rest.Contexts) {
+	setID, err := strconv.ParseInt(ctx.Request.PathParameter(common.BKSetIDField), 10, 64)
+	set, err := s.cacheSet.Business.GetSet(setID)
+	if err != nil {
+		ctx.RespErrorCodeOnly(common.CCErrCommDBSelectFailed, "search set with id in cache failed, err: %v", err)
+		return
+	}
+	ctx.RespString(set)
+}
+
+func (s *coreService) SearchModuleInCache(ctx *rest.Contexts) {
+	moduleID, err := strconv.ParseInt(ctx.Request.PathParameter(common.BKModuleIDField), 10, 64)
+	module, err := s.cacheSet.Business.GetModule(moduleID)
+	if err != nil {
+		ctx.RespErrorCodeOnly(common.CCErrCommDBSelectFailed, "search module with id in cache failed, err: %v", err)
+		return
+	}
+	ctx.RespString(module)
+}
+
+func (s *coreService) SearchCustomLayerInCache(ctx *rest.Contexts) {
+	objID := ctx.Request.PathParameter(common.BKObjIDField)
+	instID, err := strconv.ParseInt(ctx.Request.PathParameter(common.BKInstIDField), 10, 64)
+	inst, err := s.cacheSet.Business.GetCustomLevelDetail(objID, instID)
+	if err != nil {
+		ctx.RespErrorCodeOnly(common.CCErrCommDBSelectFailed, "search custom layer with id in cache failed, err: %v", err)
+		return
+	}
+	ctx.RespString(inst)
 }

--- a/src/source_controller/coreservice/service/service_initfunc.go
+++ b/src/source_controller/coreservice/service/service_initfunc.go
@@ -301,6 +301,10 @@ func (s *coreService) initCache(web *restful.WebService) {
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/cache/topotree", Handler: s.SearchTopologyTreeInCache})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/cache/host/with_inner_ip", Handler: s.SearchHostWithInnerIPInCache})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/cache/host/with_host_id", Handler: s.SearchHostWithHostIDInCache})
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/cache/biz/{bk_biz_id}", Handler: s.SearchBusinessInCache})
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/cache/set/{bk_set_id}", Handler: s.SearchSetInCache})
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/cache/module/{bk_module_id}", Handler: s.SearchModuleInCache})
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/cache/{bk_obj_id}/{bk_inst_id}", Handler: s.SearchCustomLayerInCache})
 
 	utility.AddToRestfulWebService(web)
 }


### PR DESCRIPTION
### 新加的功能:
- 添加主机身份使用的cache相关接口
### 优化的功能:
- 主机身份事件推送使用coreservice的cache
### 修复的问题：
- 修复业务和集群缓存错误的问题
- 修复自定义层级panic的问题
