### PR TITLE
主机快照在bk_cpu_mhz上下波动不超过100时判断为不变

### DIFF
--- a/src/scene_server/datacollection/datacollection/hostsnap/hostsnap.go
+++ b/src/scene_server/datacollection/datacollection/hostsnap/hostsnap.go
@@ -223,6 +223,13 @@ func needToUpdate(src, toCompare string) bool {
 	for idx := range compareFields {
 		// compare these value with string directly to avoid empty value or null value.
 		if srcElements[idx].String() != compareElements[idx].String() {
+			// tolerate bk_cpu_mhz changes less than 100
+			if compareFields[idx] == "bk_cpu_mhz" {
+				diff := srcElements[idx].Int() - compareElements[idx].Int()
+				if -100 < diff && diff < 100 {
+					continue
+				}
+			}
 			return true
 		}
 	}


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
