### PR TITLE
fix: 查询已归档业务时，忽略大小写

### DIFF
--- a/src/ui/src/views/business/archived.vue
+++ b/src/ui/src/views/business/archived.vue
@@ -159,7 +159,7 @@
                     }
                 }
                 if (this.filter.name) {
-                    params.condition.bk_biz_name = { '$regex': this.filter.name }
+                    params.condition.bk_biz_name = this.filter.name
                 }
                 return params
             },


### PR DESCRIPTION
### 修复的问题：
- 目前用户搜索查询已归档业务时，区分了大小写，这样不对；已修改为忽略大小写。

close #4250 