### PR TITLE
修复批量创建集群的空指针引用错误

### DIFF
--- a/src/scene_server/topo_server/service/inst_set.go
+++ b/src/scene_server/topo_server/service/inst_set.go
@@ -84,10 +84,14 @@ func (s *Service) BatchCreateSet(ctx *rest.Contexts) {
 			return err
 		})
 
+		errMsg := ""
+		if txnErr != nil {
+			errMsg = txnErr.Error()
+		}
 		batchCreateResult = append(batchCreateResult, OneSetCreateResult{
 			Index:    idx,
 			Data:     result,
-			ErrorMsg: txnErr.Error(),
+			ErrorMsg: errMsg,
 		})
 	}
 	ctx.RespEntityWithError(batchCreateResult, firstErr)


### PR DESCRIPTION
修复批量创建集群的空指针引用错误