### PR TITLE
optoptimize: 主机快照上报不支持IPV6, 新增对未注册到cmdb的主机快照过滤，降低缓存穿透。

### DIFF
--- a/src/common/rdapi/rdfunc.go
+++ b/src/common/rdapi/rdfunc.go
@@ -85,9 +85,9 @@ func RequestLogFilter() func(req *restful.Request, resp *restful.Response, fchai
 	return func(req *restful.Request, resp *restful.Response, fchain *restful.FilterChain) {
 		header := req.Request.Header
 		body, _ := util.PeekRequest(req.Request)
-		blog.Infof("code:%s, user:%s, rip:%s, uri:%s, body:%s, rid:%s",
-			header.Get("Bk-App-Code"), header.Get("Bk_user"), header.Get("X-Real-Ip"), 
-			req.Request.RequestURI,  body, util.GetHTTPCCRequestID(header))
+		blog.Infof("code: %s, user: %s, rip: %s, uri: %s, body: %s, rid: %s",
+			header.Get("Bk-App-Code"), header.Get("Bk_user"), header.Get("X-Real-Ip"),
+			req.Request.RequestURI, body, util.GetHTTPCCRequestID(header))
 
 		fchain.ProcessFilter(req, resp)
 		return

--- a/src/scene_server/datacollection/datacollection/hostsnap/filter.go
+++ b/src/scene_server/datacollection/datacollection/hostsnap/filter.go
@@ -1,0 +1,85 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hostsnap
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+func newFilter() *filter {
+	f := &filter{
+		pool: make(map[string]int64),
+		// 30 minutes
+		ttlSeconds: 30 * 60,
+	}
+	go f.gc()
+	return f
+}
+
+// filter is used to filter out the ip which is not register to cmdb,
+// but still report snapshot data to cmdb, this will forced us to search it 
+// from mongodb again and again, because we always can not find it in the cache.
+type filter struct {
+	lock sync.Mutex
+	// key: ip:cloud_id
+	// v: unix time for key expire ttl seconds.
+	pool map[string]int64
+	ttlSeconds int64
+}
+
+// only set the invalid ip which can not found in db.
+func (f *filter) Set(ip string, cloudID int64)  {
+	key := fmt.Sprintf("%s:%d", ip, cloudID)
+	f.lock.Lock()
+	f.pool[key]=time.Now().Unix()
+	f.lock.Unlock()
+}
+
+// if exist, then do not use this ip to search in mongodb.
+func (f *filter) Exist(ip string, cloudID int64) bool {
+	key := fmt.Sprintf("%s:%d", ip, cloudID)
+	f.lock.Lock()
+	ttl, exist := f.pool[key]
+	f.lock.Unlock()
+	
+	if !exist {
+		return false
+	}
+	
+	if time.Now().Unix() - ttl > f.ttlSeconds {
+		// force to update the cache in the next round
+		return false
+	}
+	
+	return true
+}
+
+func (f *filter) gc() {
+	for {
+		time.Sleep(time.Duration(f.ttlSeconds) * time.Second)
+		f.lock.Lock()
+		for host, ttl := range f.pool {
+			if time.Now().Unix() - ttl > f.ttlSeconds {
+				// remove from the cache.
+				delete(f.pool, host)
+			}
+		}
+		f.lock.Unlock()
+	}
+}
+
+
+
+

--- a/src/scene_server/datacollection/datacollection/hostsnap/hostsnap.go
+++ b/src/scene_server/datacollection/datacollection/hostsnap/hostsnap.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"configcenter/src/auth/extensions"
@@ -28,6 +27,7 @@ import (
 	"configcenter/src/common/auditlog"
 	"configcenter/src/common/backbone"
 	"configcenter/src/common/blog"
+	ccErr "configcenter/src/common/errors"
 	"configcenter/src/common/mapstr"
 	"configcenter/src/common/metadata"
 	"configcenter/src/common/util"
@@ -42,9 +42,9 @@ type HostSnap struct {
 	authManager extensions.AuthManager
 	*backbone.Engine
 
-	cachelock sync.RWMutex
-	ctx       context.Context
-	db        dal.RDB
+	filter *filter
+	ctx    context.Context
+	db     dal.RDB
 }
 
 func NewHostSnap(ctx context.Context, redisCli *redis.Client, db dal.RDB, engine *backbone.Engine, authManager extensions.AuthManager) *HostSnap {
@@ -54,6 +54,7 @@ func NewHostSnap(ctx context.Context, redisCli *redis.Client, db dal.RDB, engine
 		db:          db,
 		authManager: authManager,
 		Engine:      engine,
+		filter:      newFilter(),
 	}
 	return h
 }
@@ -392,6 +393,11 @@ func (h *HostSnap) getHostByVal(header http.Header, cloudID int64, ips []string,
 	}
 
 	for _, ip := range ips {
+		if h.filter.Exist(ip, cloudID) {
+			// skip the cached invalid ip which may not exist.
+			continue
+		}
+
 		opt := &metadata.SearchHostWithInnerIPOption{
 			InnerIP: ip,
 			CloudID: cloudID,
@@ -401,6 +407,11 @@ func (h *HostSnap) getHostByVal(header http.Header, cloudID int64, ips []string,
 		host, err := h.Engine.CoreAPI.CoreService().Cache().SearchHostWithInnerIP(context.Background(), header, opt)
 		if err != nil {
 			blog.Errorf("get host info with ip: %s, cloud id: %d failed, err: %v, rid: %s", ip, cloudID, err, rid)
+			if ccErr, ok := err.(ccErr.CCErrorCoder); ok {
+				if ccErr.GetCode() == common.CCErrCommDBSelectFailed {
+					h.filter.Set(ip, cloudID)
+				}
+			}
 			// do not return, continue search with next ip
 		}
 
@@ -423,7 +434,8 @@ func getIPS(val *gjson.Result) []string {
 	rootIP := val.Get("ip").String()
 	if !strings.HasPrefix(rootIP, "127.0.0.") && net.ParseIP(rootIP) != nil {
 		if strings.Contains(rootIP, ":") {
-			ipv6 = append(ipv6, rootIP)
+			// not support ipv6 for now.
+			// ipv6 = append(ipv6, rootIP)
 		} else {
 			ipv4 = append(ipv4, rootIP)
 		}
@@ -443,7 +455,8 @@ func getIPS(val *gjson.Result) []string {
 			}
 
 			if strings.Contains(ip, ":") {
-				ipv6 = append(ipv6, ip)
+				// not support ipv6 for now.
+				// ipv6 = append(ipv6, ip)
 			} else {
 				ipv4 = append(ipv4, ip)
 			}


### PR DESCRIPTION
### 优化的功能:
- 主机快照上报不支持IPV6, 新增对未注册到cmdb的主机快照过滤，降低缓存穿透。

