### PR TITLE
调整netcollector更新设备接口鉴权url的api版本

### DIFF
--- a/src/auth/parser/netcollector.go
+++ b/src/auth/parser/netcollector.go
@@ -84,7 +84,7 @@ const (
 )
 
 var (
-	updateNetDeviceRegexp = regexp.MustCompile(`/api/v1/collector/netcollect/device/[0-9]+/action/update`)
+	updateNetDeviceRegexp = regexp.MustCompile(`/api/v3/collector/netcollect/device/[0-9]+/action/update`)
 )
 
 func (ps *parseStream) netDevice() *parseStream {


### PR DESCRIPTION
### 修复的问题：
- 调整netcollector更新设备接口鉴权url的api版本
