### PR TITLE
补全进程实例与模版同步中差异对比所缺失的网管代理字段，修正获取进程实例关系的数量返回值

### DIFF
--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -471,6 +471,18 @@ const (
 	// BKProcPortEnable whether enable port,  enable port use for monitor app. default value
 	BKProcPortEnable = "bk_enable_port"
 
+	// BKProcGatewayIP the process gateway ip
+	BKProcGatewayIP = "bk_gateway_ip"
+
+	// BKProcGatewayPort the process gateway port
+	BKProcGatewayPort = "bk_gateway_port"
+
+	// BKProcGatewayProtocol the process gateway protocol
+	BKProcGatewayProtocol = "bk_gateway_protocol"
+
+	// BKProcGatewayCity the process gateway city
+	BKProcGatewayCity = "bk_gateway_city"
+
 	// BKUser the user
 	BKUser = "user"
 

--- a/src/scene_server/proc_server/logics/processinstance.go
+++ b/src/scene_server/proc_server/logics/processinstance.go
@@ -483,5 +483,61 @@ func (lgc *Logic) DiffWithProcessTemplate(t *metadata.ProcessProperty, i *metada
 		}
 	}
 
+	if metadata.IsAsDefaultValue(t.GatewayIP.AsDefaultValue) {
+		if (t.GatewayIP.Value == nil && i.GatewayIP != nil) ||
+			(t.GatewayIP.Value != nil && i.GatewayIP == nil) ||
+			(t.GatewayIP.Value != nil && i.GatewayIP != nil && *t.GatewayIP.Value != *i.GatewayIP) {
+			changes = append(changes, metadata.ProcessChangedAttribute{
+				ID:                    attrMap[common.BKProcGatewayIP].ID,
+				PropertyID:            common.BKProcGatewayIP,
+				PropertyName:          attrMap[common.BKProcGatewayIP].PropertyName,
+				PropertyValue:         i.GatewayIP,
+				TemplatePropertyValue: t.GatewayIP,
+			})
+		}
+	}
+
+	if metadata.IsAsDefaultValue(t.GatewayPort.AsDefaultValue) {
+		if (t.GatewayPort.Value == nil && i.GatewayPort != nil) ||
+			(t.GatewayPort.Value != nil && i.GatewayPort == nil) ||
+			(t.GatewayPort.Value != nil && i.GatewayPort != nil && *t.GatewayPort.Value != *i.GatewayPort) {
+			changes = append(changes, metadata.ProcessChangedAttribute{
+				ID:                    attrMap[common.BKProcGatewayPort].ID,
+				PropertyID:            common.BKProcGatewayPort,
+				PropertyName:          attrMap[common.BKProcGatewayPort].PropertyName,
+				PropertyValue:         i.GatewayPort,
+				TemplatePropertyValue: t.GatewayPort,
+			})
+		}
+	}
+
+	if metadata.IsAsDefaultValue(t.GatewayProtocol.AsDefaultValue) {
+		if (t.GatewayProtocol.Value == nil && i.GatewayProtocol != nil) ||
+			(t.GatewayProtocol.Value != nil && i.GatewayProtocol == nil) ||
+			(t.GatewayProtocol.Value != nil && i.GatewayProtocol != nil && *t.GatewayProtocol.Value != *i.GatewayProtocol) {
+			changes = append(changes, metadata.ProcessChangedAttribute{
+				ID:                    attrMap[common.BKProcGatewayProtocol].ID,
+				PropertyID:            common.BKProcGatewayProtocol,
+				PropertyName:          attrMap[common.BKProcGatewayProtocol].PropertyName,
+				PropertyValue:         i.GatewayProtocol,
+				TemplatePropertyValue: t.GatewayProtocol,
+			})
+		}
+	}
+
+	if metadata.IsAsDefaultValue(t.GatewayCity.AsDefaultValue) {
+		if (t.GatewayCity.Value == nil && i.GatewayCity != nil) ||
+			(t.GatewayCity.Value != nil && i.GatewayCity == nil) ||
+			(t.GatewayCity.Value != nil && i.GatewayCity != nil && *t.GatewayCity.Value != *i.GatewayCity) {
+			changes = append(changes, metadata.ProcessChangedAttribute{
+				ID:                    attrMap[common.BKProcGatewayCity].ID,
+				PropertyID:            common.BKProcGatewayCity,
+				PropertyName:          attrMap[common.BKProcGatewayCity].PropertyName,
+				PropertyValue:         i.GatewayCity,
+				TemplatePropertyValue: t.GatewayCity,
+			})
+		}
+	}
+
 	return changes
 }

--- a/src/source_controller/coreservice/core/process/process_instance_relation.go
+++ b/src/source_controller/coreservice/core/process/process_instance_relation.go
@@ -164,14 +164,14 @@ func (p *processOperation) ListProcessInstanceRelation(kit *rest.Kit, option met
 	blog.Debug("filter: %v", filter)
 	var total uint64
 	var err error
-	if total, err = p.dbProxy.Table(common.BKTableNameServiceTemplate).Find(filter).Count(kit.Ctx); nil != err {
-		blog.Errorf("ListServiceTemplates failed, mongodb failed, table: %s, filter: %+v, err: %+v, rid: %s", common.BKTableNameServiceTemplate, filter, err, kit.Rid)
+	if total, err = p.dbProxy.Table(common.BKTableNameProcessInstanceRelation).Find(filter).Count(kit.Ctx); nil != err {
+		blog.Errorf("ListProcessInstanceRelation failed, mongodb failed, table: %s, filter: %+v, err: %+v, rid: %s", common.BKTableNameProcessInstanceRelation, filter, err, kit.Rid)
 		return nil, kit.CCError.CCErrorf(common.CCErrCommDBSelectFailed)
 	}
 	relations := make([]metadata.ProcessInstanceRelation, 0)
-	if err := p.dbProxy.Table(common.BKTableNameProcessInstanceRelation).Find(filter).Start(
+	if err := p.dbProxy.Table(common.BKTableNameProcessInstanceRelation).Find(filter).Sort(option.Page.Sort).Start(
 		uint64(option.Page.Start)).Limit(uint64(option.Page.Limit)).All(kit.Ctx, &relations); nil != err {
-		blog.Errorf("ListServiceTemplates failed, mongodb failed, table: %s, err: %+v, rid: %s", common.BKTableNameProcessInstanceRelation, err, kit.Rid)
+		blog.Errorf("ListProcessInstanceRelation failed, mongodb failed, table: %s, err: %+v, rid: %s", common.BKTableNameProcessInstanceRelation, err, kit.Rid)
 		return nil, kit.CCError.CCErrorf(common.CCErrCommDBSelectFailed)
 	}
 


### PR DESCRIPTION
### 修复的问题：
- 补全进程实例与模版同步中差异对比所缺失的网管代理字段
- 修正获取进程实例关系的数量返回值
