### PR TITLE
放开了对“主线模型实例关联普通模型实例”的权限控制

### DIFF
--- a/src/auth/authcenter/permit/permit.go
+++ b/src/auth/authcenter/permit/permit.go
@@ -57,8 +57,7 @@ func ShouldSkipAuthorize(rsc *meta.ResourceAttribute) bool {
 	case rsc.Type == meta.ModelAssociation && IsReadAction(rsc.Action):
 		return true
 
-	// all the model instance association related operation is all authorized for now.
-	case rsc.Type == meta.ModelInstanceAssociation && IsReadAction(rsc.Action):
+	case rsc.Type == meta.ModelInstanceAssociation:
 		return true
 
 	// case rsc.Type == meta.ModelInstance && (rsc.Action == meta.Find || rsc.Action == meta.FindMany):
@@ -101,7 +100,7 @@ func ShouldSkipAuthorize(rsc *meta.ResourceAttribute) bool {
 	case rsc.Type == meta.ModelInstance && IsReadAction(rsc.Action):
 		return true
 	case rsc.Type == meta.SystemConfig:
-    return true
+		return true
 	case rsc.Type == meta.Plat && IsReadAction(rsc.Action):
 		return true
 	default:


### PR DESCRIPTION
### 修复的问题：
- 放开了对“主线模型实例关联普通模型实例”的权限控制
close #4292 
