### PR TITLE
修复导入excel更新主机时需要全局主机编辑权限的问题

### DIFF
--- a/src/auth/parser/host.go
+++ b/src/auth/parser/host.go
@@ -817,8 +817,9 @@ func (ps *parseStream) host() *parseStream {
 		ps.Attribute.Resources = []meta.ResourceAttribute{
 			meta.ResourceAttribute{
 				Basic: meta.Basic{
-					Type:   meta.HostInstance,
-					Action: meta.UpdateMany,
+					Type: meta.HostInstance,
+					// Action: meta.UpdateMany,
+					Action: meta.SkipAction,
 				},
 			},
 		}


### PR DESCRIPTION
### 修复的问题：
- 修复导入excel更新主机时需要全局主机编辑权限的问题
