### PR TITLE
fix: PANIC by global cc error object in datacollection issue #4313

### DIFF
--- a/src/scene_server/datacollection/app/server.go
+++ b/src/scene_server/datacollection/app/server.go
@@ -26,6 +26,7 @@ import (
 	"configcenter/src/common/backbone"
 	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
+	"configcenter/src/common/errors"
 	"configcenter/src/common/types"
 	"configcenter/src/scene_server/datacollection/app/options"
 	"configcenter/src/scene_server/datacollection/datacollection"
@@ -58,6 +59,9 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	if err != nil {
 		return fmt.Errorf("new backbone failed, err: %v", err)
 	}
+
+	// set global cc errors.
+	errors.SetGlobalCCError(engine.CCErr)
 
 	service.Engine = engine
 	process.Core = engine

--- a/src/test/host_server/host_test.go
+++ b/src/test/host_server/host_test.go
@@ -1337,7 +1337,7 @@ var _ = Describe("batch_update_host test", func() {
 					common.BKHostIDField: hostId2,
 					"properties": map[string]interface{}{
 						"bk_bak_operator": "admin",
-						"bk_host_outerip": "127.0.0.1",
+						"bk_host_outerip": "127.2.3.4",
 					},
 				},
 			},
@@ -1357,6 +1357,6 @@ var _ = Describe("batch_update_host test", func() {
 		Expect(searchRsp.Data.Info[0]["host"].(map[string]interface{})["bk_comment"].(string)).To(Equal("test"))
 		Expect(searchRsp.Data.Info[0]["host"].(map[string]interface{})["bk_isp_name"].(string)).To(Equal("1"))
 		Expect(searchRsp.Data.Info[1]["host"].(map[string]interface{})["bk_bak_operator"].(string)).To(Equal("admin"))
-		Expect(searchRsp.Data.Info[1]["host"].(map[string]interface{})["bk_host_outerip"].(string)).To(Equal("127.0.0.1"))
+		Expect(searchRsp.Data.Info[1]["host"].(map[string]interface{})["bk_host_outerip"].(string)).To(Equal("127.2.3.4"))
 	})
 })

--- a/src/test/host_server/host_test.go
+++ b/src/test/host_server/host_test.go
@@ -1337,7 +1337,7 @@ var _ = Describe("batch_update_host test", func() {
 					common.BKHostIDField: hostId2,
 					"properties": map[string]interface{}{
 						"bk_bak_operator": "admin",
-						"bk_host_outerip": "1.2.3.4",
+						"bk_host_outerip": "127.0.0.1",
 					},
 				},
 			},
@@ -1357,6 +1357,6 @@ var _ = Describe("batch_update_host test", func() {
 		Expect(searchRsp.Data.Info[0]["host"].(map[string]interface{})["bk_comment"].(string)).To(Equal("test"))
 		Expect(searchRsp.Data.Info[0]["host"].(map[string]interface{})["bk_isp_name"].(string)).To(Equal("1"))
 		Expect(searchRsp.Data.Info[1]["host"].(map[string]interface{})["bk_bak_operator"].(string)).To(Equal("admin"))
-		Expect(searchRsp.Data.Info[1]["host"].(map[string]interface{})["bk_host_outerip"].(string)).To(Equal("1.2.3.4"))
+		Expect(searchRsp.Data.Info[1]["host"].(map[string]interface{})["bk_host_outerip"].(string)).To(Equal("127.0.0.1"))
 	})
 })


### PR DESCRIPTION

### 修复的问题：
- 修复datacollection模块因全局CCError对象未能正确初始化产生panic的问题 
