### PR TITLE
用户创建的模型属性禁止使用"_bk_"和"bk_"前缀

### DIFF
--- a/src/source_controller/coreservice/core/model/attribute_curd.go
+++ b/src/source_controller/coreservice/core/model/attribute_curd.go
@@ -175,6 +175,12 @@ func (m *modelAttribute) checkAttributeValidity(kit *rest.Kit, attribute metadat
 			blog.Errorf("attribute.PropertyID:%s not SatisfyMongoFieldLimit", attribute.PropertyID)
 			return kit.CCError.Errorf(common.CCErrCommParamsIsInvalid, metadata.AttributeFieldPropertyID)
 		}
+
+		if !attribute.IsPre {
+			if strings.HasPrefix(attribute.PropertyID, "bk_") || strings.HasPrefix(attribute.PropertyID, "_bk") {
+				return kit.CCError.CCErrorf(common.CCErrCommParamsIsInvalid, metadata.AttributeFieldPropertyID)
+			}
+		}
 	}
 
 	if attribute.PropertyName = strings.TrimSpace(attribute.PropertyName); common.AttributeNameMaxLength < utf8.RuneCountInString(attribute.PropertyName) {


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
