### PR TITLE
fix:模型表格存在内置字段时，导入模型表格会报错。

### DIFF
--- a/src/source_controller/coreservice/core/model/attribute_curd.go
+++ b/src/source_controller/coreservice/core/model/attribute_curd.go
@@ -314,7 +314,6 @@ func (m *modelAttribute) checkUpdate(ctx core.ContextParams, data mapstr.MapStr,
 
 	// 预定义字段，只能更新分组、分组内排序、名称、单位、提示语和option
 	if hasIsPreProperty {
-		hasNotAllowField := false
 		_ = data.ForEach(func(key string, val interface{}) error {
 			if key != metadata.AttributeFieldPropertyGroup &&
 				key != metadata.AttributeFieldPropertyIndex &&
@@ -322,15 +321,10 @@ func (m *modelAttribute) checkUpdate(ctx core.ContextParams, data mapstr.MapStr,
 				key != metadata.AttributeFieldUnit &&
 				key != metadata.AttributeFieldPlaceHolder &&
 				key != metadata.AttributeFieldOption {
-				hasNotAllowField = true
+				data.Remove(key)
 			}
 			return nil
 		})
-		// 出现编辑预定义属性的字段
-		if hasNotAllowField {
-			blog.ErrorJSON("update model predefined attribute,input:%s, attr info:%s, rid:%s", cond.ToMapStr(), dbAttributeArr, ctx.ReqID)
-			return changeRow, ctx.Error.Error(common.CCErrCoreServiceNotUpdatePredefinedAttrErr)
-		}
 	}
 
 	if option, exists := data.Get(metadata.AttributeFieldOption); exists {


### PR DESCRIPTION
### 修复的问题：
- 模型表格存在内置字段时，导入模型表格会报错。
修改逻辑是，见到内置字段，丢弃就好了；其余的字段可以正常执行。
这个问题在3.8已经处理好了，本次处理3.5。
close #4347 