### PR TITLE
修复查询主机关系时fields不生效的问题，PaasDomainUrl支持URL末尾有无/的写法

### DIFF
--- a/src/source_controller/coreservice/core/host/transfer/manager.go
+++ b/src/source_controller/coreservice/core/host/transfer/manager.go
@@ -431,6 +431,7 @@ func (manager *TransferManager) GetHostModuleRelation(kit *rest.Kit, input *meta
 	hostModuleArr := make([]metadata.ModuleHost, 0)
 	db := manager.dbProxy.Table(common.BKTableNameModuleHostConfig).
 		Find(cond).
+		Fields(input.Fields...).
 		Start(uint64(input.Page.Start)).
 		Sort(input.Page.Sort)
 

--- a/src/web_server/service/index.go
+++ b/src/web_server/service/index.go
@@ -13,6 +13,8 @@
 package service
 
 import (
+	"strings"
+
 	"configcenter/src/common"
 	"configcenter/src/common/version"
 
@@ -37,6 +39,6 @@ func (s *Service) Index(c *gin.Context) {
 		"userName":       userName,
 		"agentAppUrl":    s.Config.AgentAppUrl,
 		"authCenter":     s.Config.AuthCenter,
-		"userManage":     s.Config.Site.PaasDomainUrl + "/api/c/compapi/v2/usermanage/fs_list_users/",
+		"userManage":     strings.TrimSuffix(s.Config.Site.PaasDomainUrl, "/") + "/api/c/compapi/v2/usermanage/fs_list_users/",
 	})
 }


### PR DESCRIPTION
### 优化的功能:
- PaasDomainUrl支持URL末尾有无/的写法
### 修复的问题：
- 修复查询主机关系时fields不生效的问题
