### PR TITLE
修复校验主机IP只能为数组导致升级失败的问题

### DIFF
--- a/src/storage/dal/mongo/local/mongo.go
+++ b/src/storage/dal/mongo/local/mongo.go
@@ -182,6 +182,16 @@ func (c *Mongo) Table(collName string) types.Table {
 	return &col
 }
 
+// get db client
+func (c *Mongo) GetDBClient() *mongo.Client {
+	return c.dbc
+}
+
+// get db name
+func (c *Mongo) GetDBName() string {
+	return c.dbname
+}
+
 // Collection implement client.Collection interface
 type Collection struct {
 	collName string // 集合名


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
