### PR TITLE
集群同步相关问题修改

### DIFF
--- a/src/apimachinery/coreservice/settemplate/api.go
+++ b/src/apimachinery/coreservice/settemplate/api.go
@@ -333,3 +333,25 @@ func (p *setTemplate) ListSetTemplateSyncHistory(ctx context.Context, header htt
 
 	return ret.Data, nil
 }
+
+func (p *setTemplate) ModifySetTemplateSyncStatus(ctx context.Context, header http.Header, setID int64, syncStatus metadata.SyncStatus) errors.CCErrorCoder {
+	ret := struct {
+		metadata.BaseResp
+	}{}
+	subPath := "/update/topo/set_template_sync_status/bk_set_id/%d/status/%s"
+
+	err := p.client.Put().
+		WithContext(ctx).
+		Body(nil).
+		SubResourcef(subPath, setID, syncStatus).
+		WithHeaders(header).
+		Do().
+		Into(&ret)
+
+	if err != nil {
+		blog.Errorf("UpdateSetTemplateSyncStatus failed, http request failed, err: %+v", err)
+		return errors.CCHttpError
+	}
+
+	return ret.CCError()
+}

--- a/src/apimachinery/coreservice/settemplate/settemplate.go
+++ b/src/apimachinery/coreservice/settemplate/settemplate.go
@@ -34,6 +34,7 @@ type SetTemplateInterface interface {
 	ListSetTemplateSyncStatus(ctx context.Context, header http.Header, bizID int64, option metadata.ListSetTemplateSyncStatusOption) (metadata.MultipleSetTemplateSyncStatus, errors.CCErrorCoder)
 	DeleteSetTemplateSyncStatus(ctx context.Context, header http.Header, bizID int64, setIDs []int64) errors.CCErrorCoder
 	ListSetTemplateSyncHistory(ctx context.Context, header http.Header, bizID int64, option metadata.ListSetTemplateSyncStatusOption) (metadata.MultipleSetTemplateSyncStatus, errors.CCErrorCoder)
+	ModifySetTemplateSyncStatus(ctx context.Context, header http.Header, setID int64, syncStatus metadata.SyncStatus) errors.CCErrorCoder
 }
 
 func NewSetTemplateInterfaceClient(client rest.ClientInterface) SetTemplateInterface {

--- a/src/common/http/rest/contexts.go
+++ b/src/common/http/rest/contexts.go
@@ -25,6 +25,7 @@ import (
 	"configcenter/src/common/errors"
 	"configcenter/src/common/json"
 	"configcenter/src/common/metadata"
+	"configcenter/src/common/util"
 
 	"github.com/emicklei/go-restful"
 )
@@ -316,4 +317,34 @@ func (c *Contexts) writeAsJson(resp *metadata.Response) {
 		blog.ErrorfDepthf(2, "response http request failed, err: %v, rid: %s", err, c.Kit.Rid)
 		return
 	}
+}
+
+// NewContexts 产生一个新的contexts， 一般用于在创建新的协程的时候，这个时候会对header 做处理，删除不必要的http header。
+func (c *Contexts) NewContexts() *Contexts {
+	newHeader := util.CCHeader(c.Kit.Header)
+	c.Kit.Header = newHeader
+	return &Contexts{
+		Kit:            c.Kit,
+		Request:        c.Request,
+		resp:           c.resp,
+		respStatusCode: 0,
+	}
+}
+
+// NewHeader 产生一个新的header， 一般用于在创建新的协程的时候，这个时候会对header 做处理，删除不必要的http header。
+func (c *Contexts) NewHeader() http.Header {
+	return util.CCHeader(c.Kit.Header)
+}
+
+// NewKit 产生一个新的kit， 一般用于在创建新的协程的时候，这个时候会对header 做处理，删除不必要的http header。
+func (kit *Kit) NewKit() *Kit {
+	newHeader := util.CCHeader(kit.Header)
+	newKit := *kit
+	newKit.Header = newHeader
+	return &newKit
+}
+
+// NewHeader 产生一个新的header， 一般用于在创建新的协程的时候，这个时候会对header 做处理，删除不必要的http header。
+func (kit *Kit) NewHeader() http.Header {
+	return util.CCHeader(kit.Header)
 }

--- a/src/common/lock/lock_key.go
+++ b/src/common/lock/lock_key.go
@@ -1,3 +1,15 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package lock
 
 import (
@@ -11,6 +23,9 @@ const (
 
 	// CreateModuleAttrFormat create model  attribute format
 	CreateModuleAttrFormat = "coreservice:create:model:%s:attr:%s"
+
+	// CheckSetTemplateSyncFormat  检测集群模板同步的状态
+	CheckSetTemplateSyncFormat = "topo:settemplate:sync:status:check:%d"
 )
 
 // StrFormat  build  lock key format

--- a/src/common/util/lib.go
+++ b/src/common/util/lib.go
@@ -22,6 +22,7 @@ import (
 
 	"configcenter/src/common"
 	"configcenter/src/common/errors"
+
 	"github.com/emicklei/go-restful"
 	"github.com/gin-gonic/gin"
 	"github.com/rs/xid"
@@ -198,4 +199,19 @@ func GetDefaultCCError(header http.Header) errors.DefaultCCErrorIf {
 	}
 	language := GetLanguage(header)
 	return globalCCError.CreateDefaultCCErrorIf(language)
+}
+
+func CCHeader(header http.Header) http.Header {
+	newHeader := make(http.Header, 0)
+	newHeader.Add(common.BKHTTPCCRequestID, header.Get(common.BKHTTPCCRequestID))
+	newHeader.Add(common.BKHTTPCookieLanugageKey, header.Get(common.BKHTTPCookieLanugageKey))
+	newHeader.Add(common.BKHTTPHeaderUser, header.Get(common.BKHTTPHeaderUser))
+	newHeader.Add(common.BKHTTPLanguage, header.Get(common.BKHTTPLanguage))
+	newHeader.Add(common.BKHTTPOwner, header.Get(common.BKHTTPOwner))
+	newHeader.Add(common.BKHTTPOwnerID, header.Get(common.BKHTTPOwnerID))
+	newHeader.Add(common.BKHTTPRequestAppCode, header.Get(common.BKHTTPRequestAppCode))
+	newHeader.Add(common.BKHTTPRequestRealIP, header.Get(common.BKHTTPRequestRealIP))
+	newHeader.Add(common.BKHTTPSupplierID, header.Get(common.BKHTTPSupplierID))
+
+	return newHeader
 }

--- a/src/scene_server/topo_server/app/server.go
+++ b/src/scene_server/topo_server/app/server.go
@@ -28,6 +28,7 @@ import (
 	"configcenter/src/scene_server/topo_server/app/options"
 	"configcenter/src/scene_server/topo_server/core"
 	"configcenter/src/scene_server/topo_server/service"
+	"configcenter/src/storage/driver/redis"
 	"configcenter/src/thirdpartyclient/elasticsearch"
 )
 
@@ -123,6 +124,11 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	authorize, err := authcenter.NewAuthCenter(nil, server.Config.Auth, engine.Metric().Registry())
 	if err != nil {
 		blog.Errorf("it is failed to create a new auth API, err:%s", err.Error())
+		return err
+	}
+	// TODO  redis, auth 可以在backbone 完成
+	if err := redis.InitClient("redis", &server.Config.Redis); err != nil {
+		blog.Errorf("it is failed to connect reids. err:%s", err.Error())
 		return err
 	}
 

--- a/src/scene_server/topo_server/service/set_template.go
+++ b/src/scene_server/topo_server/service/set_template.go
@@ -857,6 +857,17 @@ func (s *Service) ListSetTemplateSyncStatus(ctx *rest.Contexts) {
 		ctx.RespAutoError(err)
 		return
 	}
+
+	// 处理当前需要同步任务的状态
+	for _, info := range result.Info {
+		if !info.Status.IsFinished() {
+			go func(info metadata.SetTemplateSyncStatus) {
+				s.Core.SetTemplateOperation().TriggerCheckSetTemplateSyncingStatus(ctx.NewContexts().Kit, info.BizID, info.SetTemplateID, info.SetID)
+			}(info)
+		}
+
+	}
+
 	ctx.RespEntity(result)
 	return
 }

--- a/src/source_controller/coreservice/core/core.go
+++ b/src/source_controller/coreservice/core/core.go
@@ -267,6 +267,7 @@ type SetTemplateOperation interface {
 	ListSetTemplateSyncStatus(kit *rest.Kit, option metadata.ListSetTemplateSyncStatusOption) (metadata.MultipleSetTemplateSyncStatus, errors.CCErrorCoder)
 	ListSetTemplateSyncHistory(kit *rest.Kit, option metadata.ListSetTemplateSyncStatusOption) (metadata.MultipleSetTemplateSyncStatus, errors.CCErrorCoder)
 	DeleteSetTemplateSyncStatus(kit *rest.Kit, option metadata.DeleteSetTemplateSyncStatusOption) errors.CCErrorCoder
+	ModifySetTemplateSyncStatus(kit *rest.Kit, setID int64, sysncStatus metadata.SyncStatus) errors.CCErrorCoder
 }
 
 type HostApplyRuleOperation interface {

--- a/src/source_controller/coreservice/core/settemplate/sync_status.go
+++ b/src/source_controller/coreservice/core/settemplate/sync_status.go
@@ -120,11 +120,11 @@ func (sto *setTemplateOperation) ModifySetTemplateSyncStatus(kit *rest.Kit, setI
 	// check 数据是否存在
 	cnt, err := sto.dbProxy.Table(common.BKTableNameSetTemplateSyncStatus).Find(filter).Count(kit.Ctx)
 	if err != nil {
-		blog.Errorf("ModifyStatus failed, db upsert sync status failed, id: %d, status: %s, err: %s, rid: %s", setID, sysncStatus, err.Error(), kit.Rid)
+		blog.Errorf("ModifyStatus failed, find set template sync info error, id: %d, status: %s, err: %s, rid: %s", setID, sysncStatus, err.Error(), kit.Rid)
 		return kit.CCError.CCError(common.CCErrCommDBSelectFailed)
 	}
 	if cnt <= 0 {
-		blog.Errorf("ModifyStatus failed, db upsert sync status failed, id: %d, status: %s, err: %s, rid: %s", setID, sysncStatus, err.Error(), kit.Rid)
+		blog.Errorf("ModifyStatus failed, not find set template sync info, id: %d, status: %s, err: %s, rid: %s", setID, sysncStatus, err.Error(), kit.Rid)
 		return kit.CCError.CCError(common.CCErrCommNotFound)
 	}
 

--- a/src/source_controller/coreservice/service/service_set_template_initfunc.go
+++ b/src/source_controller/coreservice/service/service_set_template_initfunc.go
@@ -37,6 +37,7 @@ func (s *coreService) initSetTemplate(web *restful.WebService) {
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/findmany/topo/set_template_sync_status/bk_biz_id/{bk_biz_id}", Handler: s.ListSetTemplateSyncStatus})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/findmany/topo/set_template_sync_history/bk_biz_id/{bk_biz_id}", Handler: s.ListSetTemplateSyncHistory})
 	utility.AddHandler(rest.Action{Verb: http.MethodDelete, Path: "/deletemany/topo/set_template_sync_status/bk_biz_id/{bk_biz_id}", Handler: s.DeleteSetTemplateSyncStatus})
+	utility.AddHandler(rest.Action{Verb: http.MethodPut, Path: "/update/topo/set_template_sync_status/bk_set_id/{bk_set_id}/status/{status}", Handler: s.ModifySetTemplateSyncStatus})
 
 	utility.AddToRestfulWebService(web)
 }


### PR DESCRIPTION
### 新加的功能:
- 使用redis driver 初始化缓存
- 使用redis lock 对任务隔离
- 在查询集群模板同步状态的时候，执行对正在同步集群的状态更新
- 对rest.Contexts, rest.Kit 新派生新的rest.Contexts, rest.Kit 和header 对象
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx


close #4395 