### PR TITLE
v3.8.x主机快照硬盘计算优化

### DIFF
--- a/src/scene_server/datacollection/collections/hostsnap/ginkgo_parseSetter_test.go
+++ b/src/scene_server/datacollection/collections/hostsnap/ginkgo_parseSetter_test.go
@@ -1,0 +1,90 @@
+package hostsnap
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/tidwall/gjson"
+)
+const defaultjson = `{
+    "data":
+        {
+        "mem":
+            {
+            "meminfo":
+                {
+                "total":1234567891010
+                }
+            }
+        "disk":
+                {
+                "usage":[
+                     {"total":10000000000}
+                     {"total":10000000000}
+                     {"total":12345678910}
+                     {"total":10000000000}
+                     {"total":10000000000}
+                    ]
+                }
+        }
+}`
+//使用parse函数得到disk
+func getDiskFromParse(value *gjson.Result) (uint64,string){
+	setter ,str:= parseSetter(value,"127.0.0.1","0.0.0.0")
+	// 获取bk_disk字段
+	cv,ok:= setter["bk_disk"]
+	Expect(ok).To(BeTrue())
+	// 将结果转化为uint64
+	results,ok := cv.(uint64)
+	Expect(ok).To(BeTrue())
+	return results,str
+}
+//自己计算disk
+func getDiskFromSelf(value *gjson.Result) uint64{
+	var sum uint64
+	arr := value.Get("data.disk.usage.#.total").Array()
+	for _,v := range arr{
+		sum += v.Uint() >> 10 >> 10 >> 10
+	}
+	return sum
+}
+//使用parse函数得到mem
+func getMemFromParse(value *gjson.Result) (uint64,string){
+	setter ,str:= parseSetter(value,"127.0.0.1","0.0.0.0")
+	// 获取bk_disk字段
+	cv,ok:= setter["bk_mem"]
+	Expect(ok).To(BeTrue())
+	// 将结果转化为uint64
+	results,ok := cv.(uint64)
+	Expect(ok).To(BeTrue())
+	return results,str
+}
+//自己计算mem
+func getMemFromSelf(value *gjson.Result) uint64{
+	return  value.Get("data.mem.meminfo.total").Uint() >> 10 >> 10
+}
+var _ = Describe("Hostsnap", func() {
+	Context("test key-disk", func() {
+		It("", func() {
+			// 解析为gjson.Result
+			gson := gjson.Parse(defaultjson)
+			// 求出parse函数得出的结果与理论结果
+			shouldout :=getDiskFromSelf(&gson)
+			result,_ := getDiskFromParse(&gson)
+
+			Expect(shouldout).To(Equal(result))
+
+		})
+	})
+	Context("test key-mem",func(){
+		It("", func() {
+			// 解析为gjson.Result
+			gson := gjson.Parse(defaultjson)
+			// 求出parse函数得出的结果与理论结果
+			shouldout := getMemFromSelf(&gson)
+			result,_:=getMemFromParse(&gson)
+
+			Expect(shouldout).To(Equal(result))
+
+		})
+	})
+})

--- a/src/scene_server/datacollection/collections/hostsnap/ginkgo_parsesetter_test.go
+++ b/src/scene_server/datacollection/collections/hostsnap/ginkgo_parsesetter_test.go
@@ -1,3 +1,15 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package hostsnap
 
 import (
@@ -5,6 +17,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/tidwall/gjson"
 )
+
 const defaultjson = `{
     "data":
         {
@@ -27,18 +40,22 @@ const defaultjson = `{
                 }
         }
 }`
-//使用parse函数得到disk
+
+// 使用parse函数得到disk.
 func getDiskFromParse(value *gjson.Result) (uint64,string){
 	setter ,str:= parseSetter(value,"127.0.0.1","0.0.0.0")
-	// 获取bk_disk字段
+	
+	// 获取bk_disk字段.
 	cv,ok:= setter["bk_disk"]
 	Expect(ok).To(BeTrue())
-	// 将结果转化为uint64
+	
+	// 将结果转化为uint64.
 	results,ok := cv.(uint64)
 	Expect(ok).To(BeTrue())
 	return results,str
 }
-//自己计算disk
+
+// 自己计算disk.
 func getDiskFromSelf(value *gjson.Result) uint64{
 	var sum uint64
 	arr := value.Get("data.disk.usage.#.total").Array()
@@ -47,27 +64,33 @@ func getDiskFromSelf(value *gjson.Result) uint64{
 	}
 	return sum
 }
-//使用parse函数得到mem
+
+// 使用parse函数得到mem.
 func getMemFromParse(value *gjson.Result) (uint64,string){
 	setter ,str:= parseSetter(value,"127.0.0.1","0.0.0.0")
-	// 获取bk_disk字段
+	
+	// 获取bk_disk字段.
 	cv,ok:= setter["bk_mem"]
 	Expect(ok).To(BeTrue())
-	// 将结果转化为uint64
+	
+	// 将结果转化为uint64.
 	results,ok := cv.(uint64)
 	Expect(ok).To(BeTrue())
 	return results,str
 }
-//自己计算mem
+
+// 自己计算mem.
 func getMemFromSelf(value *gjson.Result) uint64{
 	return  value.Get("data.mem.meminfo.total").Uint() >> 10 >> 10
 }
+
 var _ = Describe("Hostsnap", func() {
 	Context("test key-disk", func() {
 		It("", func() {
-			// 解析为gjson.Result
+			// 解析为gjson.Result.
 			gson := gjson.Parse(defaultjson)
-			// 求出parse函数得出的结果与理论结果
+			
+			// 求出parse函数得出的结果与理论结果.
 			shouldout :=getDiskFromSelf(&gson)
 			result,_ := getDiskFromParse(&gson)
 
@@ -75,11 +98,13 @@ var _ = Describe("Hostsnap", func() {
 
 		})
 	})
+
 	Context("test key-mem",func(){
 		It("", func() {
-			// 解析为gjson.Result
+			// 解析为gjson.Result.
 			gson := gjson.Parse(defaultjson)
-			// 求出parse函数得出的结果与理论结果
+			
+			// 求出parse函数得出的结果与理论结果.
 			shouldout := getMemFromSelf(&gson)
 			result,_:=getMemFromParse(&gson)
 

--- a/src/scene_server/datacollection/collections/hostsnap/ginkgo_suite_test.go
+++ b/src/scene_server/datacollection/collections/hostsnap/ginkgo_suite_test.go
@@ -1,3 +1,15 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package hostsnap
 
 import (

--- a/src/scene_server/datacollection/collections/hostsnap/ginkgo_suite_test.go
+++ b/src/scene_server/datacollection/collections/hostsnap/ginkgo_suite_test.go
@@ -1,0 +1,13 @@
+package hostsnap
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestHostsnap(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Hostsnap Suite")
+}


### PR DESCRIPTION

### 优化的功能:
- 主机快照硬盘计算优化，让disk先计算再进行求和，否则可能溢出。
- disk和mem数据类型从int64改为uint64
### 修复的问题：
- 格式化字符串中int64数据couldID使用了%s输出，现修改为%d
