### PR TITLE
v3.5.x 主机快照硬盘计算优化

### DIFF
--- a/src/scene_server/datacollection/datacollection/hostsnap/ginkgo_parseSetter_test.go
+++ b/src/scene_server/datacollection/datacollection/hostsnap/ginkgo_parseSetter_test.go
@@ -1,0 +1,90 @@
+package hostsnap
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/tidwall/gjson"
+)
+const defaultjson = `{
+    "data":
+        {
+        "mem":
+            {
+            "meminfo":
+                {
+                "total":1234567891010
+                }
+            }
+        "disk":
+                {
+                "usage":[
+                     {"total":10000000000}
+                     {"total":10000000000}
+                     {"total":12345678910}
+                     {"total":10000000000}
+                     {"total":10000000000}
+                    ]
+                }
+        }
+}`
+//使用parse函数得到disk
+func getDiskFromParse(value *gjson.Result) uint64{
+	setter := parseSetter(value,"127.0.0.1","0.0.0.0")
+	// 获取bk_disk字段
+	cv,ok:= setter["bk_disk"]
+	Expect(ok).To(BeTrue())
+	// 将结果转化为uint64
+	results,ok := cv.(uint64)
+	Expect(ok).To(BeTrue())
+	return results
+}
+//自己计算disk
+func getDiskFromSelf(value *gjson.Result) uint64{
+	var sum uint64
+	arr := value.Get("data.disk.usage.#.total").Array()
+	for _,v := range arr{
+		sum += v.Uint() >> 10 >> 10 >> 10
+	}
+	return sum
+}
+//使用parse函数得到mem
+func getMemFromParse(value *gjson.Result) uint64{
+	setter := parseSetter(value,"127.0.0.1","0.0.0.0")
+	// 获取bk_disk字段
+	cv,ok:= setter["bk_mem"]
+	Expect(ok).To(BeTrue())
+	// 将结果转化为uint64
+	results,ok := cv.(uint64)
+	Expect(ok).To(BeTrue())
+	return results
+}
+//自己计算mem
+func getMemFromSelf(value *gjson.Result) uint64{
+	return  value.Get("data.mem.meminfo.total").Uint() >> 10 >> 10
+}
+var _ = Describe("Hostsnap", func() {
+	Context("test key-disk", func() {
+		It("", func() {
+			// 解析为gjson.Result
+			gson := gjson.Parse(defaultjson)
+			// 求出parse函数得出的结果与理论结果
+			shouldout :=getDiskFromSelf(&gson)
+			result:= getDiskFromParse(&gson)
+
+			Expect(shouldout).To(Equal(result))
+
+		})
+	})
+	Context("test key-mem",func(){
+		It("", func() {
+			// 解析为gjson.Result
+			gson := gjson.Parse(defaultjson)
+			// 求出parse函数得出的结果与理论结果
+			shouldout := getMemFromSelf(&gson)
+			result:=getMemFromParse(&gson)
+
+			Expect(shouldout).To(Equal(result))
+
+		})
+	})
+})

--- a/src/scene_server/datacollection/datacollection/hostsnap/ginkgo_parsesetter_test.go
+++ b/src/scene_server/datacollection/datacollection/hostsnap/ginkgo_parsesetter_test.go
@@ -1,3 +1,15 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package hostsnap
 
 import (
@@ -5,6 +17,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/tidwall/gjson"
 )
+
 const defaultjson = `{
     "data":
         {
@@ -27,47 +40,60 @@ const defaultjson = `{
                 }
         }
 }`
-//使用parse函数得到disk
+
+// 使用parse函数得到disk.
 func getDiskFromParse(value *gjson.Result) uint64{
 	setter := parseSetter(value,"127.0.0.1","0.0.0.0")
-	// 获取bk_disk字段
+
+	// 获取bk_disk字段.
 	cv,ok:= setter["bk_disk"]
 	Expect(ok).To(BeTrue())
-	// 将结果转化为uint64
+
+	// 将结果转化为uint64.
 	results,ok := cv.(uint64)
 	Expect(ok).To(BeTrue())
 	return results
 }
-//自己计算disk
+
+// 自己计算disk.
 func getDiskFromSelf(value *gjson.Result) uint64{
 	var sum uint64
+
+	// 获得total对应的值的数组.
 	arr := value.Get("data.disk.usage.#.total").Array()
+
 	for _,v := range arr{
 		sum += v.Uint() >> 10 >> 10 >> 10
 	}
 	return sum
 }
-//使用parse函数得到mem
+
+// 使用parse函数得到mem.
 func getMemFromParse(value *gjson.Result) uint64{
 	setter := parseSetter(value,"127.0.0.1","0.0.0.0")
-	// 获取bk_disk字段
+
+	// 获取bk_disk字段.
 	cv,ok:= setter["bk_mem"]
 	Expect(ok).To(BeTrue())
-	// 将结果转化为uint64
+
+	// 将结果转化为uint64.
 	results,ok := cv.(uint64)
 	Expect(ok).To(BeTrue())
 	return results
 }
-//自己计算mem
+
+// 自己计算mem.
 func getMemFromSelf(value *gjson.Result) uint64{
 	return  value.Get("data.mem.meminfo.total").Uint() >> 10 >> 10
 }
+
 var _ = Describe("Hostsnap", func() {
 	Context("test key-disk", func() {
 		It("", func() {
-			// 解析为gjson.Result
+			// 解析为gjson.Result.
 			gson := gjson.Parse(defaultjson)
-			// 求出parse函数得出的结果与理论结果
+
+			// 求出parse函数得出的结果与理论结果.
 			shouldout :=getDiskFromSelf(&gson)
 			result:= getDiskFromParse(&gson)
 
@@ -75,11 +101,13 @@ var _ = Describe("Hostsnap", func() {
 
 		})
 	})
+
 	Context("test key-mem",func(){
 		It("", func() {
-			// 解析为gjson.Result
+			// 解析为gjson.Result.
 			gson := gjson.Parse(defaultjson)
-			// 求出parse函数得出的结果与理论结果
+
+			// 求出parse函数得出的结果与理论结果.
 			shouldout := getMemFromSelf(&gson)
 			result:=getMemFromParse(&gson)
 

--- a/src/scene_server/datacollection/datacollection/hostsnap/ginkgo_suite_test.go
+++ b/src/scene_server/datacollection/datacollection/hostsnap/ginkgo_suite_test.go
@@ -1,3 +1,15 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package hostsnap
 
 import (

--- a/src/scene_server/datacollection/datacollection/hostsnap/ginkgo_suite_test.go
+++ b/src/scene_server/datacollection/datacollection/hostsnap/ginkgo_suite_test.go
@@ -1,0 +1,13 @@
+package hostsnap
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestHostsnap(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Hostsnap Suite")
+}

--- a/src/scene_server/datacollection/datacollection/hostsnap/hostsnap.go
+++ b/src/scene_server/datacollection/datacollection/hostsnap/hostsnap.go
@@ -218,11 +218,11 @@ func parseSetter(val *gjson.Result, innerIP, outerIP string) map[string]interfac
 		cupnum += core.Int()
 	}
 	var CPUMhz = val.Get("data.cpu.cpuinfo.0.mhz").Int()
-	var disk int64
+	var disk uint64
 	for _, disktotal := range val.Get("data.disk.usage.#.total").Array() {
-		disk += disktotal.Int()
+		disk += disktotal.Uint() >> 10 >> 10 >>10
 	}
-	var mem = val.Get("data.mem.meminfo.total").Int()
+	var mem = val.Get("data.mem.meminfo.total").Uint()
 	var hostname = val.Get("data.system.info.hostname").String()
 	var ostype = val.Get("data.system.info.os").String()
 	var osname string
@@ -262,12 +262,13 @@ func parseSetter(val *gjson.Result, innerIP, outerIP string) map[string]interfac
 	dockerClientVersion := val.Get("data.system.docker.Client.Version").String()
 	dockerServerVersion := val.Get("data.system.docker.Server.Version").String()
 
+	mem = mem >> 10 >> 10
 	setter := map[string]interface{}{
 		"bk_cpu":                            cupnum,
 		"bk_cpu_module":                     cpumodule,
 		"bk_cpu_mhz":                        CPUMhz,
-		"bk_disk":                           disk / 1024 / 1024 / 1024,
-		"bk_mem":                            mem / 1024 / 1024,
+		"bk_disk":                           disk,
+		"bk_mem":                            mem,
 		"bk_os_type":                        ostype,
 		"bk_os_name":                        osname,
 		"bk_os_version":                     version,


### PR DESCRIPTION
### 优化的功能:
- 主机快照硬盘计算优化，让disk先计算再进行求和，否则可能溢出。
- disk和mem数据类型从int64改为uint64

