### PR TITLE
升级程序创建属性时进行唯一校验，防止重复创建

### DIFF
--- a/src/scene_server/admin_server/upgrader/y3.6.201911141516/obj_host_add_field_type_list.go
+++ b/src/scene_server/admin_server/upgrader/y3.6.201911141516/obj_host_add_field_type_list.go
@@ -82,8 +82,8 @@ func addHostFieldTypeList(ctx context.Context, db dal.RDB, conf *upgrader.Config
 	}
 
 	uniqueFields := []string{common.BKObjIDField, common.BKPropertyIDField, common.BKOwnerIDField}
-	if _, _, err := upgrader.Upsert(ctx, db, common.BKTableNameObjAttDes, hostListTypeField, "id", uniqueFields, []string{}); err != nil {
-		blog.ErrorJSON("addHostFieldTypeList failed, Upsert err: %s, attribute: %#v, ", err, hostListTypeField)
+	if err := upgrader.Insert(ctx, db, common.BKTableNameObjAttDes, hostListTypeField, "id", uniqueFields); err != nil {
+		blog.ErrorJSON("addHostFieldTypeList failed, Insert err: %s, attribute: %#v, ", err, hostListTypeField)
 		return err
 	}
 

--- a/src/scene_server/admin_server/upgrader/y3.7.202002231026/add_bk_port_enable_property.go
+++ b/src/scene_server/admin_server/upgrader/y3.7.202002231026/add_bk_port_enable_property.go
@@ -18,7 +18,6 @@ import (
 
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
-	"configcenter/src/common/metadata"
 	"configcenter/src/scene_server/admin_server/upgrader"
 	"configcenter/src/storage/dal"
 )
@@ -26,11 +25,6 @@ import (
 func addProcEnablePortProperty(ctx context.Context, db dal.RDB, conf *upgrader.Config) error {
 
 	blog.Infof("start execute y3_7_202002231026")
-	id, err := db.NextSequence(ctx, common.BKTableNameObjAttDes)
-	if err != nil {
-		blog.Errorf("get proerty id error. err:%s", err.Error())
-		return fmt.Errorf("get proerty id error. err:%s", err.Error())
-	}
 
 	propertyGroup := "proc_port"
 	maxIdxCond := map[string]interface{}{
@@ -38,14 +32,13 @@ func addProcEnablePortProperty(ctx context.Context, db dal.RDB, conf *upgrader.C
 		common.BKObjIDField:         common.BKInnerObjIDProc,
 	}
 	maxIdxAttr := &Attribute{}
-	err = db.Table(common.BKTableNameObjAttDes).Find(maxIdxCond).Sort(fmt.Sprintf("%s:-1", common.BKPropertyGroupField)).One(ctx, maxIdxAttr)
+	err := db.Table(common.BKTableNameObjAttDes).Find(maxIdxCond).Sort(fmt.Sprintf("%s:-1", common.BKPropertyGroupField)).One(ctx, maxIdxAttr)
 	if err != nil {
 		blog.ErrorJSON("get proerty max index value error.cond:%s, err:%s", maxIdxCond, err.Error())
 		return fmt.Errorf("get proerty max index value error. err:%s", err.Error())
 	}
 
 	addPortEnable := Attribute{
-		ID:            int64(id),
 		OwnerID:       common.BKDefaultOwnerID,
 		ObjectID:      common.BKInnerObjIDProc,
 		PropertyID:    common.BKProcPortEnable,
@@ -64,14 +57,14 @@ func addProcEnablePortProperty(ctx context.Context, db dal.RDB, conf *upgrader.C
 		Option:        true,
 		Description:   "",
 		Creator:       common.CCSystemOperatorUserName,
-		LastTime:      &metadata.Time{Time: time.Now()},
-		CreateTime:    &metadata.Time{Time: time.Now()},
+		CreateTime:    time.Now(),
+		LastTime:      time.Now(),
 	}
 
-	err = db.Table(common.BKTableNameObjAttDes).Insert(ctx, addPortEnable)
-	if err != nil {
-		blog.Errorf("add process proerty %s error. err:%s", common.BKProcPortEnable, err.Error())
-		return fmt.Errorf("add process proerty %s error. err:%s", common.BKProcPortEnable, err.Error())
+	uniqueFields := []string{common.BKObjIDField, common.BKPropertyIDField, common.BKOwnerIDField}
+	if _, _, err := upgrader.Upsert(ctx, db, common.BKTableNameObjAttDes, addPortEnable, "id", uniqueFields, []string{}); err != nil {
+		blog.ErrorJSON("addProcEnablePortProperty failed, Upsert err: %s, attribute: %#v, ", err, addPortEnable)
+		return err
 	}
 
 	return nil
@@ -142,9 +135,9 @@ type Attribute struct {
 	Option            interface{} `field:"option" json:"option" bson:"option"`
 	Description       string      `field:"description" json:"description" bson:"description"`
 
-	Creator    string         `field:"creator" json:"creator" bson:"creator"`
-	CreateTime *metadata.Time `json:"create_time" bson:"create_time"`
-	LastTime   *metadata.Time `json:"last_time" bson:"last_time"`
+	Creator    string    `field:"creator" json:"creator" bson:"creator"`
+	CreateTime time.Time `json:"create_time" bson:"create_time"`
+	LastTime   time.Time `json:"last_time" bson:"last_time"`
 }
 
 // Metadata  used to define the metadata for the resources

--- a/src/scene_server/admin_server/upgrader/y3.7.202002231026/add_bk_port_enable_property.go
+++ b/src/scene_server/admin_server/upgrader/y3.7.202002231026/add_bk_port_enable_property.go
@@ -62,8 +62,8 @@ func addProcEnablePortProperty(ctx context.Context, db dal.RDB, conf *upgrader.C
 	}
 
 	uniqueFields := []string{common.BKObjIDField, common.BKPropertyIDField, common.BKOwnerIDField}
-	if _, _, err := upgrader.Upsert(ctx, db, common.BKTableNameObjAttDes, addPortEnable, "id", uniqueFields, []string{}); err != nil {
-		blog.ErrorJSON("addProcEnablePortProperty failed, Upsert err: %s, attribute: %#v, ", err, addPortEnable)
+	if err := upgrader.Insert(ctx, db, common.BKTableNameObjAttDes, addPortEnable, "id", uniqueFields); err != nil {
+		blog.ErrorJSON("addProcEnablePortProperty failed, Insert err: %s, attribute: %#v, ", err, addPortEnable)
 		return err
 	}
 

--- a/src/scene_server/admin_server/upgrader/y3.8.202004151435/add_proc_gateway_attr.go
+++ b/src/scene_server/admin_server/upgrader/y3.8.202004151435/add_proc_gateway_attr.go
@@ -38,10 +38,10 @@ func addProcNetworkProxyGroup(ctx context.Context, db dal.RDB, conf *upgrader.Co
 	}
 
 	uniqueFields := []string{common.BKObjIDField, common.BKPropertyGroupIDField, common.BKOwnerIDField}
-	_, _, err := upgrader.Upsert(ctx, db, common.BKTableNamePropertyGroup, group, "id", uniqueFields, []string{})
+	err := upgrader.Insert(ctx, db, common.BKTableNamePropertyGroup, group, "id", uniqueFields)
 	if err != nil {
 		if db.IsNotFoundError(err) == false {
-			blog.ErrorJSON("addProcNetworkProxyGroup failed, Upsert err: %s, group: %#v, ", err, group)
+			blog.ErrorJSON("addProcNetworkProxyGroup failed, Insert err: %s, group: %#v, ", err, group)
 
 			return err
 		}
@@ -72,7 +72,7 @@ func addProcNetworkProxyAttrs(ctx context.Context, db dal.RDB, conf *upgrader.Co
 		r.LastEditor = common.CCSystemOperatorUserName
 		r.Description = ""
 
-		if _, _, err := upgrader.Upsert(ctx, db, common.BKTableNameObjAttDes, r, "id", uniqueFields, []string{}); err != nil {
+		if err := upgrader.Insert(ctx, db, common.BKTableNameObjAttDes, r, "id", uniqueFields); err != nil {
 			blog.ErrorJSON("addProcNetworkProxyAttrs failed, Upsert err: %s, attribute: %#v, ", err, r)
 			return err
 		}

--- a/src/scene_server/admin_server/upgrader/y3.8.202005201015/add_host_attr.go
+++ b/src/scene_server/admin_server/upgrader/y3.8.202005201015/add_host_attr.go
@@ -42,8 +42,8 @@ func addHostAttr(ctx context.Context, db dal.RDB, conf *upgrader.Config) error {
 		r.LastEditor = common.CCSystemOperatorUserName
 		r.Description = ""
 
-		if _, _, err := upgrader.Upsert(ctx, db, common.BKTableNameObjAttDes, r, "id", uniqueFields, []string{}); err != nil {
-			blog.ErrorJSON("addHostAttr failed, Upsert err: %s, attribute: %#v, ", err, r)
+		if err := upgrader.Insert(ctx, db, common.BKTableNameObjAttDes, r, "id", uniqueFields); err != nil {
+			blog.ErrorJSON("addHostAttr failed, Insert err: %s, attribute: %#v, ", err, r)
 			return err
 		}
 	}


### PR DESCRIPTION
### 修复的问题：
- 升级程序创建属性时进行唯一校验，防止重复创建

close #4416