### PR TITLE
v3.8.x 修改Distinct函数接口形式，并让其支持string和bool类型的查询

### DIFF
--- a/src/common/util/conv.go
+++ b/src/common/util/conv.go
@@ -243,3 +243,78 @@ func SplitStrField(str, sep string) []string {
 	}
 	return strings.Split(str, sep)
 }
+
+// SliceInterfaceToInt64 将interface切片转化为int64切片,且interface的真实类型可以是任何整数类型.
+// 失败则返回nil,error.
+func SliceInterfaceToInt64(faceSlice []interface{}) ([]int64,error){
+	// 预分配空间.
+	var results = make([]int64,len(faceSlice))
+
+	// 转化操作.
+	for i,item := range faceSlice{
+		switch val := item.(type) {
+		case int64:
+			results[i] = val
+		case int:
+			results[i] = int64(val)
+		case int8:
+			results[i] = int64(val)
+		case int16:
+			results[i] = int64(val)
+		case int32:
+			results[i] = int64(val)
+		case uint:
+			results[i] = int64(val)
+		case uint8:
+			results[i] = int64(val)
+		case uint16:
+			results[i] = int64(val)
+		case uint32:
+			results[i] = int64(val)
+		case uint64:
+			results[i] = int64(val)
+		default:
+			return nil,errors.New("can't convert to int64")
+		}
+	}
+	return results,nil
+}
+
+
+// SliceInterfaceToBool将interface切片转化为string切片,且interface的真实类型必须是string.
+// 失败则返回nil,error.
+func SliceInterfaceToString(faceSlice []interface{}) ([]string,error){
+	// 预分配空间.
+	var results = make([]string,len(faceSlice))
+
+	// 转化操作.
+	for i,item := range faceSlice{
+		var ok bool
+
+		//如果转化失败则返回错误.
+		if results[i],ok = item.(string) ; !ok {
+			return nil,errors.New("can't convert to string")
+		}
+
+	}
+	return results,nil
+}
+
+// SliceInterfaceToBool将interface切片转化为bool切片,且interface的真实类型必须是bool.
+// 失败则返回nil,error.
+func SliceInterfaceToBool(faceSlice []interface{}) ([]bool,error){
+	// 预分配空间.
+	var results = make([]bool,len(faceSlice))
+
+	// 转化操作.
+	for i,item := range faceSlice{
+		 var ok bool
+
+		 //如果转化失败则返回错误.
+		 if results[i],ok = item.(bool) ; !ok {
+			 return nil,errors.New("can't convert to bool")
+		 }
+
+	}
+	return results,nil
+}

--- a/src/common/util/ginkgo_conv_test.go
+++ b/src/common/util/ginkgo_conv_test.go
@@ -1,0 +1,101 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util_test
+
+import (
+	"configcenter/src/common/util"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Test SliceInterfaceToString,Int64,Bool", func() {
+	Context("Test SliceInterfaceToString ", func() {
+		It("number1", func() {
+			var input = []interface{}{"abcd","1111",""}
+			var shouldout = []string{"abcd","1111",""}
+			results ,err := util.SliceInterfaceToString(input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldout).To(Equal(results))
+		})
+
+		It("number2", func() {
+			var input = []interface{}{}
+			var shouldout = []string{}
+			results ,err := util.SliceInterfaceToString(input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldout).To(Equal(results))
+		})
+
+		It("shoule error", func() {
+			var input = []interface{}{"abcd",12}
+			_ ,err := util.SliceInterfaceToString(input)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("Test SliceInterfaceToBool", func() {
+		It("number1", func() {
+			var input = []interface{}{true,false,true,true}
+			var shouldout = []bool{true,false,true,true}
+			results ,err := util.SliceInterfaceToBool(input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldout).To(Equal(results))
+		})
+
+		It("number2", func() {
+			var input = []interface{}{}
+			var shouldout = []bool{}
+			results ,err := util.SliceInterfaceToBool(input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldout).To(Equal(results))
+		})
+
+		It("shoule error", func() {
+			var input = []interface{}{"abcd",12}
+			_ ,err := util.SliceInterfaceToBool(input)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("Test SliceInterfaceToInt64", func() {
+		It("number1", func() {
+			var input = []interface{}{int64(1),int32(32),int(32),uint8(100)}
+			var shouldout = []int64{1,32,32,100}
+			results ,err := util.SliceInterfaceToInt64(input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldout).To(Equal(results))
+		})
+
+		It("number2", func() {
+			var input = []interface{}{int64(1),int64(32),int64(32),int64(100)}
+			var shouldout = []int64{1,32,32,100}
+			results ,err := util.SliceInterfaceToInt64(input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldout).To(Equal(results))
+		})
+
+		It("number3", func() {
+			var input = []interface{}{}
+			var shouldout = []int64{}
+			results ,err := util.SliceInterfaceToInt64(input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldout).To(Equal(results))
+		})
+		It("shoule error", func() {
+			var input = []interface{}{"abcd",12}
+			_ ,err := util.SliceInterfaceToInt64(input)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/src/common/util/ginkgo_util_suite_test.go
+++ b/src/common/util/ginkgo_util_suite_test.go
@@ -1,0 +1,25 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util Suite")
+}

--- a/src/source_controller/coreservice/core/host/transfer/manager.go
+++ b/src/source_controller/coreservice/core/host/transfer/manager.go
@@ -527,12 +527,18 @@ func (manager *TransferManager) GetDistinctHostIDsByTopoRelation(kit *rest.Kit, 
 	}
 	cond = util.SetQueryOwner(moduleHostCond.ToMapStr(), kit.SupplierAccount)
 
-	hostIDArr := make([]int64, 0)
-	err := manager.dbProxy.Table(common.BKTableNameModuleHostConfig).Distinct(kit.Ctx, common.BKHostIDField, cond, &hostIDArr)
+	// 根据约束cond,获得去重后的主机id.
+	ret,err := manager.dbProxy.Table(common.BKTableNameModuleHostConfig).Distinct(kit.Ctx, common.BKHostIDField, cond)
 	if err != nil {
 		blog.Errorf("get module host config  failed, err: %v, cond:%#v, rid: %s", err, cond, kit.Rid)
 		return nil, kit.CCError.CCError(common.CCErrCommDBSelectFailed)
 	}
 
+	// 将ret转化为[]int64
+	var hostIDArr []int64
+	if hostIDArr,err = util.SliceInterfaceToInt64(ret); err != nil{
+		blog.Errorf("get module host config  failed, err: %v, cond:%#v, rid: %s", err, cond, kit.Rid)
+		return nil, kit.CCError.CCError(common.CCErrCommDBSelectFailed)
+	}
 	return hostIDArr, nil
 }

--- a/src/storage/dal/mongo/local/mongo.go
+++ b/src/storage/dal/mongo/local/mongo.go
@@ -765,8 +765,7 @@ func (c *Collection) AggregateOne(ctx context.Context, pipeline interface{}, res
 // Distinct Finds the distinct values for a specified field across a single collection or view and returns the results in an
 // field the field for which to return distinct values.
 // filter query that specifies the documents from which to retrieve the distinct values.
-// result execute query result.  result must be ptr, ptr raw type is must be array,  array item type can integer(int8,int16,int31,int64,int,uint8,uint16,uint31,uint64,uint),string
-func (c *Collection) Distinct(ctx context.Context, field string, filter types.Filter, results interface{}) error {
+func (c *Collection) Distinct(ctx context.Context, field string, filter types.Filter) ([]interface{},error) {
 	rid := ctx.Value(common.ContextRequestIDField)
 	start := time.Now()
 	defer func() {
@@ -776,142 +775,16 @@ func (c *Collection) Distinct(ctx context.Context, field string, filter types.Fi
 	if filter == nil {
 		filter = bson.M{}
 	}
+	var results []interface{} = nil
 
-	return c.tm.AutoRunWithTxn(ctx, c.dbc, func(ctx context.Context) error {
-		dbResults, err := c.dbc.Database(c.dbname).Collection(c.collName).Distinct(ctx, field, filter)
-		if err != nil {
-			return err
-		}
-
-		return decodeDistinctIntoSlice(ctx, dbResults, results)
+	err := c.tm.AutoRunWithTxn(ctx, c.dbc, func(ctx context.Context) error {
+		var err error
+		results, err = c.dbc.Database(c.dbname).Collection(c.collName).Distinct(ctx, field, filter)
+		return err
 
 	})
+	return results,err
 }
-
-func decodeDistinctIntoSlice(ctx context.Context, dbResults []interface{}, results interface{}) error {
-	resultv := reflect.ValueOf(results)
-	if resultv.Kind() != reflect.Ptr || resultv.Elem().Kind() != reflect.Slice {
-		return errors.New("result argument must be a slice address")
-	}
-
-	elemt := resultv.Elem().Type().Elem()
-
-	isInt := false
-	isUint := false
-	isStr := false
-	switch elemt.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		isInt = true
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		isUint = true
-	case reflect.String:
-		isStr = false
-	default:
-		return errors.New("not support decode distinct result to " + elemt.Kind().String())
-	}
-
-	slice := reflect.MakeSlice(resultv.Elem().Type(), 0, len(dbResults))
-
-	for _, item := range dbResults {
-
-		elemp := reflect.New(elemt)
-		switch val := item.(type) {
-		case int:
-			if isInt {
-				elemp.Elem().SetInt(int64(val))
-			} else if isUint {
-				elemp.Elem().SetUint(uint64(val))
-			} else {
-				return errors.New("not can int to " + elemt.Kind().String())
-			}
-		case int8:
-			if isInt {
-				elemp.Elem().SetInt(int64(val))
-			} else if isUint {
-				elemp.Elem().SetUint(uint64(val))
-			} else {
-				return errors.New("not can " + " to int8" + elemt.Kind().String())
-			}
-		case int16:
-			if isInt {
-				elemp.Elem().SetInt(int64(val))
-			} else if isUint {
-				elemp.Elem().SetUint(uint64(val))
-			} else {
-				return errors.New("not can " + " to int16" + elemt.Kind().String())
-			}
-		case int32:
-			if isInt {
-				elemp.Elem().SetInt(int64(val))
-			} else if isUint {
-				elemp.Elem().SetUint(uint64(val))
-			} else {
-				return errors.New("not can " + " to int32" + elemt.Kind().String())
-			}
-		case int64:
-			if isInt {
-				elemp.Elem().SetInt(val)
-			} else if isUint {
-				elemp.Elem().SetUint(uint64(val))
-			} else {
-				return errors.New("not can " + " to int64" + elemt.Kind().String())
-			}
-		case uint:
-			if isInt {
-				elemp.Elem().SetInt(int64(val))
-			} else if isUint {
-				elemp.Elem().SetUint(uint64(val))
-			} else {
-				return errors.New("not can " + " to uint" + elemt.Kind().String())
-			}
-		case uint8:
-			if isInt {
-				elemp.Elem().SetInt(int64(val))
-			} else if isUint {
-				elemp.Elem().SetUint(uint64(val))
-			} else {
-				return errors.New("not can " + " to uint8" + elemt.Kind().String())
-			}
-		case uint16:
-			if isInt {
-				elemp.Elem().SetInt(int64(val))
-			} else if isUint {
-				elemp.Elem().SetUint(uint64(val))
-			} else {
-				return errors.New("not can " + " to uint16" + elemt.Kind().String())
-			}
-		case uint32:
-			if isInt {
-				elemp.Elem().SetInt(int64(val))
-			} else if isUint {
-				elemp.Elem().SetUint(uint64(val))
-			} else {
-				return errors.New("not can uint32 to" + elemt.Kind().String())
-			}
-		case uint64:
-			if isInt {
-				elemp.Elem().SetInt(int64(val))
-			} else if isUint {
-				elemp.Elem().SetUint(uint64(val))
-			} else {
-				return errors.New("not can uint64 to" + elemt.Kind().String())
-			}
-		case string:
-			if !isStr {
-				return errors.New("not can string to" + elemt.Kind().String())
-			}
-			elemp.Elem().SetString(val)
-		default:
-			return errors.New("not can " + elemt.Kind().String())
-		}
-		slice = reflect.Append(slice, elemp.Elem())
-
-	}
-	resultv.Elem().Set(slice)
-
-	return nil
-}
-
 func decodeCusorIntoSlice(ctx context.Context, cursor *mongo.Cursor, result interface{}) error {
 	resultv := reflect.ValueOf(result)
 	if resultv.Kind() != reflect.Ptr || resultv.Elem().Kind() != reflect.Slice {

--- a/src/storage/dal/mongo/local/mongo.go
+++ b/src/storage/dal/mongo/local/mongo.go
@@ -781,7 +781,6 @@ func (c *Collection) Distinct(ctx context.Context, field string, filter types.Fi
 		var err error
 		results, err = c.dbc.Database(c.dbname).Collection(c.collName).Distinct(ctx, field, filter)
 		return err
-
 	})
 	return results,err
 }

--- a/src/storage/dal/mongo/local/mongo_test.go
+++ b/src/storage/dal/mongo/local/mongo_test.go
@@ -22,12 +22,11 @@ import (
 
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
+	"configcenter/src/common/util"
 	"configcenter/src/storage/dal/types"
-	"configcenter/src/storage/driver/mongodb"
-
-	"go.mongodb.org/mongo-driver/x/mongo/driver/uuid"
 
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/uuid"
 )
 
 func BenchmarkLocalCUD(b *testing.B) {
@@ -1336,8 +1335,10 @@ func TestDistinct(t *testing.T) {
 	tableName := "tmp_test_distinct"
 
 	db := dbCleint(t)
+
 	// 清理数据
 	err := db.DropTable(ctx, tableName)
+
 	require.NoError(t, err)
 	require.NoError(t, err)
 
@@ -1371,54 +1372,77 @@ func TestDistinct(t *testing.T) {
 			"type":   "int",
 		},
 		map[string]interface{}{
-			"str":  "aa",
-			"type": "str",
+			"string":  "bb",
+			"type": "string",
 		},
 		map[string]interface{}{
-			"str":  "bb",
-			"type": "str",
+			"string":  "aa",
+			"type": "string",
+		},
+		map[string]interface{}{
+			"bool": true,
+			"type": "bool",
+		},
+		map[string]interface{}{
+			"bool": false,
+			"type": "bool",
 		},
 	}
 
-	dbErr := mongodb.Client().DropTable(context.TODO(), tableName)
+	dbErr := db.DropTable(context.TODO(), tableName)
 	require.NoError(t, dbErr, "insert row to  mongodb error")
 
-	dbErr = mongodb.Client().Table(tableName).Insert(context.TODO(), insertRows)
+	dbErr = db.Table(tableName).Insert(context.TODO(), insertRows)
 	require.NoError(t, dbErr, "insert row to  mongodb error")
 
-	// distinct int64 字段， db 数据和返回的结构都是int64
-	rowInt64Arr := make([]int64, 0)
-	dbErr = table.Distinct(context.TODO(), "int64", map[string]string{"type": "int"}, &rowInt64Arr)
+	// distinct int64 字段, db数据为int64,返回的结构都是int64.
+	var ret []interface{}
+	ret, dbErr = table.Distinct(context.TODO(), "int64", map[string]string{"type": "int"})
 	require.NoError(t, err, "find distinct int64 error")
-	require.Equal(t, []int64{64, 164}, rowInt64Arr)
+	if true{
+		// 测试转化后的结果与预期是否相同.
+		results,err := util.SliceInterfaceToInt64(ret)
+		require.NoError(t, err,"convert to []int64 error")
+		require.Equal(t,[]int64{64, 164},results)
+	}
 
-	// distinct int 字段， db 数据和返回的结构都是int
-	rowIntArr := make([]int, 0)
-	dbErr = table.Distinct(context.TODO(), "int", map[string]string{"type": "int"}, &rowIntArr)
+	// distinct int 字段, db数据为int,返回的结构都是int64.
+	ret, dbErr = table.Distinct(context.TODO(), "int", map[string]string{"type": "int"})
 	require.NoError(t, dbErr, "find distinct int error")
-	require.Equal(t, []int{0, 100}, rowIntArr)
+	if true{
+		// 测试转化后的结果与预期是否相同.
+		results,err := util.SliceInterfaceToInt64(ret)
+		require.NoError(t, err,"convert to []int64 error")
+		require.Equal(t,[]int64{0, 100},results)
+	}
 
-	// distinct int64 字段， db 数据是int, 返回的结构都是int64
-	rowInt64Arr = make([]int64, 0)
-	dbErr = table.Distinct(context.TODO(), "int", map[string]string{"type": "int"}, &rowInt64Arr)
-	require.NoError(t, dbErr, "find distinct db int into int64 result error")
-	require.Equal(t, []int64{0, 100}, rowInt64Arr)
-
-	// distinct uint64 字段， db 数据和返回的结构都是uint64
-	rowUint64Arr := make([]uint64, 0)
-	dbErr = table.Distinct(context.TODO(), "uint64", map[string]string{"type": "int"}, &rowUint64Arr)
-	require.NoError(t, dbErr, "find distinct uint64 error")
-	require.Equal(t, []uint64{64, 164}, rowUint64Arr)
-
-	// distinct uint 字段， db 数据和返回的结构都是uint
-	rowUintArr := make([]uint, 0)
-	dbErr = table.Distinct(context.TODO(), "uint", map[string]string{"type": "int"}, &rowUintArr)
+	// distinct uint 字段, db数据为uint,返回的结构都是int64.
+	ret, dbErr = table.Distinct(context.TODO(), "uint", map[string]string{"type": "int"})
 	require.NoError(t, dbErr, "find distinct uint error")
-	require.Equal(t, []uint{0, 100}, rowUintArr)
+	if true{
+		// 测试转化后的结果与预期是否相同.
+		results,err := util.SliceInterfaceToInt64(ret)
+		require.NoError(t, err,"convert to []int64 error")
+		require.Equal(t,[]int64{0, 100},results)
+	}
 
-	// distinct uint64 字段， db 数据是uint, 返回的结构都是int64
-	rowUint64Arr = make([]uint64, 0)
-	dbErr = table.Distinct(context.TODO(), "uint", map[string]string{"type": "int"}, &rowUint64Arr)
-	require.NoError(t, dbErr, "find distinct db uint into uint64 result error")
-	require.Equal(t, []uint64{0, 100}, rowUint64Arr)
+	// distinct string 字段, db数据为string,返回的结构都是string.
+	ret, dbErr = table.Distinct(context.TODO(), "string", map[string]string{"type": "string"})
+	require.NoError(t, dbErr, "find distinct string error")
+	if true{
+		// 测试转化后的结果与预期是否相同.
+		results,err := util.SliceInterfaceToString(ret)
+		require.NoError(t, err,"convert to []string error")
+		require.Equal(t,[]string{"aa", "bb"},results)
+	}
+
+	// distinct bool 字段， db数据为bool,返回的结构都是bool.
+	ret, dbErr = table.Distinct(context.TODO(), "bool", map[string]string{"type": "bool"})
+	require.NoError(t, dbErr, "find distinct bool error")
+	if true{
+		// 测试转化后的结果与预期是否相同.
+		results,err := util.SliceInterfaceToBool(ret)
+		require.NoError(t, err,"convert to []bool error")
+		require.Equal(t,[]bool{false,true},results)
+	}
 }

--- a/src/storage/dal/types/types.go
+++ b/src/storage/dal/types/types.go
@@ -72,8 +72,7 @@ type Table interface {
 	// Distinct Finds the distinct values for a specified field across a single collection or view and returns the results in an
 	// field the field for which to return distinct values.
 	// filter query that specifies the documents from which to retrieve the distinct values.
-	// result execute query result.  result must be ptr, ptr raw type is must be array,  array item type can integer(int8,int16,int31,int64,int,uint8,uint16,uint31,uint64,uint),string
-	Distinct(ctx context.Context, field string, filter Filter, results interface{}) error
+	Distinct(ctx context.Context, field string, filter Filter) ([]interface{},error)
 }
 
 // Find find operation interface


### PR DESCRIPTION
### 新加的功能:
变更Distinct函数接口形式，让其支持string和bool类型的查询，并返回[]interface{}。

对于转化成具体类型：如转化为int64使用SliceInterfaceToInt64函数，转化成string需要SliceInterfaceToString函数，转化成SliceInterfaceToBool函数

如果查询结果为空，那么返回长度为0的的[]interface{}


修改的文件：
- `conv.go`  增添了三个函数：
    - `SliceInterfaceToInt64(faceSlice []interface{}) ([]int64,error)`  将interface切片转化为int64切片,且interface的真实类型可以是任何整数类型
    - `SliceInterfaceToString(faceSlice []interface{}) ([]string,error)`  将interface切片转化为string切片
    - `SliceInterfaceToBool(faceSlice []interface{}) ([]bool,error)` 将interface切片转化为bool切片

- `mongo.go`  Distinct接口的修改
- `manager.go`  为了兼容Distinct接口所作的修改
- `mongo_test.go`  为了兼容Distinct接口所作的修改，并测试DIstinct函数
- `types.go`   为了兼容Distinct接口所作的修改，并更改Distinct接口注释


增加的文件：
- `ginkgo_util_suite_test.go` 在util包内ginkgo测试框架的的测试入口，`ginkgo_conv_test.go`的前置文件
- `ginkgo_conv_test.go` 测试conv.go的三个新添函数
