### PR TITLE
V3.5.x host cloudarea type

### DIFF
--- a/src/scene_server/host_server/service/host.go
+++ b/src/scene_server/host_server/service/host.go
@@ -593,6 +593,7 @@ func (s *Service) UpdateHostBatch(req *restful.Request, resp *restful.Response) 
 
 	data.Remove(common.MetadataField)
 	data.Remove(common.BKHostIDField)
+	data.Remove(common.BKCloudIDField)
 	hostFields, err := srvData.lgc.GetHostAttributes(srvData.ctx, srvData.ownerID, nil)
 	if err != nil {
 		blog.Errorf("update host batch, but get host attribute for audit failed, err: %v,rid:%s", err, srvData.rid)

--- a/src/test/host_server/host_abnormal_test.go
+++ b/src/test/host_server/host_abnormal_test.go
@@ -318,8 +318,8 @@ var _ = Describe("host abnormal test", func() {
 				}
 				rsp, err := hostServerClient.AddHost(context.Background(), header, input)
 				util.RegisterResponse(rsp)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(rsp.Result).To(Equal(true))
+				Expect(err).To(HaveOccurred())
+				Expect(rsp.Result).To(Equal(false))
 			})
 
 			// 如果云区域ID没有给出，默认是0
@@ -559,8 +559,8 @@ var _ = Describe("host abnormal test", func() {
 				}
 				rsp, err := hostServerClient.AddHost(context.Background(), header, input)
 				util.RegisterResponse(rsp)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(rsp.Result).To(Equal(true))
+				Expect(err).To(HaveOccurred())
+				Expect(rsp.Result).To(Equal(false))
 			})
 
 			It("add host using excel with no bk_cloud_id", func() {


### PR DESCRIPTION
### 新加的功能:
- 新加add host 接口修改主机的，不能修改运区域的
- 新加批量修改主机的接口， 忽略运区域
### 优化的功能:
- 
### 修复的问题：
-  修复add host 接口新加主机的时候，可以使用不存在运区域的问题
-  修复add host 接口新加主机的时候，云区域ID为字符串的问题

