### PR TITLE
修改主机实例属性api 无法修改运区域

### DIFF
--- a/src/scene_server/host_server/logics/import.go
+++ b/src/scene_server/host_server/logics/import.go
@@ -124,6 +124,7 @@ func (lgc *Logics) AddHost(ctx context.Context, appID int64, moduleIDs []int64, 
 		if existInDB {
 			// remove unchangeable fields
 			delete(host, common.BKHostInnerIPField)
+			delete(host, common.BKCloudIDField)
 
 			// get host info before really change it
 			preData, _, _ = lgc.GetHostInstanceDetails(ctx, intHostID)
@@ -135,7 +136,7 @@ func (lgc *Logics) AddHost(ctx context.Context, appID int64, moduleIDs []int64, 
 			}
 			action = metadata.AuditUpdate
 		} else {
-			intHostID, err = instance.addHostInstance(int64(common.BKDefaultDirSubArea), index, appID, moduleIDs, toInternalModule, host)
+			intHostID, err = instance.addHostInstance(iSubAreaVal, index, appID, moduleIDs, toInternalModule, host)
 			if err != nil {
 				errMsg = append(errMsg, err.Error())
 				continue
@@ -245,6 +246,7 @@ type importInstance struct {
 	ccErr         ccErr.DefaultCCErrorIf
 	ccLang        language.DefaultCCLanguageIf
 	rid           string
+	lgc           *Logics
 }
 
 func NewImportInstance(ctx context.Context, ownerID string, lgc *Logics) *importInstance {
@@ -256,6 +258,7 @@ func NewImportInstance(ctx context.Context, ownerID string, lgc *Logics) *import
 		ccErr:   lgc.ccErr,
 		ccLang:  lgc.ccLang,
 		rid:     lgc.rid,
+		lgc:     lgc,
 	}
 }
 
@@ -281,12 +284,32 @@ func (h *importInstance) updateHostInstance(index int64, host map[string]interfa
 	return nil
 }
 
+// addHostInstance  add host
+// cloud id：host belong cloud area id
+// index: index number
+// app id : host belong app id
+// module id: host belong module id
+// host : host info
 func (h *importInstance) addHostInstance(cloudID, index, appID int64, moduleIDs []int64, toInternalModule bool, host map[string]interface{}) (int64, error) {
 	ip, _ := host[common.BKHostInnerIPField].(string)
-	_, ok := host[common.BKCloudIDField]
-	if false == ok {
-		host[common.BKCloudIDField] = cloudID
+	if cloudID < 0 {
+		return 0, fmt.Errorf(h.ccLang.Languagef("host_import_add_fail", index, ip, h.ccLang.Language("import_host_cloudID_invalid")))
 	}
+
+	// determine if the cloud area exists
+	// default cloud area must be exist
+	if cloudID != common.BKDefaultDirSubArea {
+		isExist, err := h.lgc.IsPlatExist(h.ctx, mapstr.MapStr{common.BKCloudIDField: cloudID})
+		if nil != err {
+			return 0, fmt.Errorf(h.ccLang.Languagef("host_import_add_fail", index, ip, err.Error()))
+
+		}
+		if !isExist {
+			return 0, fmt.Errorf(h.ccLang.Languagef("host_import_add_fail", index, ip, h.ccErr.Errorf(common.CCErrTopoCloudNotFound).Error()))
+
+		}
+	}
+	host[common.BKCloudIDField] = cloudID
 
 	input := &metadata.CreateModelInstance{
 		Data: host,

--- a/src/scene_server/host_server/service/host.go
+++ b/src/scene_server/host_server/service/host.go
@@ -745,6 +745,7 @@ func (s *Service) UpdateHostBatch(req *restful.Request, resp *restful.Response) 
 
 	data.Remove(common.MetadataField)
 	data.Remove(common.BKHostIDField)
+	data.Remove(common.BKCloudIDField)
 	hostFields, err := srvData.lgc.GetHostAttributes(srvData.ctx, srvData.ownerID, meta.BizLabelNotExist)
 	if err != nil {
 		blog.Errorf("update host batch, but get host attribute for audit failed, err: %v,rid:%s", err, srvData.rid)

--- a/src/test/host_server/host_abnormal_test.go
+++ b/src/test/host_server/host_abnormal_test.go
@@ -314,7 +314,7 @@ var _ = Describe("host abnormal test", func() {
 				Expect(rsp.Data.Count).To(Equal(1))
 			})
 
-			// 云区域ID不存在不会影响添加主机
+			// 云区域ID不存在新加主机报错
 			It("add host using api with noexist cloud_id", func() {
 				input := map[string]interface{}{
 					"bk_biz_id": bizId,
@@ -328,7 +328,7 @@ var _ = Describe("host abnormal test", func() {
 				rsp, err := hostServerClient.AddHost(context.Background(), header, input)
 				util.RegisterResponse(rsp)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(rsp.Result).To(Equal(true), rsp.ToString())
+				Expect(rsp.Result).To(Equal(false), rsp.ToString())
 			})
 
 			// 如果云区域ID没有给出，默认是0
@@ -569,7 +569,7 @@ var _ = Describe("host abnormal test", func() {
 				rsp, err := hostServerClient.AddHost(context.Background(), header, input)
 				util.RegisterResponse(rsp)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(rsp.Result).To(Equal(true))
+				Expect(rsp.Result).To(Equal(false))
 			})
 
 			It("add host using excel with no bk_cloud_id", func() {

--- a/src/test/host_server/host_abnormal_test.go
+++ b/src/test/host_server/host_abnormal_test.go
@@ -555,23 +555,6 @@ var _ = Describe("host abnormal test", func() {
 				Expect(rsp.Data.Count).To(Equal(1))
 			})
 
-			It("add host using excel with noexist cloud_id", func() {
-				input := map[string]interface{}{
-					"bk_biz_id": bizId,
-					"host_info": map[string]interface{}{
-						"4": map[string]interface{}{
-							"bk_host_innerip": "127.0.1.1",
-							"bk_cloud_id":     noExistID,
-						},
-					},
-					"input_type": "excel",
-				}
-				rsp, err := hostServerClient.AddHost(context.Background(), header, input)
-				util.RegisterResponse(rsp)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(rsp.Result).To(Equal(false))
-			})
-
 			It("add host using excel with no bk_cloud_id", func() {
 				input := map[string]interface{}{
 					"bk_biz_id": bizId,

--- a/src/test/host_server/host_abnormal_test.go
+++ b/src/test/host_server/host_abnormal_test.go
@@ -164,6 +164,23 @@ var _ = Describe("host abnormal test", func() {
 			faultModuleId = rsp.Data.Module[1].ModuleID
 			recycleModuleId = rsp.Data.Module[1].ModuleID
 		})
+
+		// 云区域ID不存在新加主机报错
+		It("add host using api with noexist cloud_id", func() {
+			input := map[string]interface{}{
+				"bk_biz_id": bizId,
+				"host_info": map[string]interface{}{
+					"4": map[string]interface{}{
+						"bk_host_innerip": "127.0.1.1",
+						"bk_cloud_id":     noExistID,
+					},
+				},
+			}
+			rsp, err := hostServerClient.AddHost(context.Background(), header, input)
+			util.RegisterResponse(rsp)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rsp.Result).To(Equal(false), rsp.ToString())
+		})
 	})
 
 	Describe("add host test", func() {
@@ -312,23 +329,6 @@ var _ = Describe("host abnormal test", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(rsp.Result).To(Equal(true))
 				Expect(rsp.Data.Count).To(Equal(1))
-			})
-
-			// 云区域ID不存在新加主机报错
-			It("add host using api with noexist cloud_id", func() {
-				input := map[string]interface{}{
-					"bk_biz_id": bizId,
-					"host_info": map[string]interface{}{
-						"4": map[string]interface{}{
-							"bk_host_innerip": "127.0.1.1",
-							"bk_cloud_id":     noExistID,
-						},
-					},
-				}
-				rsp, err := hostServerClient.AddHost(context.Background(), header, input)
-				util.RegisterResponse(rsp)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(rsp.Result).To(Equal(false), rsp.ToString())
 			})
 
 			// 如果云区域ID没有给出，默认是0


### PR DESCRIPTION
### 新加的功能:
- 新加add host 接口修改主机的，不能修改运区域的
- 新加批量修改主机的接口， 忽略运区域
### 优化的功能:
- 
### 修复的问题：
-  修复add host 接口新加主机的时候，可以使用不存在运区域的问题
-  修复add host 接口新加主机的时候，云区域ID为字符串的问题

close  #4435 