### PR TITLE
修复excel导入主机时，组织类型字段参数校验失败的问题

### DIFF
--- a/src/common/metadata/attribute.go
+++ b/src/common/metadata/attribute.go
@@ -701,7 +701,7 @@ func (attribute *Attribute) validOrganization(ctx context.Context, val interface
 	switch val.(type) {
 	case []interface{}:
 	default:
-		blog.Errorf("params should be type organization, rid: %s", rid)
+		blog.Errorf("params should be type organization,but its type is %T, rid: %s", val, rid)
 		return errors.RawErrorInfo{
 			ErrCode: common.CCErrCommParamsInvalid,
 			Args:    []interface{}{key},

--- a/src/scene_server/proc_server/service/servicetemplate.go
+++ b/src/scene_server/proc_server/service/servicetemplate.go
@@ -51,7 +51,7 @@ func (ps *ProcServer) CreateServiceTemplate(ctx *rest.Contexts) {
 		tpl, err = ps.CoreAPI.CoreService().Process().CreateServiceTemplate(ctx.Kit.Ctx, ctx.Kit.Header, newTemplate)
 		if err != nil {
 			blog.Errorf("create service template failed, err: %v", err)
-			return ctx.Kit.CCError.CCError(common.CCErrCommHTTPDoRequestFailed)
+			return err
 		}
 
 		if err := ps.AuthManager.RegisterServiceTemplates(ctx.Kit.Ctx, ctx.Kit.Header, *tpl); err != nil {
@@ -130,7 +130,7 @@ func (ps *ProcServer) UpdateServiceTemplate(ctx *rest.Contexts) {
 		tpl, err = ps.CoreAPI.CoreService().Process().UpdateServiceTemplate(ctx.Kit.Ctx, ctx.Kit.Header, option.ID, updateParam)
 		if err != nil {
 			blog.Errorf("update service template failed, err: %v", err)
-			return ctx.Kit.CCError.CCError(common.CCErrCommHTTPDoRequestFailed)
+			return err
 		}
 
 		if err := ps.AuthManager.UpdateRegisteredServiceTemplates(ctx.Kit.Ctx, ctx.Kit.Header, *tpl); err != nil {

--- a/src/web_server/logics/excel_util.go
+++ b/src/web_server/logics/excel_util.go
@@ -259,6 +259,29 @@ func getDataFromByExcelRow(ctx context.Context, row *xlsx.Row, rowIndex int, fie
 			} else {
 				blog.Debug("get excel cell value error, field:%s, value:%s, error:%s, rid: %s", fieldName, host[fieldName], err.Error(), rid)
 			}
+		case common.FieldTypeOrganization:
+			org := util.GetStrByInterface(host[fieldName])
+			if len(org) >= 2 && strings.HasPrefix(org, "[") && strings.HasSuffix(org, "]") {
+				if strings.TrimSpace(org[1:len(org)-1]) == "" {
+					host[fieldName] = []int64{}
+					break
+				}
+				orgItems := strings.Split(org[1:len(org)-1], ",")
+				orgSlice := make([]int64, len(orgItems))
+				var err error
+				for i, v := range orgItems {
+					orgSlice[i], err = strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+					if err != nil {
+						blog.Debug("get excel cell value error, field:%s, value:%s, error:%s, rid: %s", fieldName, host[fieldName], "not a valid organization type", rid)
+						break
+					}
+				}
+				if err == nil {
+					host[fieldName] = orgSlice
+				}
+			} else {
+				blog.Debug("get excel cell value error, field:%s, value:%s, error:%s, rid: %s", fieldName, host[fieldName], "not a valid organization type", rid)
+			}
 		default:
 			if util.IsStrProperty(field.PropertyType) {
 				host[fieldName] = strings.TrimSpace(cell.Value)


### PR DESCRIPTION
### 修复的问题：
- 修复excel导入主机时，组织类型字段参数校验失败的问题
- 解决新建的服务模板与已建模板的名称重复时，提示语不清晰的问题
