### PR TITLE
实现进程bind_info 多态

### DIFF
--- a/resources/language/default/property.json
+++ b/resources/language/default/property.json
@@ -89,6 +89,7 @@
     "process_property_bk_gateway_port": "网关端口",
     "process_property_bk_gateway_protocol": "网关协议",
     "process_property_bk_gateway_city": "网关所在城市",
+    "process_property_bind_info": "绑定信息",
     "bk_switch_property_bk_asset_id": "固资编号",
     "bk_switch_property_bk_sn": "SN",
     "bk_switch_property_bk_name": "名称",

--- a/resources/language/en/property.json
+++ b/resources/language/en/property.json
@@ -60,7 +60,6 @@
     "host_property_bk_province_name": "province name",
     "host_property_bk_isp_name": "isp name",
     "host_property_bk_state": "current status",
-
     "process_property_bk_biz_id": "business id",
     "process_property_bk_process_name": "process alias name",
     "process_property_description": "comment",
@@ -90,6 +89,7 @@
     "process_property_bk_gateway_port": "gateway port",
     "process_property_bk_gateway_protocol": "gateway protocol",
     "process_property_bk_gateway_city": "gateway city",
+    "process_property_bind_info": "bind information",
     "bk_switch_property_bk_asset_id": "asset id",
     "bk_switch_property_bk_sn": "SN",
     "bk_switch_property_bk_inst_name": "middleware",

--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -492,6 +492,9 @@ const (
 	// BKProcGatewayCity the process gateway city
 	BKProcGatewayCity = "bk_gateway_city"
 
+	// BKProcBindInfo the process bind info
+	BKProcBindInfo = "bind_info"
+
 	// BKUser the user
 	BKUser = "user"
 
@@ -767,8 +770,11 @@ const (
 	// FieldTypeBool the bool type
 	FieldTypeBool string = "bool"
 
-	// FieldTypeList the lis type
+	// FieldTypeList the list type
 	FieldTypeList string = "list"
+
+	// FieldTypeTable the table type, inner type.
+	FieldTypeTable string = "table"
 
 	// FieldTypeOrganization the organization field type
 	FieldTypeOrganization string = "organization"

--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -501,6 +501,12 @@ const (
 	// BKProtocol the protocol
 	BKProtocol = "protocol"
 
+	// BKIP the ip
+	BKIP = "ip"
+
+	// BKEnable the enable
+	BKEnable = "enable"
+
 	// the process object name
 	BKProcessObjectName = "process"
 

--- a/src/common/metadata/attribute.go
+++ b/src/common/metadata/attribute.go
@@ -153,6 +153,9 @@ func (attribute *Attribute) Validate(ctx context.Context, data interface{}, key 
 		rawError = attribute.validOrganization(ctx, data, key)
 	case "foreignkey", "singleasst", "multiasst":
 		// TODO what validation should do on these types
+	case common.FieldTypeTable:
+		// TODO what validation should do on these types
+		rawError = attribute.validTable(ctx, data, key)
 	default:
 		rawError = errors.RawErrorInfo{
 			ErrCode: common.CCErrCommUnexpectedFieldType,
@@ -710,6 +713,13 @@ func (attribute *Attribute) validOrganization(ctx context.Context, val interface
 	return errors.RawErrorInfo{}
 }
 
+// validTable valid object attribute that is bool type
+func (attribute *Attribute) validTable(ctx context.Context, val interface{}, key string) (rawError errors.RawErrorInfo) {
+	// rid := util.ExtractRequestIDFromContext(ctx)
+	// TODO 暂时不需要实现，目前只有进程和进程模板使用
+	return errors.RawErrorInfo{}
+}
+
 // parseFloatOption  parse float data in option
 func parseFloatOption(ctx context.Context, val interface{}) FloatOption {
 	rid := util.ExtractRequestIDFromContext(ctx)
@@ -1058,4 +1068,37 @@ func CheckAllowHostApplyOnField(field string) bool {
 		return allow
 	}
 	return true
+}
+
+// SubAttribute sub attribute metadata definition
+type SubAttribute struct {
+	PropertyID   string      `field:"bk_property_id" json:"bk_property_id" bson:"bk_property_id"`
+	PropertyName string      `field:"bk_property_name" json:"bk_property_name" bson:"bk_property_name"`
+	Placeholder  string      `field:"placeholder" json:"placeholder" bson:"placeholder"`
+	IsEditable   bool        `field:"editable" json:"editable" bson:"editable"`
+	IsRequired   bool        `field:"isrequired" json:"isrequired" bson:"isrequired"`
+	IsReadOnly   bool        `field:"isreadonly" json:"isreadonly" bson:"isreadonly"`
+	IsSystem     bool        `field:"bk_issystem" json:"bk_issystem" bson:"bk_issystem"`
+	IsAPI        bool        `field:"bk_isapi" json:"bk_isapi" bson:"bk_isapi"`
+	PropertyType string      `field:"bk_property_type" json:"bk_property_type" bson:"bk_property_type"`
+	Option       interface{} `field:"option" json:"option" bson:"option"`
+	Description  string      `field:"description" json:"description" bson:"description"`
+}
+
+func (sa *SubAttribute) Validate(ctx context.Context, data interface{}, key string) (rawError errors.RawErrorInfo) {
+	attr := Attribute{
+		PropertyID:   sa.PropertyID,
+		PropertyName: sa.PropertyName,
+		Placeholder:  sa.Placeholder,
+
+		IsEditable:   sa.IsEditable,
+		IsRequired:   sa.IsRequired,
+		IsReadOnly:   sa.IsReadOnly,
+		IsSystem:     sa.IsSystem,
+		IsAPI:        sa.IsAPI,
+		PropertyType: sa.PropertyType,
+		Option:       sa.Option,
+		Description:  sa.Description,
+	}
+	return attr.Validate(ctx, data, key)
 }

--- a/src/common/metadata/inst.go
+++ b/src/common/metadata/inst.go
@@ -103,16 +103,22 @@ func (identifier *HostIdentifier) MarshalBinary() (data []byte, err error) {
 }
 
 type HostIdentProcess struct {
-	ProcessID       int64   `json:"bk_process_id" bson:"bk_process_id"`               // 进程名称
-	ProcessName     string  `json:"bk_process_name" bson:"bk_process_name"`           // 进程名称
-	BindIP          string  `json:"bind_ip" bson:"bind_ip"`                           // 绑定IP, 枚举: [{ID: "1", Name: "127.0.0.1"}, {ID: "2", Name: "0.0.0.0"}, {ID: "3", Name: "第一内网IP"}, {ID: "4", Name: "第一外网IP"}]
-	Port            string  `json:"port" bson:"port"`                                 // 端口, 单个端口："8080", 多个连续端口："8080-8089", 多个不连续端口："8080-8089,8199"
+	ProcessID   int64  `json:"bk_process_id" bson:"bk_process_id"`     // 进程名称
+	ProcessName string `json:"bk_process_name" bson:"bk_process_name"` // 进程名称
+	// deprecated  后续的版本会被废弃掉
+	BindIP string `json:"bind_ip" bson:"bind_ip"` // 绑定IP, 枚举: [{ID: "1", Name: "127.0.0.1"}, {ID: "2", Name: "0.0.0.0"}, {ID: "3", Name: "第一内网IP"}, {ID: "4", Name: "第一外网IP"}]
+	// deprecated  后续的版本会被废弃掉
+	Port string `json:"port" bson:"port"` // 端口, 单个端口："8080", 多个连续端口："8080-8089", 多个不连续端口："8080-8089,8199"
+	// deprecated  后续的版本会被废弃掉
 	Protocol        string  `json:"protocol" bson:"protocol"`                         // 协议, 枚举: [{ID: "1", Name: "TCP"}, {ID: "2", Name: "UDP"}],
 	FuncID          string  `json:"bk_func_id" bson:"bk_func_id"`                     // 功能ID
 	FuncName        string  `json:"bk_func_name" bson:"bk_func_name"`                 // 功能名称
 	StartParamRegex string  `json:"bk_start_param_regex" bson:"bk_start_param_regex"` // 启动参数匹配规则
 	BindModules     []int64 `json:"bind_modules" bson:"bind_modules"`                 // 进程绑定的模块ID，数字数组
-	PortEnable      bool    `field:"bk_enable_port" json:"bk_enable_port" bson:"bk_enable_port"`
+	// deprecated  后续的版本会被废弃掉
+	PortEnable bool `field:"bk_enable_port" json:"bk_enable_port" bson:"bk_enable_port"`
+	// BindInfo 进程绑定信息
+	BindInfo []ProcBindInfo `field:"bind_info" json:"bind_info" bson:"bind_info"`
 }
 
 type HostIdentProcessSorter []HostIdentProcess

--- a/src/common/metadata/process.go
+++ b/src/common/metadata/process.go
@@ -494,39 +494,39 @@ func (p ProtocolType) Validate() error {
 }
 
 type Process struct {
-	ProcNum         *int64        `field:"proc_num" json:"proc_num" bson:"proc_num" structs:"proc_num" mapstructure:"proc_num"`
-	StopCmd         *string       `field:"stop_cmd" json:"stop_cmd" bson:"stop_cmd" structs:"stop_cmd" mapstructure:"stop_cmd"`
-	RestartCmd      *string       `field:"restart_cmd" json:"restart_cmd" bson:"restart_cmd" structs:"restart_cmd" mapstructure:"restart_cmd"`
-	ForceStopCmd    *string       `field:"face_stop_cmd" json:"face_stop_cmd" bson:"face_stop_cmd" structs:"face_stop_cmd" mapstructure:"face_stop_cmd"`
-	ProcessID       int64         `field:"bk_process_id" json:"bk_process_id" bson:"bk_process_id" structs:"bk_process_id" mapstructure:"bk_process_id"`
-	FuncName        *string       `field:"bk_func_name" json:"bk_func_name" bson:"bk_func_name" structs:"bk_func_name" mapstructure:"bk_func_name"`
-	WorkPath        *string       `field:"work_path" json:"work_path" bson:"work_path" structs:"work_path" mapstructure:"work_path"`
-	BindIP          *string       `field:"bind_ip" json:"bind_ip" bson:"bind_ip" structs:"bind_ip" mapstructure:"bind_ip"`
-	Priority        *int64        `field:"priority" json:"priority" bson:"priority" structs:"priority" mapstructure:"priority"`
-	ReloadCmd       *string       `field:"reload_cmd" json:"reload_cmd" bson:"reload_cmd" structs:"reload_cmd" mapstructure:"reload_cmd"`
-	ProcessName     *string       `field:"bk_process_name" json:"bk_process_name" bson:"bk_process_name" structs:"bk_process_name" mapstructure:"bk_process_name"`
-	Port            *string       `field:"port" json:"port" bson:"port" structs:"port" mapstructure:"port"`
-	PidFile         *string       `field:"pid_file" json:"pid_file" bson:"pid_file" structs:"pid_file" mapstructure:"pid_file"`
-	AutoStart       *bool         `field:"auto_start" json:"auto_start" bson:"auto_start" structs:"auto_start" mapstructure:"auto_start"`
-	AutoTimeGap     *int64        `field:"auto_time_gap" json:"auto_time_gap" bson:"auto_time_gap" structs:"auto_time_gap" mapstructure:"auto_time_gap"`
-	LastTime        time.Time     `field:"last_time" json:"last_time" bson:"last_time" structs:"last_time" mapstructure:"last_time"`
-	CreateTime      time.Time     `field:"create_time" json:"create_time" bson:"create_time" structs:"create_time" mapstructure:"create_time"`
-	BusinessID      int64         `field:"bk_biz_id" json:"bk_biz_id" bson:"bk_biz_id" structs:"bk_biz_id" mapstructure:"bk_biz_id"`
-	StartCmd        *string       `field:"start_cmd" json:"start_cmd" bson:"start_cmd" structs:"start_cmd" mapstructure:"start_cmd"`
-	FuncID          *string       `field:"bk_func_id" json:"bk_func_id" bson:"bk_func_id" structs:"bk_func_id" mapstructure:"bk_func_id"`
-	User            *string       `field:"user" json:"user" bson:"user" structs:"user" mapstructure:"user"`
-	TimeoutSeconds  *int64        `field:"timeout" json:"timeout" bson:"timeout" structs:"timeout" mapstructure:"timeout"`
-	Protocol        *ProtocolType `field:"protocol" json:"protocol" bson:"protocol" structs:"protocol" mapstructure:"protocol"`
-	Description     *string       `field:"description" json:"description" bson:"description" structs:"description" mapstructure:"description"`
-	SupplierAccount string        `field:"bk_supplier_account" json:"bk_supplier_account" bson:"bk_supplier_account" structs:"bk_supplier_account" mapstructure:"bk_supplier_account"`
-	StartParamRegex *string       `field:"bk_start_param_regex" json:"bk_start_param_regex" bson:"bk_start_param_regex" structs:"bk_start_param_regex" mapstructure:"bk_start_param_regex"`
-	PortEnable      *bool         `field:"bk_enable_port" json:"bk_enable_port" bson:"bk_enable_port"`
-	GatewayIP       *string       `field:"bk_gateway_ip" json:"bk_gateway_ip" bson:"bk_gateway_ip" structs:"bk_gateway_ip" mapstructure:"bk_gateway_ip"`
-	GatewayPort     *string       `field:"bk_gateway_port" json:"bk_gateway_port" bson:"bk_gateway_port" structs:"bk_gateway_port" mapstructure:"bk_gateway_port"`
-	GatewayProtocol *ProtocolType `field:"bk_gateway_protocol" json:"bk_gateway_protocol" bson:"bk_gateway_protocol" structs:"bk_gateway_protocol" mapstructure:"bk_gateway_protocol"`
-	GatewayCity     *string       `field:"bk_gateway_city" json:"bk_gateway_city" bson:"bk_gateway_city" structs:"bk_gateway_city" mapstructure:"bk_gateway_city"`
+	ProcNum      *int64  `field:"proc_num" json:"proc_num" bson:"proc_num" structs:"proc_num" mapstructure:"proc_num"`
+	StopCmd      *string `field:"stop_cmd" json:"stop_cmd" bson:"stop_cmd" structs:"stop_cmd" mapstructure:"stop_cmd"`
+	RestartCmd   *string `field:"restart_cmd" json:"restart_cmd" bson:"restart_cmd" structs:"restart_cmd" mapstructure:"restart_cmd"`
+	ForceStopCmd *string `field:"face_stop_cmd" json:"face_stop_cmd" bson:"face_stop_cmd" structs:"face_stop_cmd" mapstructure:"face_stop_cmd"`
+	ProcessID    int64   `field:"bk_process_id" json:"bk_process_id" bson:"bk_process_id" structs:"bk_process_id" mapstructure:"bk_process_id"`
+	FuncName     *string `field:"bk_func_name" json:"bk_func_name" bson:"bk_func_name" structs:"bk_func_name" mapstructure:"bk_func_name"`
+	WorkPath     *string `field:"work_path" json:"work_path" bson:"work_path" structs:"work_path" mapstructure:"work_path"`
+	//BindIP          *string       `field:"bind_ip" json:"bind_ip" bson:"bind_ip" structs:"bind_ip" mapstructure:"bind_ip"`
+	Priority    *int64  `field:"priority" json:"priority" bson:"priority" structs:"priority" mapstructure:"priority"`
+	ReloadCmd   *string `field:"reload_cmd" json:"reload_cmd" bson:"reload_cmd" structs:"reload_cmd" mapstructure:"reload_cmd"`
+	ProcessName *string `field:"bk_process_name" json:"bk_process_name" bson:"bk_process_name" structs:"bk_process_name" mapstructure:"bk_process_name"`
+	//Port           *string   `field:"port" json:"port" bson:"port" structs:"port" mapstructure:"port"`
+	PidFile        *string   `field:"pid_file" json:"pid_file" bson:"pid_file" structs:"pid_file" mapstructure:"pid_file"`
+	AutoStart      *bool     `field:"auto_start" json:"auto_start" bson:"auto_start" structs:"auto_start" mapstructure:"auto_start"`
+	AutoTimeGap    *int64    `field:"auto_time_gap" json:"auto_time_gap" bson:"auto_time_gap" structs:"auto_time_gap" mapstructure:"auto_time_gap"`
+	LastTime       time.Time `field:"last_time" json:"last_time" bson:"last_time" structs:"last_time" mapstructure:"last_time"`
+	CreateTime     time.Time `field:"create_time" json:"create_time" bson:"create_time" structs:"create_time" mapstructure:"create_time"`
+	BusinessID     int64     `field:"bk_biz_id" json:"bk_biz_id" bson:"bk_biz_id" structs:"bk_biz_id" mapstructure:"bk_biz_id"`
+	StartCmd       *string   `field:"start_cmd" json:"start_cmd" bson:"start_cmd" structs:"start_cmd" mapstructure:"start_cmd"`
+	FuncID         *string   `field:"bk_func_id" json:"bk_func_id" bson:"bk_func_id" structs:"bk_func_id" mapstructure:"bk_func_id"`
+	User           *string   `field:"user" json:"user" bson:"user" structs:"user" mapstructure:"user"`
+	TimeoutSeconds *int64    `field:"timeout" json:"timeout" bson:"timeout" structs:"timeout" mapstructure:"timeout"`
+	//Protocol        *ProtocolType `field:"protocol" json:"protocol" bson:"protocol" structs:"protocol" mapstructure:"protocol"`
+	Description     *string `field:"description" json:"description" bson:"description" structs:"description" mapstructure:"description"`
+	SupplierAccount string  `field:"bk_supplier_account" json:"bk_supplier_account" bson:"bk_supplier_account" structs:"bk_supplier_account" mapstructure:"bk_supplier_account"`
+	StartParamRegex *string `field:"bk_start_param_regex" json:"bk_start_param_regex" bson:"bk_start_param_regex" structs:"bk_start_param_regex" mapstructure:"bk_start_param_regex"`
+	//PortEnable      *bool         `field:"bk_enable_port" json:"bk_enable_port" bson:"bk_enable_port"`
+	//GatewayIP       *string       `field:"bk_gateway_ip" json:"bk_gateway_ip" bson:"bk_gateway_ip" structs:"bk_gateway_ip" mapstructure:"bk_gateway_ip"`
+	//GatewayPort     *string       `field:"bk_gateway_port" json:"bk_gateway_port" bson:"bk_gateway_port" structs:"bk_gateway_port" mapstructure:"bk_gateway_port"`
+	//GatewayProtocol *ProtocolType `field:"bk_gateway_protocol" json:"bk_gateway_protocol" bson:"bk_gateway_protocol" structs:"bk_gateway_protocol" mapstructure:"bk_gateway_protocol"`
+	//GatewayCity     *string       `field:"bk_gateway_city" json:"bk_gateway_city" bson:"bk_gateway_city" structs:"bk_gateway_city" mapstructure:"bk_gateway_city"`
 
-	BindInfo *ProcBindInfo `field:"bind_info" json:"bind_info" bson:"bind_info" structs:"bind_info" mapstructure:"bind_info"`
+	BindInfo []ProcBindInfo `field:"bind_info" json:"bind_info" bson:"bind_info" structs:"bind_info" mapstructure:"bind_info"`
 }
 
 type ServiceCategory struct {
@@ -689,15 +689,6 @@ func (pt *ProcessTemplate) NewProcess(bizID int64, supplierAccount string) *Proc
 		processInstance.WorkPath = property.WorkPath.Value
 	}
 
-	processInstance.BindIP = nil
-	if IsAsDefaultValue(property.BindIP.AsDefaultValue) {
-		bindIP := property.BindIP.Value.IP()
-		if len(bindIP) > 0 {
-			processInstance.BindIP = new(string)
-			*processInstance.BindIP = bindIP
-		}
-	}
-
 	processInstance.Priority = nil
 	if IsAsDefaultValue(property.Priority.AsDefaultValue) {
 		processInstance.Priority = property.Priority.Value
@@ -706,11 +697,6 @@ func (pt *ProcessTemplate) NewProcess(bizID int64, supplierAccount string) *Proc
 	processInstance.ReloadCmd = nil
 	if IsAsDefaultValue(property.ReloadCmd.AsDefaultValue) {
 		processInstance.ReloadCmd = property.ReloadCmd.Value
-	}
-
-	processInstance.Port = nil
-	if IsAsDefaultValue(property.Port.AsDefaultValue) {
-		processInstance.Port = property.Port.Value
 	}
 
 	processInstance.PidFile = nil
@@ -748,11 +734,6 @@ func (pt *ProcessTemplate) NewProcess(bizID int64, supplierAccount string) *Proc
 		processInstance.TimeoutSeconds = property.TimeoutSeconds.Value
 	}
 
-	processInstance.Protocol = nil
-	if IsAsDefaultValue(property.Protocol.AsDefaultValue) {
-		processInstance.Protocol = property.Protocol.Value
-	}
-
 	processInstance.Description = nil
 	if IsAsDefaultValue(property.Description.AsDefaultValue) {
 		processInstance.Description = property.Description.Value
@@ -761,31 +742,6 @@ func (pt *ProcessTemplate) NewProcess(bizID int64, supplierAccount string) *Proc
 	processInstance.StartParamRegex = nil
 	if IsAsDefaultValue(property.StartParamRegex.AsDefaultValue) {
 		processInstance.StartParamRegex = property.StartParamRegex.Value
-	}
-
-	processInstance.PortEnable = nil
-	if IsAsDefaultValue(property.PortEnable.AsDefaultValue) {
-		processInstance.PortEnable = property.PortEnable.Value
-	}
-
-	processInstance.GatewayIP = nil
-	if IsAsDefaultValue(property.GatewayIP.AsDefaultValue) {
-		processInstance.GatewayIP = property.GatewayIP.Value
-	}
-
-	processInstance.GatewayPort = nil
-	if IsAsDefaultValue(property.GatewayPort.AsDefaultValue) {
-		processInstance.GatewayPort = property.GatewayPort.Value
-	}
-
-	processInstance.GatewayProtocol = nil
-	if IsAsDefaultValue(property.GatewayProtocol.AsDefaultValue) {
-		processInstance.GatewayProtocol = property.GatewayProtocol.Value
-	}
-
-	processInstance.GatewayCity = nil
-	if IsAsDefaultValue(property.GatewayCity.AsDefaultValue) {
-		processInstance.GatewayCity = property.GatewayCity.Value
 	}
 
 	return processInstance
@@ -922,32 +878,6 @@ func (pt *ProcessTemplate) ExtractChangeInfo(i *Process) (mapstr.MapStr, bool, b
 		}
 	}
 
-	if IsAsDefaultValue(t.BindIP.AsDefaultValue) {
-		if t.BindIP.Value == nil && i.BindIP != nil {
-			process["bind_ip"] = nil
-			changed = true
-		} else if t.BindIP.Value != nil && i.BindIP == nil {
-			process["bind_ip"] = t.BindIP.Value.IP()
-			changed = true
-		} else if t.BindIP.Value != nil && i.BindIP != nil && t.BindIP.Value.IP() != *i.BindIP {
-			process["bind_ip"] = t.BindIP.Value.IP()
-			changed = true
-		}
-	}
-
-	if IsAsDefaultValue(t.Priority.AsDefaultValue) {
-		if t.Priority.Value != nil && i.Priority == nil {
-			process["priority"] = *t.Priority.Value
-			changed = true
-		} else if t.Priority.Value == nil && i.Priority != nil {
-			process["priority"] = nil
-			changed = true
-		} else if t.Priority.Value != nil && i.Priority != nil && *t.Priority.Value != *i.Priority {
-			process["priority"] = *t.Priority.Value
-			changed = true
-		}
-	}
-
 	if IsAsDefaultValue(t.ReloadCmd.AsDefaultValue) {
 		if t.ReloadCmd.Value == nil && i.ReloadCmd != nil {
 			process["reload_cmd"] = nil
@@ -974,35 +904,6 @@ func (pt *ProcessTemplate) ExtractChangeInfo(i *Process) (mapstr.MapStr, bool, b
 			process["bk_process_name"] = *t.ProcessName.Value
 			changed = true
 			isNamePortChanged = true
-		}
-	}
-
-	if IsAsDefaultValue(t.Port.AsDefaultValue) {
-		if t.Port.Value == nil && i.Port != nil {
-			process["port"] = nil
-			changed = true
-			isNamePortChanged = true
-		} else if t.Port.Value != nil && i.Port == nil {
-			process["port"] = *t.Port.Value
-			changed = true
-			isNamePortChanged = true
-		} else if t.Port.Value != nil && i.Port != nil && *t.Port.Value != *i.Port {
-			process["port"] = *t.Port.Value
-			changed = true
-			isNamePortChanged = true
-		}
-	}
-
-	if IsAsDefaultValue(t.PidFile.AsDefaultValue) {
-		if t.PidFile.Value == nil && i.PidFile != nil {
-			process["pid_file"] = nil
-			changed = true
-		} else if t.PidFile.Value != nil && i.PidFile == nil {
-			process["pid_file"] = *t.PidFile.Value
-			changed = true
-		} else if t.PidFile.Value != nil && i.PidFile != nil && *t.PidFile.Value != *i.PidFile {
-			process["pid_file"] = *t.PidFile.Value
-			changed = true
 		}
 	}
 
@@ -1084,19 +985,6 @@ func (pt *ProcessTemplate) ExtractChangeInfo(i *Process) (mapstr.MapStr, bool, b
 		}
 	}
 
-	if IsAsDefaultValue(t.Protocol.AsDefaultValue) {
-		if t.Protocol.Value == nil && i.Protocol != nil {
-			process["protocol"] = nil
-			changed = true
-		} else if t.Protocol.Value != nil && i.Protocol == nil {
-			process["protocol"] = *t.Protocol.Value
-			changed = true
-		} else if t.Protocol.Value != nil && i.Protocol != nil && *t.Protocol.Value != *i.Protocol {
-			process["protocol"] = *t.Protocol.Value
-			changed = true
-		}
-	}
-
 	if IsAsDefaultValue(t.Description.AsDefaultValue) {
 		if t.Description.Value == nil && i.Description != nil {
 			process["description"] = nil
@@ -1123,72 +1011,7 @@ func (pt *ProcessTemplate) ExtractChangeInfo(i *Process) (mapstr.MapStr, bool, b
 		}
 	}
 
-	if IsAsDefaultValue(t.PortEnable.AsDefaultValue) {
-		if t.PortEnable.Value == nil && i.PortEnable != nil {
-			process[common.BKProcPortEnable] = nil
-			changed = true
-		} else if t.PortEnable.Value != nil && i.PortEnable == nil {
-			process[common.BKProcPortEnable] = *t.PortEnable.Value
-			changed = true
-		} else if t.PortEnable.Value != nil && i.PortEnable != nil && *t.PortEnable.Value != *i.PortEnable {
-			process[common.BKProcPortEnable] = *t.PortEnable.Value
-			changed = true
-		}
-	}
-
-	if IsAsDefaultValue(t.GatewayIP.AsDefaultValue) {
-		if t.GatewayIP.Value == nil && i.GatewayIP != nil {
-			process["bk_gateway_ip"] = nil
-			changed = true
-		} else if t.GatewayIP.Value != nil && i.GatewayIP == nil {
-			process["bk_gateway_ip"] = *t.GatewayIP.Value
-			changed = true
-		} else if t.GatewayIP.Value != nil && i.GatewayIP != nil && *t.GatewayIP.Value != *i.GatewayIP {
-			process["bk_gateway_ip"] = *t.GatewayIP.Value
-			changed = true
-		}
-	}
-
-	if IsAsDefaultValue(t.GatewayPort.AsDefaultValue) {
-		if t.GatewayPort.Value == nil && i.GatewayPort != nil {
-			process["bk_gateway_port"] = nil
-			changed = true
-		} else if t.GatewayPort.Value != nil && i.GatewayPort == nil {
-			process["bk_gateway_port"] = *t.GatewayPort.Value
-			changed = true
-		} else if t.GatewayPort.Value != nil && i.GatewayPort != nil && *t.GatewayPort.Value != *i.GatewayPort {
-			process["bk_gateway_port"] = *t.GatewayPort.Value
-			changed = true
-		}
-	}
-
-	if IsAsDefaultValue(t.GatewayProtocol.AsDefaultValue) {
-		if t.GatewayProtocol.Value == nil && i.GatewayProtocol != nil {
-			process["bk_gateway_protocol"] = nil
-			changed = true
-		} else if t.GatewayProtocol.Value != nil && i.GatewayProtocol == nil {
-			process["bk_gateway_protocol"] = *t.GatewayProtocol.Value
-			changed = true
-		} else if t.GatewayProtocol.Value != nil && i.GatewayProtocol != nil && *t.GatewayProtocol.Value != *i.GatewayProtocol {
-			process["bk_gateway_protocol"] = *t.GatewayProtocol.Value
-			changed = true
-		}
-	}
-
-	if IsAsDefaultValue(t.GatewayCity.AsDefaultValue) {
-		if t.GatewayCity.Value == nil && i.GatewayCity != nil {
-			process["bk_gateway_city"] = nil
-			changed = true
-		} else if t.GatewayCity.Value != nil && i.GatewayCity == nil {
-			process["bk_gateway_city"] = *t.GatewayCity.Value
-			changed = true
-		} else if t.GatewayCity.Value != nil && i.GatewayCity != nil && *t.GatewayCity.Value != *i.GatewayCity {
-			process["bk_gateway_city"] = *t.GatewayCity.Value
-			changed = true
-		}
-	}
-
-	bindInfo, bindInfoChanged, bindInfoIsNamePortChanged := t.BindInfo.Value.ExtractChangeInfoBindInfo(i)
+	bindInfo, bindInfoChanged, bindInfoIsNamePortChanged := t.BindInfo.ExtractChangeInfoBindInfo(i)
 	process[common.BKProcBindInfo] = bindInfo
 	if bindInfoChanged {
 		changed = true
@@ -1239,14 +1062,8 @@ func (pt *ProcessTemplate) ExtractEditableFields() []string {
 	if IsAsDefaultValue(property.ProcNum.AsDefaultValue) == false {
 		editableFields = append(editableFields, "proc_num")
 	}
-	if IsAsDefaultValue(property.Port.AsDefaultValue) == false {
-		editableFields = append(editableFields, "port")
-	}
 	if IsAsDefaultValue(property.Description.AsDefaultValue) == false {
 		editableFields = append(editableFields, "description")
-	}
-	if IsAsDefaultValue(property.Protocol.AsDefaultValue) == false {
-		editableFields = append(editableFields, "protocol")
 	}
 	if IsAsDefaultValue(property.TimeoutSeconds.AsDefaultValue) == false {
 		editableFields = append(editableFields, "timeout")
@@ -1269,29 +1086,11 @@ func (pt *ProcessTemplate) ExtractEditableFields() []string {
 	if IsAsDefaultValue(property.WorkPath.AsDefaultValue) == false {
 		editableFields = append(editableFields, "work_path")
 	}
-	if IsAsDefaultValue(property.BindIP.AsDefaultValue) == false {
-		editableFields = append(editableFields, "bind_ip")
-	}
 	if IsAsDefaultValue(property.Priority.AsDefaultValue) == false {
 		editableFields = append(editableFields, "priority")
 	}
 	if IsAsDefaultValue(property.StartCmd.AsDefaultValue) == false {
 		editableFields = append(editableFields, "start_cmd")
-	}
-	if IsAsDefaultValue(property.PortEnable.AsDefaultValue) == false {
-		editableFields = append(editableFields, common.BKProcPortEnable)
-	}
-	if IsAsDefaultValue(property.GatewayIP.AsDefaultValue) == false {
-		editableFields = append(editableFields, "bk_gateway_ip")
-	}
-	if IsAsDefaultValue(property.GatewayPort.AsDefaultValue) == false {
-		editableFields = append(editableFields, "bk_gateway_port")
-	}
-	if IsAsDefaultValue(property.GatewayProtocol.AsDefaultValue) == false {
-		editableFields = append(editableFields, "bk_gateway_protocol")
-	}
-	if IsAsDefaultValue(property.GatewayCity.AsDefaultValue) == false {
-		editableFields = append(editableFields, "bk_gateway_city")
 	}
 	//
 	editableFields = append(editableFields, common.BKProcBindInfo)
@@ -1342,19 +1141,9 @@ func (pt *ProcessTemplate) ExtractInstanceUpdateData(input *Process) map[string]
 			data["proc_num"] = *input.ProcNum
 		}
 	}
-	if IsAsDefaultValue(property.Port.AsDefaultValue) == false {
-		if input.Port != nil {
-			data["port"] = *input.Port
-		}
-	}
 	if IsAsDefaultValue(property.Description.AsDefaultValue) == false {
 		if input.Description != nil {
 			data["description"] = *input.Description
-		}
-	}
-	if IsAsDefaultValue(property.Protocol.AsDefaultValue) == false {
-		if input.Protocol != nil {
-			data["protocol"] = *input.Protocol
 		}
 	}
 	if IsAsDefaultValue(property.TimeoutSeconds.AsDefaultValue) == false {
@@ -1392,11 +1181,6 @@ func (pt *ProcessTemplate) ExtractInstanceUpdateData(input *Process) map[string]
 			data["work_path"] = *input.WorkPath
 		}
 	}
-	if IsAsDefaultValue(property.BindIP.AsDefaultValue) == false {
-		if input.BindIP != nil {
-			data["bind_ip"] = *input.BindIP
-		}
-	}
 	if IsAsDefaultValue(property.Priority.AsDefaultValue) == false {
 		if input.Priority != nil {
 			data["priority"] = *input.Priority
@@ -1407,63 +1191,40 @@ func (pt *ProcessTemplate) ExtractInstanceUpdateData(input *Process) map[string]
 			data["start_cmd"] = *input.StartCmd
 		}
 	}
-	if IsAsDefaultValue(property.PortEnable.AsDefaultValue) == false {
-		if input.PortEnable != nil {
-			data[common.BKProcPortEnable] = *input.PortEnable
-		}
-	}
-	if IsAsDefaultValue(property.GatewayIP.AsDefaultValue) == false {
-		if input.GatewayIP != nil {
-			data["bk_gateway_ip"] = *input.GatewayIP
-		}
-	}
-	if IsAsDefaultValue(property.GatewayPort.AsDefaultValue) == false {
-		if input.GatewayPort != nil {
-			data["bk_gateway_port"] = *input.GatewayPort
-		}
-	}
-	if IsAsDefaultValue(property.GatewayProtocol.AsDefaultValue) == false {
-		if input.GatewayProtocol != nil {
-			data["bk_gateway_protocol"] = *input.GatewayProtocol
-		}
-	}
-	if IsAsDefaultValue(property.GatewayCity.AsDefaultValue) == false {
-		if input.GatewayCity != nil {
-			data["bk_gateway_city"] = *input.GatewayCity
-		}
-	}
+
 	// bind info 每次都是全量更新
 	data[common.BKProcBindInfo] = pt.Property.BindInfo.ExtractInstanceUpdateData(input)
+
 	return data
 }
 
 type ProcessProperty struct {
-	ProcNum            PropertyInt64    `field:"proc_num" json:"proc_num" bson:"proc_num" validate:"max=10000,min=1"`
-	StopCmd            PropertyString   `field:"stop_cmd" json:"stop_cmd" bson:"stop_cmd"`
-	RestartCmd         PropertyString   `field:"restart_cmd" json:"restart_cmd" bson:"restart_cmd"`
-	ForceStopCmd       PropertyString   `field:"face_stop_cmd" json:"face_stop_cmd" bson:"face_stop_cmd"`
-	FuncName           PropertyString   `field:"bk_func_name" json:"bk_func_name" bson:"bk_func_name" validate:"required"`
-	WorkPath           PropertyString   `field:"work_path" json:"work_path" bson:"work_path"`
-	BindIP             PropertyBindIP   `field:"bind_ip" json:"bind_ip" bson:"bind_ip"`
-	Priority           PropertyInt64    `field:"priority" json:"priority" bson:"priority" validate:"max=10000,min=1"`
-	ReloadCmd          PropertyString   `field:"reload_cmd" json:"reload_cmd" bson:"reload_cmd"`
-	ProcessName        PropertyString   `field:"bk_process_name" json:"bk_process_name" bson:"bk_process_name" validate:"required"`
-	Port               PropertyPort     `field:"port" json:"port" bson:"port"`
-	PidFile            PropertyString   `field:"pid_file" json:"pid_file" bson:"pid_file"`
-	AutoStart          PropertyBool     `field:"auto_start" json:"auto_start" bson:"auto_start"`
-	AutoTimeGapSeconds PropertyInt64    `field:"auto_time_gap" json:"auto_time_gap" bson:"auto_time_gap" validate:"max=10000,min=1"`
-	StartCmd           PropertyString   `field:"start_cmd" json:"start_cmd" bson:"start_cmd"`
-	FuncID             PropertyString   `field:"bk_func_id" json:"bk_func_id" bson:"bk_func_id"`
-	User               PropertyString   `field:"user" json:"user" bson:"user"`
-	TimeoutSeconds     PropertyInt64    `field:"timeout" json:"timeout" bson:"timeout" validate:"max=10000,min=1"`
-	Protocol           PropertyProtocol `field:"protocol" json:"protocol" bson:"protocol"`
-	Description        PropertyString   `field:"description" json:"description" bson:"description"`
-	StartParamRegex    PropertyString   `field:"bk_start_param_regex" json:"bk_start_param_regex" bson:"bk_start_param_regex"`
-	PortEnable         PropertyBool     `field:"bk_enable_port" json:"bk_enable_port" bson:"bk_enable_port"`
-	GatewayIP          PropertyString   `field:"bk_gateway_ip" json:"bk_gateway_ip" bson:"bk_gateway_ip"`
-	GatewayPort        PropertyString   `field:"bk_gateway_port" json:"bk_gateway_port" bson:"bk_gateway_port"`
-	GatewayProtocol    PropertyProtocol `field:"bk_gateway_protocol" json:"bk_gateway_protocol" bson:"bk_gateway_protocol"`
-	GatewayCity        PropertyString   `field:"bk_gateway_city" json:"bk_gateway_city" bson:"bk_gateway_city"`
+	ProcNum      PropertyInt64  `field:"proc_num" json:"proc_num" bson:"proc_num" validate:"max=10000,min=1"`
+	StopCmd      PropertyString `field:"stop_cmd" json:"stop_cmd" bson:"stop_cmd"`
+	RestartCmd   PropertyString `field:"restart_cmd" json:"restart_cmd" bson:"restart_cmd"`
+	ForceStopCmd PropertyString `field:"face_stop_cmd" json:"face_stop_cmd" bson:"face_stop_cmd"`
+	FuncName     PropertyString `field:"bk_func_name" json:"bk_func_name" bson:"bk_func_name" validate:"required"`
+	WorkPath     PropertyString `field:"work_path" json:"work_path" bson:"work_path"`
+	//BindIP             PropertyBindIP   `field:"bind_ip" json:"bind_ip" bson:"bind_ip"`
+	Priority    PropertyInt64  `field:"priority" json:"priority" bson:"priority" validate:"max=10000,min=1"`
+	ReloadCmd   PropertyString `field:"reload_cmd" json:"reload_cmd" bson:"reload_cmd"`
+	ProcessName PropertyString `field:"bk_process_name" json:"bk_process_name" bson:"bk_process_name" validate:"required"`
+	//Port               PropertyPort     `field:"port" json:"port" bson:"port"`
+	PidFile            PropertyString `field:"pid_file" json:"pid_file" bson:"pid_file"`
+	AutoStart          PropertyBool   `field:"auto_start" json:"auto_start" bson:"auto_start"`
+	AutoTimeGapSeconds PropertyInt64  `field:"auto_time_gap" json:"auto_time_gap" bson:"auto_time_gap" validate:"max=10000,min=1"`
+	StartCmd           PropertyString `field:"start_cmd" json:"start_cmd" bson:"start_cmd"`
+	FuncID             PropertyString `field:"bk_func_id" json:"bk_func_id" bson:"bk_func_id"`
+	User               PropertyString `field:"user" json:"user" bson:"user"`
+	TimeoutSeconds     PropertyInt64  `field:"timeout" json:"timeout" bson:"timeout" validate:"max=10000,min=1"`
+	//Protocol           PropertyProtocol `field:"protocol" json:"protocol" bson:"protocol"`
+	Description     PropertyString `field:"description" json:"description" bson:"description"`
+	StartParamRegex PropertyString `field:"bk_start_param_regex" json:"bk_start_param_regex" bson:"bk_start_param_regex"`
+	//PortEnable         PropertyBool     `field:"bk_enable_port" json:"bk_enable_port" bson:"bk_enable_port"`
+	//GatewayIP       PropertyString   `field:"bk_gateway_ip" json:"bk_gateway_ip" bson:"bk_gateway_ip"`
+	//GatewayPort     PropertyString   `field:"bk_gateway_port" json:"bk_gateway_port" bson:"bk_gateway_port"`
+	//GatewayProtocol PropertyProtocol `field:"bk_gateway_protocol" json:"bk_gateway_protocol" bson:"bk_gateway_protocol"`
+	//GatewayCity     PropertyString   `field:"bk_gateway_city" json:"bk_gateway_city" bson:"bk_gateway_city"`
 
 	BindInfo ProcPropertyBindInfo `field:"bind_info" json:"bind_info" bson:"bind_info" structs:"bind_info" mapstructure:"bind_info"`
 }
@@ -1477,7 +1238,12 @@ func (pt *ProcessProperty) Validate() (field string, err error) {
 	for fieldIdx := 0; fieldIdx < fieldCount; fieldIdx++ {
 		field := selfType.Field(fieldIdx)
 		fieldVal := selfVal.Field(fieldIdx)
+		tag := field.Tag.Get("json")
+		fieldName := strings.Split(tag, ",")[0]
 
+		if fieldName == common.BKProcBindInfo {
+			continue
+		}
 		// check implements interface
 		fieldValType := fieldVal.Addr().Type()
 		if !fieldValType.Implements(propertyInterfaceType) {
@@ -1490,10 +1256,13 @@ func (pt *ProcessProperty) Validate() (field string, err error) {
 		out := checkResult[0]
 		if !out.IsNil() {
 			err := out.Interface().(error)
-			tag := field.Tag.Get("json")
-			fieldName := strings.Split(tag, ",")[0]
+
 			return fieldName, err
 		}
+	}
+
+	if fieldName, err := pt.BindInfo.Validate(); err != nil {
+		return fieldName, err
 	}
 
 	if pt.ProcessName.Value == nil || len(*pt.ProcessName.Value) == 0 {

--- a/src/common/metadata/process.go
+++ b/src/common/metadata/process.go
@@ -1017,7 +1017,7 @@ func (pt *ProcessTemplate) ExtractChangeInfo(i *Process) (mapstr.MapStr, bool, b
 		changed = true
 	}
 	if bindInfoIsNamePortChanged {
-		changed = true
+		bindInfoIsNamePortChanged = true
 	}
 
 	return process, changed, isNamePortChanged

--- a/src/common/metadata/process_bind_info.go
+++ b/src/common/metadata/process_bind_info.go
@@ -1,0 +1,461 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.,
+ * Copyright (C) 2017,-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the ",License",); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an ",AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package metadata
+
+import (
+	"encoding/json"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+/*
+version: 1.0 test
+description:  由于在不同的运行版本中,进程的绑定信息的二维结构中，数据的列是不一样的。 所以又下面的实现
+
+通过定义数据反序列化的方法来实现struct 的同一个属性在不同运行版本的环境上，实现进程绑定信息的多态。
+主要是利用interface 的特性来实现，
+
+defaultPropertyBindInfoHandle，defaultProcBindInfoHandle 是在使用反序列化 进程，进程模板中进程
+绑定信息实际结构的对象
+
+下面是defaultPropertyBindInfoHandle，defaultProcBindInfoHandle中UJSON和UBSON 含义的介绍
+UJSON json反序列的方法，用于HTTP的消息处理,将数据解析到不同的struct上。 这个结构需要是ProcPropertyBindInfo，ProcBindInfoInterface interface 的实现
+UBSON  bson 反序列化的方法， 用于数据库存储,将数据解析到不同的struct上。这个结构需要是ProcPropertyBindInfo，ProcBindInfoInterface interface 的实现
+
+*/
+
+var (
+	//  内部变量，不允许改变，改变值请用对应的Register 方案
+	defaultPropertyBindInfoHandle ProcPropertyBindInfoInterface = &openVersionPropertyBindInfo{}
+	//  内部变量，不允许改变，改变值请用对应的Register 方案
+	defaultProcBindInfoHandle ProcBindInfoInterface = &openVersionProcBindInfo{}
+)
+
+// TODO 等待实现， 替换已有的进程，进程模板中进程绑定信息实际结构的处理对象
+func Register(propertyBindInfo ProcPropertyBindInfoInterface, procBindInfo ProcBindInfoInterface) {
+	defaultPropertyBindInfoHandle = propertyBindInfo
+	defaultProcBindInfoHandle = procBindInfo
+}
+
+// ProcPropertyBindInfoInterface 用来处理进程模板中bind info 数据的反序列化，
+// 序列号使用默认的方法，目前只支持json, bson, 如果需要其他请新加
+type ProcPropertyBindInfoInterface interface {
+	UJSON(data []byte) (*ProcPropertyBindInfoValue, error)
+	UBSON(data []byte) (*ProcPropertyBindInfoValue, error)
+	/* 	JSON() ([]byte, error)
+	   	BSON() ([]byte, error) */
+}
+
+// ProcBindInfoInterface 用来处理进程中bind info 数据的序反序列化，
+// 序列号使用默认的方法，目前只支持json, bson, 如果需要其他请新加
+type ProcBindInfoInterface interface {
+	UJSON(data []byte) (*ProcBindInfo, error)
+	UBSON(data []byte) (*ProcBindInfo, error)
+	/* 	JSON() ([]byte, error)
+	   	BSON() ([]byte, error) */
+}
+
+// ProcPropertyBindInfoRaw 用来限定进程模板中的校验和通过模板来限定进程实例的数据内容
+type ProcPropertyBindInfoRaw interface {
+	ExtractChangeInfoBindInfo(i *Process) (*ProcBindInfo, bool, bool)
+	ExtractInstanceUpdateData(i *Process) *ProcBindInfo
+	Validate() error
+	// 留做扩招使用
+	//Update(input ProcessProperty, rawProperty map[string]interface{})
+	Datas() []interface{}
+}
+
+// ProcPropertyBindInfo 给服务模板使用的，来存储，校验服务模板中进程绑定的信息
+type ProcPropertyBindInfo struct {
+	// 通过Unmarshal 方法实现不同的数据类型
+	Value ProcPropertyBindInfoValue
+	// 给前端做兼容
+	AsDefaultValue *bool `field:"as_default_value" json:"as_default_value" bson:"as_default_value"`
+}
+
+// ProcPropertyBindInfoValue 给服务模板使用的，来存储，校验服务模板中进程绑定的信息
+type ProcPropertyBindInfoValue struct {
+	// 通过Unmarshal 方法实现不同的数据类型
+	raw ProcPropertyBindInfoRaw `field:"value" json:"value" bson:"value"`
+}
+
+// ProcBindInfo 给服务模板使用的，来存储，校验服务实例中进程绑定的信息
+type ProcBindInfo struct {
+	// 通过Unmarshal 方法实现不同的数据类型
+	raw interface{}
+}
+
+func (ppb *ProcPropertyBindInfoValue) UnmarshalJSON(data []byte) error {
+	val, err := defaultPropertyBindInfoHandle.UJSON(data)
+	if err != nil {
+		return err
+	}
+	ppb.raw = val.raw
+
+	return nil
+}
+
+func (ppb *ProcPropertyBindInfoValue) UnmarshalBSON(data []byte) error {
+	val, err := defaultPropertyBindInfoHandle.UBSON(data)
+	if err != nil {
+		return err
+	}
+	ppb.raw = val.raw
+	return nil
+}
+
+func (ppb *ProcPropertyBindInfoValue) MarshalJSON() ([]byte, error) {
+	b, err := json.Marshal(ppb.raw)
+
+	return b, err
+}
+
+func (ppb ProcPropertyBindInfo) MarshalBSON() ([]byte, error) {
+	data := make(map[string]interface{}, 0)
+	data["as_default_value"] = ppb.AsDefaultValue
+	if ppb.Value.raw != nil && len(ppb.Value.raw.Datas()) > 0 {
+		data["value"] = ppb.Value.raw.Datas()
+
+	}
+	return bson.Marshal(data)
+}
+
+func (ppb ProcPropertyBindInfo) MarshalJSON() ([]byte, error) {
+	data := make(map[string]interface{}, 0)
+	data["as_default_value"] = ppb.AsDefaultValue
+	if ppb.Value.raw != nil && len(ppb.Value.raw.Datas()) > 0 {
+		data["value"] = ppb.Value.raw.Datas()
+
+	}
+	return json.Marshal(data)
+
+}
+
+// Validate 校验数据是否合法
+func (pbi *ProcPropertyBindInfo) Validate() error {
+	if pbi == nil || pbi.Value.raw == nil {
+		return nil
+	}
+	return pbi.Value.Validate()
+}
+
+func (pbi *ProcPropertyBindInfo) ExtractInstanceUpdateData(input *Process) *ProcBindInfo {
+	return pbi.Value.raw.ExtractInstanceUpdateData(input)
+}
+
+// Validate 校验数据是否合法
+func (pbi *ProcPropertyBindInfoValue) Validate() error {
+	if pbi == nil || pbi.raw == nil {
+		return nil
+	}
+	return pbi.raw.Validate()
+}
+
+// ExtractChangeInfoBindInfo 生成对应环境中存储数据的对象
+func (pbi *ProcPropertyBindInfoValue) ExtractChangeInfoBindInfo(i *Process) (*ProcBindInfo, bool, bool) {
+	return pbi.raw.ExtractChangeInfoBindInfo(i)
+}
+
+func (pbi *ProcBindInfo) UnmarshalJSON(data []byte) error {
+	val, err := defaultProcBindInfoHandle.UJSON(data)
+	if err != nil {
+		return err
+	}
+	pbi.raw = val.raw
+	return nil
+}
+
+func (pbi *ProcBindInfo) UnmarshalBSON(data []byte) error {
+	val, err := defaultProcBindInfoHandle.UBSON(data)
+	if err != nil {
+		return err
+	}
+	pbi.raw = val.raw
+	return nil
+}
+
+func (pbi ProcBindInfo) MarshalJSON() ([]byte, error) {
+	return json.Marshal(pbi.raw)
+}
+
+func (pbi ProcBindInfo) MarshalBSON() ([]byte, error) {
+	if pbi.raw == nil {
+		// 避免bson marshal nil 出现问题
+		return bson.Marshal([]struct{}{})
+	}
+	return bson.Marshal(pbi.raw)
+}
+
+// Update  bind info 每次更新采用的是全量更新
+func (pbi *ProcPropertyBindInfo) Update(input ProcessProperty, rawProperty map[string]interface{}) {
+	pbi.AsDefaultValue = input.BindInfo.AsDefaultValue
+	pbi.Value = input.BindInfo.Value
+	return
+}
+
+/* 公开版本的进程bind 信息处理的方法 */
+
+type openVersionPropertyBindInfo struct {
+}
+
+func (ov *openVersionPropertyBindInfo) UJSON(data []byte) (*ProcPropertyBindInfoValue, error) {
+	if data == nil || len(data) == 0 {
+		return nil, nil
+	}
+	bindInfo := &processPropertyBindInfo{}
+	err := json.Unmarshal(data, bindInfo)
+	return &ProcPropertyBindInfoValue{raw: bindInfo}, err
+}
+
+func (ov *openVersionPropertyBindInfo) UBSON(data []byte) (*ProcPropertyBindInfoValue, error) {
+	if data == nil || len(data) == 0 {
+		return nil, nil
+	}
+	var ret interface{}
+	bson.Unmarshal(data, &ret)
+	bindInfo1 := make(map[string]processPropertyBindInfoRow, 0)
+	err := bson.Unmarshal(data, &bindInfo1)
+	if err != nil {
+		return nil, err
+	}
+	// TODO 找出为什么是map[string]processPropertyBindInfoRow 原因
+	// bson 怀疑是因为bson 不支持数组做为顶级节点，
+	var bindInfo []processPropertyBindInfoRow
+	for _, item := range bindInfo1 {
+		bindInfo = append(bindInfo, item)
+	}
+	tmp := processPropertyBindInfo(bindInfo)
+	/*bindInfo := &processPropertyBindInfo{}
+	err := bson.Unmarshal(data, bindInfo)*/
+
+	return &ProcPropertyBindInfoValue{raw: &tmp}, err
+}
+
+type openVersionProcBindInfo struct {
+}
+
+func (ov *openVersionProcBindInfo) UJSON(data []byte) (*ProcBindInfo, error) {
+	if data == nil || len(data) == 0 {
+		return nil, nil
+	}
+	bindInfo := &processBindInfo{}
+	err := json.Unmarshal(data, bindInfo)
+	return &ProcBindInfo{raw: bindInfo}, err
+}
+
+func (ov *openVersionProcBindInfo) UBSON(data []byte) (*ProcBindInfo, error) {
+	if data == nil || len(data) == 0 {
+		return nil, nil
+	}
+	bindInfo := &processBindInfo{}
+	err := bson.Unmarshal(data, bindInfo)
+	return &ProcBindInfo{raw: bindInfo}, err
+}
+
+type processBindInfoRow struct {
+	IP       *string `field:"ip" json:"ip" bson:"ip"`
+	Port     *string `field:"port" json:"port" bson:"port"`
+	Protocol *string `field:"protocol" json:"protocol" bson:"protocol"`
+	Enable   *bool   `field:"enable" json:"enable" bson:"enable"`
+}
+
+type processPropertyBindInfoRow struct {
+	IP       PropertyBindIP   `field:"ip" json:"ip" bson:"ip"`
+	Port     PropertyPort     `field:"port" json:"port" bson:"port"`
+	Protocol PropertyProtocol `field:"protocol" json:"protocol" bson:"protocol"`
+	Enable   PropertyBool     `field:"enable" json:"enable" bson:"enable"`
+}
+
+type processBindInfo []processBindInfoRow
+type processPropertyBindInfo []processPropertyBindInfoRow
+
+func (pbi *processPropertyBindInfo) Validate() (err error) {
+	// call all field's Validate method one by one
+	for _, row := range *pbi {
+		if err := row.IP.Validate(); err != nil {
+			return err
+		}
+		if err := row.Port.Validate(); err != nil {
+			return err
+		}
+		if err := row.Protocol.Validate(); err != nil {
+			return err
+		}
+		if err := row.Enable.Validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ExtractChangeInfo get bind info changes that will be applied to process instance,
+func (pbi *processPropertyBindInfo) ExtractChangeInfoBindInfo(i *Process) (*ProcBindInfo, bool, bool) {
+	var changed, isNamePortChanged bool
+
+	preProcBindInfoMap := make(map[int]processBindInfoRow, 0)
+	if i.BindInfo != nil {
+		preProcBindInfoArr, ok := i.BindInfo.raw.(*processBindInfo)
+		if !ok {
+			// 这个地方出现panic， 证明在代码处理上面出现问题了
+			panic("ExtractChangeInfoBindInfo bind info panic, reason: not open version process bind info struct")
+		}
+		for idx, row := range *preProcBindInfoArr {
+			preProcBindInfoMap[idx] = row
+		}
+	}
+
+	for idx, row := range *pbi {
+		preRow, ok := preProcBindInfoMap[idx]
+		if !ok {
+			preRow = processBindInfoRow{}
+		}
+		if IsAsDefaultValue(row.IP.AsDefaultValue) {
+			if row.IP.Value == nil && preRow.IP != nil {
+				preRow.IP = nil
+				changed = true
+			} else if row.IP.Value != nil && preRow.IP == nil {
+				*preRow.IP = row.IP.Value.IP()
+				changed = true
+			} else if row.IP.Value != nil && preRow.IP != nil && row.IP.Value.IP() != *preRow.IP {
+				*preRow.IP = row.IP.Value.IP()
+				changed = true
+			}
+		}
+
+		if IsAsDefaultValue(row.Port.AsDefaultValue) {
+			if row.Port.Value == nil && preRow.Port != nil {
+				preRow.Port = nil
+				changed = true
+				isNamePortChanged = true
+			} else if row.Port.Value != nil && preRow.Port == nil {
+				*preRow.Port = *row.Port.Value
+				isNamePortChanged = true
+				changed = true
+			} else if row.Port.Value != nil && preRow.Port != nil && *row.Port.Value != *preRow.Port {
+				*preRow.Port = *row.Port.Value
+				isNamePortChanged = true
+				changed = true
+			}
+		}
+
+		if IsAsDefaultValue(row.Protocol.AsDefaultValue) {
+			if row.Protocol.Value == nil && preRow.Protocol != nil {
+				preRow.Protocol = nil
+				changed = true
+			} else if row.Protocol.Value != nil && preRow.Protocol == nil {
+				*preRow.Protocol = row.Protocol.Value.String()
+				changed = true
+			} else if row.Protocol.Value != nil && preRow.Protocol != nil && row.Protocol.Value.String() != *preRow.Protocol {
+				*preRow.Protocol = row.Protocol.Value.String()
+				changed = true
+			}
+		}
+
+		if IsAsDefaultValue(row.Enable.AsDefaultValue) {
+			if row.Enable.Value == nil && preRow.Enable != nil {
+				preRow.Enable = nil
+				changed = true
+			} else if row.Enable.Value != nil && preRow.Enable == nil {
+				*preRow.Enable = *row.Enable.Value
+				changed = true
+			} else if row.Enable.Value != nil && preRow.Enable != nil && *row.Enable.Value != *preRow.Enable {
+				*preRow.Enable = *row.Enable.Value
+				changed = true
+			}
+		}
+	}
+	newProBindInfo := make([]processBindInfoRow, len(*pbi))
+	for idx, row := range preProcBindInfoMap {
+		newProBindInfo[idx] = row
+	}
+	if len(newProBindInfo) == 0 {
+		return nil, changed, isNamePortChanged
+	}
+
+	return &ProcBindInfo{raw: newProBindInfo}, false, false
+}
+
+// ExtractChangeInfo get bind info changes that will be applied to process instance,
+func (pbi *processPropertyBindInfo) ExtractInstanceUpdateData(i *Process) *ProcBindInfo {
+	// 用户输入的进程绑定的信息
+	procBindInfoMap := make(map[int]processBindInfoRow, 0)
+	if i.BindInfo != nil && i.BindInfo.raw != nil {
+		procBindInfoArr, ok := i.BindInfo.raw.(*processBindInfo)
+		if !ok {
+			// 这个地方出现panic， 证明在代码处理上面出现问题了
+			panic("ExtractChangeInfoBindInfo bind info panic, reason: not open version process bind info struct")
+		}
+		for idx, row := range *procBindInfoArr {
+			procBindInfoMap[idx] = row
+		}
+	}
+
+	//	注意 process bind info 更新必须是全量
+	// 数据已模板为主
+	var newProBindInfo []processBindInfoRow
+	for idx, row := range *pbi {
+		// 用户输入进程绑定信息中的一行
+		procBindInfoItem, ok := procBindInfoMap[idx]
+		if !ok {
+			//
+			continue
+		}
+
+		// 通过模板处理后，存储到db中process bind info 中的一行
+		newbProcBindInfoItem := processBindInfoRow{}
+
+		if IsAsDefaultValue(row.IP.AsDefaultValue) == false {
+			if procBindInfoItem.IP != nil {
+				newbProcBindInfoItem.IP = procBindInfoItem.IP
+			}
+		} else {
+			if row.IP.Value != nil {
+				ip := row.IP.Value.String()
+				newbProcBindInfoItem.IP = &ip
+			}
+		}
+
+		if IsAsDefaultValue(row.Port.AsDefaultValue) == false {
+			if procBindInfoItem.Port != nil {
+				newbProcBindInfoItem.Port = procBindInfoItem.Port
+			}
+		} else {
+			if row.Port.Value != nil {
+				newbProcBindInfoItem.Port = row.Port.Value
+			}
+		}
+
+		if IsAsDefaultValue(row.Protocol.AsDefaultValue) == false {
+			if procBindInfoItem.Protocol != nil {
+				newbProcBindInfoItem.Protocol = procBindInfoItem.Protocol
+			}
+		} else {
+			if row.Protocol.Value != nil {
+				protocol := row.Protocol.Value.String()
+				newbProcBindInfoItem.Protocol = &protocol
+			}
+		}
+
+		newProBindInfo = append(newProBindInfo, newbProcBindInfoItem)
+	}
+
+	return &ProcBindInfo{raw: newProBindInfo}
+}
+
+func (ov processPropertyBindInfo) Datas() []interface{} {
+	var ret []interface{}
+	for _, item := range ov {
+		ret = append(ret, item)
+	}
+	return ret
+}

--- a/src/scene_server/admin_server/command/import.go
+++ b/src/scene_server/admin_server/command/import.go
@@ -601,7 +601,7 @@ func convProcTemplateProperty(ctx context.Context, proc map[string]interface{}) 
 				return nil, fmt.Errorf("%s illegal. val:%s. err:%s", key, val, err.Error())
 			}
 		case "bind_ip":
-			bindIP, ok := val.(string)
+			/* bindIP, ok := val.(string)
 			if !ok {
 				return nil, fmt.Errorf("%s not string. val:%s", key, val)
 			}
@@ -610,7 +610,7 @@ func convProcTemplateProperty(ctx context.Context, proc map[string]interface{}) 
 			processProperty.BindIP.AsDefaultValue = &blTrue
 			if err := processProperty.BindIP.Validate(); err != nil {
 				return nil, fmt.Errorf("%s illegal. val:%s. err:%s", key, val, err.Error())
-			}
+			} */
 		case "priority":
 			priority, err := util.GetInt64ByInterface(val)
 			if err != nil {
@@ -642,15 +642,15 @@ func convProcTemplateProperty(ctx context.Context, proc map[string]interface{}) 
 				return nil, fmt.Errorf("%s illegal. val:%s. err:%s", key, val, err.Error())
 			}
 		case "port":
-			port, ok := val.(string)
-			if !ok {
-				return nil, fmt.Errorf("%s not string. val:%s", key, val)
-			}
-			processProperty.Port.Value = &port
-			processProperty.Port.AsDefaultValue = &blTrue
-			if err := processProperty.Port.Validate(); err != nil {
-				return nil, fmt.Errorf("%s illegal. val:%s. err:%s", key, val, err.Error())
-			}
+		/* 	port, ok := val.(string)
+		if !ok {
+			return nil, fmt.Errorf("%s not string. val:%s", key, val)
+		}
+		processProperty.Port.Value = &port
+		processProperty.Port.AsDefaultValue = &blTrue
+		if err := processProperty.Port.Validate(); err != nil {
+			return nil, fmt.Errorf("%s illegal. val:%s. err:%s", key, val, err.Error())
+		} */
 		case "pid_file":
 			pidFile, ok := val.(string)
 			if !ok {
@@ -722,16 +722,16 @@ func convProcTemplateProperty(ctx context.Context, proc map[string]interface{}) 
 				return nil, fmt.Errorf("%s illegal. val:%s. err:%s", key, val, err.Error())
 			}
 		case "protocol":
-			protocol, ok := val.(string)
-			if !ok {
-				return nil, fmt.Errorf("%s not string. val:%s", key, val)
-			}
-			protocalAlias := metadata.ProtocolType(protocol)
-			processProperty.Protocol.Value = &protocalAlias
-			processProperty.Protocol.AsDefaultValue = &blTrue
-			if err := processProperty.Protocol.Validate(); err != nil {
-				return nil, fmt.Errorf("%s illegal. val:%s. err:%s", key, val, err.Error())
-			}
+		/* 	protocol, ok := val.(string)
+		if !ok {
+			return nil, fmt.Errorf("%s not string. val:%s", key, val)
+		}
+		protocalAlias := metadata.ProtocolType(protocol)
+		processProperty.Protocol.Value = &protocalAlias
+		processProperty.Protocol.AsDefaultValue = &blTrue
+		if err := processProperty.Protocol.Validate(); err != nil {
+			return nil, fmt.Errorf("%s illegal. val:%s. err:%s", key, val, err.Error())
+		} */
 		case "description":
 			desc, ok := val.(string)
 			if !ok {

--- a/src/scene_server/admin_server/imports.go
+++ b/src/scene_server/admin_server/imports.go
@@ -93,5 +93,5 @@ import (
 	_ "configcenter/src/scene_server/admin_server/upgrader/y3.8.202006231730"
 	_ "configcenter/src/scene_server/admin_server/upgrader/y3.8.202006241144"
 	_ "configcenter/src/scene_server/admin_server/upgrader/y3.8.202006281530"
-	_ "configcenter/src/scene_server/admin_server/upgrader/y3.8.202007011748"
+	_ "configcenter/src/scene_server/admin_server/upgrader/y3.8.202007211455"
 )

--- a/src/scene_server/admin_server/upgrader/x19.05.16.01/upgrade_service_template.go
+++ b/src/scene_server/admin_server/upgrader/x19.05.16.01/upgrade_service_template.go
@@ -71,7 +71,7 @@ type ProcessTemplate struct {
 
 	// stores a process instance's data includes all the process's
 	// properties's value.
-	Property *metadata.ProcessProperty `field:"property" json:"property,omitempty" bson:"property"`
+	Property *ProcessProperty `field:"property" json:"property,omitempty" bson:"property"`
 
 	Creator         string    `field:"creator" json:"creator,omitempty" bson:"creator"`
 	Modifier        string    `field:"modifier" json:"modifier,omitempty" bson:"modifier"`
@@ -88,8 +88,8 @@ type ServiceInstance struct {
 
 	// the template id can not be updated, once the service is created.
 	// it can be 0 when the service is not created with a service template.
-	ServiceTemplateID int64  `field:"service_template_id" json:"service_template_id,omitempty" bson:"service_template_id"`
-	HostID            int64  `field:"bk_host_id" json:"bk_host_id,omitempty" bson:"bk_host_id"`
+	ServiceTemplateID int64 `field:"service_template_id" json:"service_template_id,omitempty" bson:"service_template_id"`
+	HostID            int64 `field:"bk_host_id" json:"bk_host_id,omitempty" bson:"bk_host_id"`
 
 	// the module that this service belongs to.
 	ModuleID int64 `field:"bk_module_id" json:"bk_module_id,omitempty" bson:"bk_module_id"`
@@ -373,9 +373,9 @@ func backupProcessBase(ctx context.Context, db dal.RDB, conf *upgrader.Config) (
 	return db.Table(common.BKTableNameBaseProcess).Update(ctx, nil, mapstr.MapStr{"old_flag": true})
 }
 
-func procInstToProcTemplate(inst Process) *metadata.ProcessProperty {
+func procInstToProcTemplate(inst Process) *ProcessProperty {
 	var True = true
-	template := metadata.ProcessProperty{}
+	template := ProcessProperty{}
 	if inst.ProcNum != nil && *inst.ProcNum > 0 {
 		template.ProcNum.Value = inst.ProcNum
 		template.ProcNum.AsDefaultValue = &True
@@ -467,4 +467,35 @@ func procInstToProcTemplate(inst Process) *metadata.ProcessProperty {
 	}
 
 	return &template
+}
+
+type ProcessProperty struct {
+	ProcNum            metadata.PropertyInt64    `field:"proc_num" json:"proc_num" bson:"proc_num" validate:"max=10000,min=1"`
+	StopCmd            metadata.PropertyString   `field:"stop_cmd" json:"stop_cmd" bson:"stop_cmd"`
+	RestartCmd         metadata.PropertyString   `field:"restart_cmd" json:"restart_cmd" bson:"restart_cmd"`
+	ForceStopCmd       metadata.PropertyString   `field:"face_stop_cmd" json:"face_stop_cmd" bson:"face_stop_cmd"`
+	FuncName           metadata.PropertyString   `field:"bk_func_name" json:"bk_func_name" bson:"bk_func_name" validate:"required"`
+	WorkPath           metadata.PropertyString   `field:"work_path" json:"work_path" bson:"work_path"`
+	BindIP             metadata.PropertyBindIP   `field:"bind_ip" json:"bind_ip" bson:"bind_ip"`
+	Priority           metadata.PropertyInt64    `field:"priority" json:"priority" bson:"priority" validate:"max=10000,min=1"`
+	ReloadCmd          metadata.PropertyString   `field:"reload_cmd" json:"reload_cmd" bson:"reload_cmd"`
+	ProcessName        metadata.PropertyString   `field:"bk_process_name" json:"bk_process_name" bson:"bk_process_name" validate:"required"`
+	Port               metadata.PropertyPort     `field:"port" json:"port" bson:"port"`
+	PidFile            metadata.PropertyString   `field:"pid_file" json:"pid_file" bson:"pid_file"`
+	AutoStart          metadata.PropertyBool     `field:"auto_start" json:"auto_start" bson:"auto_start"`
+	AutoTimeGapSeconds metadata.PropertyInt64    `field:"auto_time_gap" json:"auto_time_gap" bson:"auto_time_gap" validate:"max=10000,min=1"`
+	StartCmd           metadata.PropertyString   `field:"start_cmd" json:"start_cmd" bson:"start_cmd"`
+	FuncID             metadata.PropertyString   `field:"bk_func_id" json:"bk_func_id" bson:"bk_func_id"`
+	User               metadata.PropertyString   `field:"user" json:"user" bson:"user"`
+	TimeoutSeconds     metadata.PropertyInt64    `field:"timeout" json:"timeout" bson:"timeout" validate:"max=10000,min=1"`
+	Protocol           metadata.PropertyProtocol `field:"protocol" json:"protocol" bson:"protocol"`
+	Description        metadata.PropertyString   `field:"description" json:"description" bson:"description"`
+	StartParamRegex    metadata.PropertyString   `field:"bk_start_param_regex" json:"bk_start_param_regex" bson:"bk_start_param_regex"`
+	PortEnable         metadata.PropertyBool     `field:"bk_enable_port" json:"bk_enable_port" bson:"bk_enable_port"`
+	GatewayIP          metadata.PropertyString   `field:"bk_gateway_ip" json:"bk_gateway_ip" bson:"bk_gateway_ip"`
+	GatewayPort        metadata.PropertyString   `field:"bk_gateway_port" json:"bk_gateway_port" bson:"bk_gateway_port"`
+	GatewayProtocol    metadata.PropertyProtocol `field:"bk_gateway_protocol" json:"bk_gateway_protocol" bson:"bk_gateway_protocol"`
+	GatewayCity        metadata.PropertyString   `field:"bk_gateway_city" json:"bk_gateway_city" bson:"bk_gateway_city"`
+
+	BindInfo metadata.ProcPropertyBindInfo `field:"bind_info" json:"bind_info" bson:"bind_info" structs:"bind_info" mapstructure:"bind_info"`
 }

--- a/src/scene_server/admin_server/upgrader/y3.8.202007211455/pkg.go
+++ b/src/scene_server/admin_server/upgrader/y3.8.202007211455/pkg.go
@@ -1,0 +1,52 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package y3_8_202007211455
+
+import (
+	"context"
+
+	"configcenter/src/common/blog"
+	"configcenter/src/scene_server/admin_server/upgrader"
+	"configcenter/src/storage/dal"
+)
+
+func init() {
+	upgrader.RegistUpgrader("y3.8.202007211455", upgrade)
+}
+
+func upgrade(ctx context.Context, db dal.RDB, conf *upgrader.Config) (err error) {
+	blog.Infof("start execute y3.8.202007211455")
+
+	if err = addProcBindInfo(ctx, db, conf); err != nil {
+		blog.Errorf("[upgrade y3.8.202007211455] change process bind attr, error  %s", err.Error())
+		return err
+	}
+
+	if err = migrateProcTempBindInfo(ctx, db, conf); err != nil {
+		blog.Errorf("[upgrade y3.8.202007211455] migrate process template bind info, error  %s", err.Error())
+		return err
+	}
+
+	if err = migrateProcBindInfo(ctx, db, conf); err != nil {
+		blog.Errorf("[upgrade y3.8.202007211455] migrate process bind info, error  %s", err.Error())
+		return err
+	}
+
+	// upgrate data 之后才可以删除
+	if err = clearProcAttrAndGroup(ctx, db, conf); err != nil {
+		blog.Errorf("[upgrade y3.8.202007211455] clean process bind attr, error  %s", err.Error())
+		return err
+	}
+
+	return nil
+}

--- a/src/scene_server/admin_server/upgrader/y3.8.202007211455/proc_bind_change.go
+++ b/src/scene_server/admin_server/upgrader/y3.8.202007211455/proc_bind_change.go
@@ -1,0 +1,319 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package y3_8_202007211455
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"configcenter/src/common"
+	"configcenter/src/common/blog"
+	"configcenter/src/common/metadata"
+	"configcenter/src/scene_server/admin_server/upgrader"
+	"configcenter/src/storage/dal"
+)
+
+func addProcBindInfo(ctx context.Context, db dal.RDB, conf *upgrader.Config) error {
+
+	bindIPAttrFilter := map[string]interface{}{
+		common.BKObjIDField:      common.BKInnerObjIDProc,
+		common.BKPropertyIDField: "bind_info",
+	}
+	cnt, err := db.Table(common.BKTableNameObjAttDes).Find(bindIPAttrFilter).Count(ctx)
+	if err != nil {
+		return err
+	}
+	if cnt != 0 {
+		blog.Infof("add process attribute bind_info error.")
+		return nil
+	}
+
+	// add module attribute field
+	newAttributeID, err := db.NextSequence(ctx, common.BKTableNameObjAttDes)
+	if err != nil {
+		blog.Errorf("addProcBindIP failed, NextSequence failed, err: %s", err.Error())
+		return fmt.Errorf("NextSequence failed, err: %s", err.Error())
+	}
+
+	bindIPAttrIdxFilter := map[string]interface{}{
+		common.BKObjIDField: common.BKInnerObjIDProc,
+	}
+	sort := common.BKPropertyIndexField + ":-1"
+	procAttr := &Attribute{}
+	if err := db.Table(common.BKTableNameObjAttDes).Find(bindIPAttrIdxFilter).Sort(sort).One(ctx, procAttr); err != nil {
+		blog.Errorf("addProcBindIP failed, find proc max property index id failed, filter: %s err: %s", bindIPAttrIdxFilter, err.Error())
+		return err
+	}
+
+	nowTime := metadata.Now()
+	procBindIPAttr := &Attribute{
+		ID:            int64(newAttributeID),
+		OwnerID:       conf.OwnerID,
+		ObjectID:      common.BKInnerObjIDProc,
+		PropertyID:    "bind_info",
+		PropertyName:  "bind_info",
+		PropertyGroup: "proc_port",
+		PropertyIndex: procAttr.PropertyIndex + 1,
+		Placeholder:   "process bind port information",
+		IsEditable:    true,
+		IsPre:         true,
+		IsRequired:    false,
+		PropertyType:  common.FieldTypeTable,
+		Option:        getSubAttr(),
+		Creator:       conf.User,
+		CreateTime:    &nowTime,
+		LastTime:      &nowTime,
+	}
+
+	return db.Table(common.BKTableNameObjAttDes).Insert(ctx, procBindIPAttr)
+}
+
+func migrateProcBindInfo(ctx context.Context, db dal.RDB, conf *upgrader.Config) error {
+
+	// 已经处理过最大的进程id
+	maxProcID := int64(0)
+	for {
+		procs := make([]dbProcess, 0)
+		filter := map[string]interface{}{
+			common.BKProcIDField:  map[string]interface{}{common.BKDBGT: maxProcID},
+			common.BKProcBindInfo: map[string]interface{}{common.BKDBExists: false},
+		}
+		if err := db.Table(common.BKTableNameBaseProcess).Find(filter).Limit(500).All(ctx, &procs); err != nil {
+			return err
+		}
+		blog.InfoJSON("start process  bind info. process id start: %d", maxProcID)
+
+		for _, proc := range procs {
+			if proc.ProcessID > maxProcID {
+				maxProcID = proc.ProcessID
+			}
+
+			updateFilter := map[string]interface{}{
+				common.BKProcIDField:  proc.ProcessID,
+				common.BKProcBindInfo: map[string]interface{}{common.BKDBExists: false},
+			}
+			doc := map[string]interface{}{
+				common.BKProcBindInfo: []interface{}{
+					map[string]interface{}{
+						"template_row_id": 1,
+						"ip":              proc.BindIP,
+						"port":            proc.Port,
+						"protocol":        proc.Protocol,
+						"enable":          proc.PortEnable,
+					},
+				},
+			}
+			if err := db.Table(common.BKTableNameBaseProcess).Update(ctx, updateFilter, doc); err != nil {
+				return err
+			}
+
+		}
+		if len(procs) == 0 {
+			break
+		}
+
+	}
+
+	return nil
+}
+
+func migrateProcTempBindInfo(ctx context.Context, db dal.RDB, conf *upgrader.Config) error {
+
+	// 已经处理过最大的id
+	maxID := int64(0)
+	for {
+		procTemps := make([]dbProcessTemplate, 0)
+		filter := map[string]interface{}{
+			common.BKFieldID:                    map[string]interface{}{common.BKDBGT: maxID},
+			"property." + common.BKProcBindInfo: map[string]interface{}{common.BKDBExists: false},
+		}
+		if err := db.Table(common.BKTableNameProcessTemplate).Find(filter).Limit(500).All(ctx, &procTemps); err != nil {
+			return err
+		}
+		blog.InfoJSON("start process template bind info. id start: %d", maxID)
+
+		for _, procTemp := range procTemps {
+			if procTemp.ID > maxID {
+				maxID = procTemp.ID
+			}
+
+			// 保证数据库的数据不是null
+			bindInfoValue := make([]map[string]interface{}, 0)
+			if procTemp.Property != nil {
+				bindInfoValue = append(bindInfoValue, map[string]interface{}{
+					// 老版本只能有一行数据
+					"row_id":   1,
+					"ip":       procTemp.Property["bind_ip"],
+					"port":     procTemp.Property[common.BKPort],
+					"protocol": procTemp.Property[common.BKProtocol],
+					"enable":   procTemp.Property[common.BKProcPortEnable],
+				})
+			}
+			updateFilter := map[string]interface{}{
+				common.BKFieldID:      procTemp.ID,
+				common.BKProcBindInfo: map[string]interface{}{common.BKDBExists: false},
+			}
+			doc := map[string]interface{}{
+				"property." + common.BKProcBindInfo: map[string]interface{}{
+					"as_default_value": true,
+					"value":            bindInfoValue,
+				},
+			}
+			if err := db.Table(common.BKTableNameProcessTemplate).Update(ctx, updateFilter, doc); err != nil {
+				return err
+			}
+
+		}
+		if len(procTemps) == 0 {
+			break
+		}
+
+	}
+
+	return nil
+}
+
+func clearProcAttrAndGroup(ctx context.Context, db dal.RDB, conf *upgrader.Config) error {
+	delPropertyID := []string{common.BKProcGatewayIP, common.BKProcGatewayPort, common.BKProcGatewayProtocol, common.BKProcGatewayCity, common.BKBindIP, common.BKPort, common.BKProtocol, common.BKProcPortEnable}
+
+	delProcAttr := map[string]interface{}{
+		common.BKObjIDField:      common.BKInnerObjIDProc,
+		common.BKPropertyIDField: map[string]interface{}{common.BKDBIN: delPropertyID},
+	}
+
+	if err := db.Table(common.BKTableNameObjAttDes).Delete(ctx, delProcAttr); err != nil {
+		blog.ErrorJSON("clearProcAttrAndGroup failed, delete attribute, filter:%s err: %s", delProcAttr, err.Error())
+		return err
+	}
+
+	proxyGroupAttrFilter := map[string]interface{}{
+		common.BKObjIDField:         common.BKInnerObjIDProc,
+		common.BKPropertyGroupField: "network_proxy",
+	}
+	cnt, err := db.Table(common.BKTableNameObjAttDes).Find(proxyGroupAttrFilter).Count(ctx)
+	if err != nil {
+		blog.ErrorJSON("clearProcAttrAndGroup failed, find network proxy  attribute, filter:%s err: %s", proxyGroupAttrFilter, err.Error())
+		return err
+	}
+	if cnt > 0 {
+		return nil
+	}
+	delProxyGroupAttrFilter := map[string]interface{}{
+		common.BKObjIDField:         common.BKInnerObjIDProc,
+		common.BKPropertyGroupField: "network_proxy",
+	}
+	if err := db.Table(common.BKTableNamePropertyGroup).Delete(ctx, delProxyGroupAttrFilter); err != nil {
+		blog.ErrorJSON("clearProcAttrAndGroup failed, find network proxy  attribute, filter:%s err: %s", delProxyGroupAttrFilter, err.Error())
+		return err
+	}
+
+	return nil
+
+}
+
+func getSubAttr() []SubAttriubte {
+
+	return []SubAttriubte{
+		SubAttriubte{
+			PropertyID:   "ip",
+			PropertyName: "ip",
+			Placeholder:  "bind ip",
+			IsEditable:   true,
+			PropertyType: common.FieldTypeSingleChar,
+			Option:       "^([0-9]{1,3}\\.){3}[0-9]{1,3}$",
+		},
+		SubAttriubte{
+			PropertyID:   "port",
+			PropertyName: "port",
+			Placeholder:  "single port: 8080, </br>multiple consecutive ports: 8080-8089,</br> multiple discontinuous ports: 8080-8089, 8199.",
+			IsEditable:   true,
+			PropertyType: common.FieldTypeSingleChar,
+			Option:       "^(((([1-9][0-9]{0,3})|([1-5][0-9]{4})|(6[0-4][0-9]{3})|(65[0-4][0-9]{2})|(655[0-2][0-9])|(6553[0-5]))-(([1-9][0-9]{0,3})|([1-5][0-9]{4})|(6[0-4][0-9]{3})|(65[0-4][0-9]{2})|(655[0-2][0-9])|(6553[0-5])))|((([1-9][0-9]{0,3})|([1-5][0-9]{4})|(6[0-4][0-9]{3})|(65[0-4][0-9]{2})|(655[0-2][0-9])|(6553[0-5]))))(,(((([1-9][0-9]{0,3})|([1-5][0-9]{4})|(6[0-4][0-9]{3})|(65[0-4][0-9]{2})|(655[0-2][0-9])|(6553[0-5])))|((([1-9][0-9]{0,3})|([1-5][0-9]{4})|(6[0-4][0-9]{3})|(65[0-4][0-9]{2})|(655[0-2][0-9])|(6553[0-5]))-(([1-9][0-9]{0,3})|([1-5][0-9]{4})|(6[0-4][0-9]{3})|(65[0-4][0-9]{2})|(655[0-2][0-9])|(6553[0-5])))))*$",
+		},
+		SubAttriubte{
+			PropertyID:   "protocol",
+			PropertyName: "protocol",
+			Placeholder:  "service use protocol,",
+			IsEditable:   true,
+			PropertyType: common.FieldTypeEnum,
+			Option:       []metadata.EnumVal{{ID: "1", Name: "TCP", Type: "text", IsDefault: true}, {ID: "2", Name: "UDP", Type: "text"}},
+		},
+		SubAttriubte{
+			PropertyID:   "enable",
+			PropertyName: "enable",
+			Placeholder:  "enable port",
+			IsEditable:   true,
+			PropertyType: common.FieldTypeBool,
+		},
+	}
+}
+
+// Attribute attribute metadata definition
+type Attribute metadata.Attribute
+
+type SubAttriubte metadata.SubAttribute
+
+// dbProcess 当前数据库中数据的格式
+type dbProcess struct {
+	ProcNum         *int64                 `field:"proc_num" json:"proc_num" bson:"proc_num" structs:"proc_num" mapstructure:"proc_num"`
+	StopCmd         *string                `field:"stop_cmd" json:"stop_cmd" bson:"stop_cmd" structs:"stop_cmd" mapstructure:"stop_cmd"`
+	RestartCmd      *string                `field:"restart_cmd" json:"restart_cmd" bson:"restart_cmd" structs:"restart_cmd" mapstructure:"restart_cmd"`
+	ForceStopCmd    *string                `field:"face_stop_cmd" json:"face_stop_cmd" bson:"face_stop_cmd" structs:"face_stop_cmd" mapstructure:"face_stop_cmd"`
+	ProcessID       int64                  `field:"bk_process_id" json:"bk_process_id" bson:"bk_process_id" structs:"bk_process_id" mapstructure:"bk_process_id"`
+	FuncName        *string                `field:"bk_func_name" json:"bk_func_name" bson:"bk_func_name" structs:"bk_func_name" mapstructure:"bk_func_name"`
+	WorkPath        *string                `field:"work_path" json:"work_path" bson:"work_path" structs:"work_path" mapstructure:"work_path"`
+	BindIP          *string                `field:"bind_ip" json:"bind_ip" bson:"bind_ip" structs:"bind_ip" mapstructure:"bind_ip"`
+	Priority        *int64                 `field:"priority" json:"priority" bson:"priority" structs:"priority" mapstructure:"priority"`
+	ReloadCmd       *string                `field:"reload_cmd" json:"reload_cmd" bson:"reload_cmd" structs:"reload_cmd" mapstructure:"reload_cmd"`
+	ProcessName     *string                `field:"bk_process_name" json:"bk_process_name" bson:"bk_process_name" structs:"bk_process_name" mapstructure:"bk_process_name"`
+	Port            *string                `field:"port" json:"port" bson:"port" structs:"port" mapstructure:"port"`
+	PidFile         *string                `field:"pid_file" json:"pid_file" bson:"pid_file" structs:"pid_file" mapstructure:"pid_file"`
+	AutoStart       *bool                  `field:"auto_start" json:"auto_start" bson:"auto_start" structs:"auto_start" mapstructure:"auto_start"`
+	AutoTimeGap     *int64                 `field:"auto_time_gap" json:"auto_time_gap" bson:"auto_time_gap" structs:"auto_time_gap" mapstructure:"auto_time_gap"`
+	LastTime        time.Time              `field:"last_time" json:"last_time" bson:"last_time" structs:"last_time" mapstructure:"last_time"`
+	CreateTime      time.Time              `field:"create_time" json:"create_time" bson:"create_time" structs:"create_time" mapstructure:"create_time"`
+	BusinessID      int64                  `field:"bk_biz_id" json:"bk_biz_id" bson:"bk_biz_id" structs:"bk_biz_id" mapstructure:"bk_biz_id"`
+	StartCmd        *string                `field:"start_cmd" json:"start_cmd" bson:"start_cmd" structs:"start_cmd" mapstructure:"start_cmd"`
+	FuncID          *string                `field:"bk_func_id" json:"bk_func_id" bson:"bk_func_id" structs:"bk_func_id" mapstructure:"bk_func_id"`
+	User            *string                `field:"user" json:"user" bson:"user" structs:"user" mapstructure:"user"`
+	TimeoutSeconds  *int64                 `field:"timeout" json:"timeout" bson:"timeout" structs:"timeout" mapstructure:"timeout"`
+	Protocol        *metadata.ProtocolType `field:"protocol" json:"protocol" bson:"protocol" structs:"protocol" mapstructure:"protocol"`
+	Description     *string                `field:"description" json:"description" bson:"description" structs:"description" mapstructure:"description"`
+	SupplierAccount string                 `field:"bk_supplier_account" json:"bk_supplier_account" bson:"bk_supplier_account" structs:"bk_supplier_account" mapstructure:"bk_supplier_account"`
+	StartParamRegex *string                `field:"bk_start_param_regex" json:"bk_start_param_regex" bson:"bk_start_param_regex" structs:"bk_start_param_regex" mapstructure:"bk_start_param_regex"`
+	PortEnable      *bool                  `field:"bk_enable_port" json:"bk_enable_port" bson:"bk_enable_port"`
+	GatewayIP       *string                `field:"bk_gateway_ip" json:"bk_gateway_ip" bson:"bk_gateway_ip" structs:"bk_gateway_ip" mapstructure:"bk_gateway_ip"`
+	GatewayPort     *string                `field:"bk_gateway_port" json:"bk_gateway_port" bson:"bk_gateway_port" structs:"bk_gateway_port" mapstructure:"bk_gateway_port"`
+	GatewayProtocol *metadata.ProtocolType `field:"bk_gateway_protocol" json:"bk_gateway_protocol" bson:"bk_gateway_protocol" structs:"bk_gateway_protocol" mapstructure:"bk_gateway_protocol"`
+	GatewayCity     *string                `field:"bk_gateway_city" json:"bk_gateway_city" bson:"bk_gateway_city" structs:"bk_gateway_city" mapstructure:"bk_gateway_city"`
+}
+
+// this works for the process instance which is used for a template.
+type dbProcessTemplate struct {
+	ID          int64  `field:"id" json:"id" bson:"id"`
+	ProcessName string `field:"bk_process_name" json:"bk_process_name" bson:"bk_process_name"`
+	BizID       int64  `field:"bk_biz_id" json:"bk_biz_id" bson:"bk_biz_id"`
+	// the service template's, which this process template belongs to.
+	ServiceTemplateID int64 `field:"service_template_id" json:"service_template_id" bson:"service_template_id"`
+
+	// stores a process instance's data includes all the process's
+	// properties's value.
+	Property map[string]interface{} `field:"property" json:"property" bson:"property"`
+
+	Creator         string    `field:"creator" json:"creator" bson:"creator"`
+	Modifier        string    `field:"modifier" json:"modifier" bson:"modifier"`
+	CreateTime      time.Time `field:"create_time" json:"create_time" bson:"create_time"`
+	LastTime        time.Time `field:"last_time" json:"last_time" bson:"last_time"`
+	SupplierAccount string    `field:"bk_supplier_account" json:"bk_supplier_account" bson:"bk_supplier_account"`
+}

--- a/src/scene_server/event_server/identifier/hostcache.go
+++ b/src/scene_server/event_server/identifier/hostcache.go
@@ -68,7 +68,7 @@ func fillProcess(process *metadata.HostIdentProcess, ctx context.Context, cache 
 		return err
 	}
 
-	ip, port, protocol, enable := getBindInfo(proc.data[common.BKProcBindInfo])
+	ip, port, protocol, enable, bindInfoArr := getBindInfo(proc.data[common.BKProcBindInfo])
 	process.ProcessName = getString(proc.data[common.BKProcessNameField])
 	process.FuncID = getString(proc.data[common.BKFuncIDField])
 	process.FuncName = getString(proc.data[common.BKFuncName])
@@ -76,12 +76,14 @@ func fillProcess(process *metadata.HostIdentProcess, ctx context.Context, cache 
 	process.Protocol = protocol // getString(proc.data[common.BKProtocol])
 	process.Port = port         // getString(proc.data[common.BKPort])
 	process.PortEnable = enable
+	process.BindInfo = bindInfoArr
 	process.StartParamRegex = getString(proc.data[common.BKStartParamRegex])
 	return nil
 }
 
 func fillModule(identifier *metadata.HostIdentifier, hostIdentModule *metadata.HostIdentModule, customLayers []string,
 	ctx context.Context, cache *redis.Client, clientSet apimachinery.ClientSetInterface, db dal.RDB) error {
+
 	biz, err := getCache(ctx, cache, clientSet, db, common.BKInnerObjIDApp, hostIdentModule.BizID)
 	if err != nil {
 		blog.Errorf("identifier: getCache for %s %d error %s", common.BKInnerObjIDApp, hostIdentModule.BizID, err.Error())

--- a/src/scene_server/event_server/identifier/hostcache.go
+++ b/src/scene_server/event_server/identifier/hostcache.go
@@ -67,12 +67,15 @@ func fillProcess(process *metadata.HostIdentProcess, ctx context.Context, cache 
 		blog.Errorf("identifier: getCache for %s %d error %s", common.BKInnerObjIDProc, process.ProcessID, err.Error())
 		return err
 	}
+
+	ip, port, protocol, enable := getBindInfo(proc.data[common.BKProcBindInfo])
 	process.ProcessName = getString(proc.data[common.BKProcessNameField])
 	process.FuncID = getString(proc.data[common.BKFuncIDField])
 	process.FuncName = getString(proc.data[common.BKFuncName])
-	process.BindIP = getString(proc.data[common.BKBindIP])
-	process.Protocol = getString(proc.data[common.BKProtocol])
-	process.Port = getString(proc.data[common.BKPort])
+	process.BindIP = ip         //getString(proc.data[common.BKBindIP])
+	process.Protocol = protocol // getString(proc.data[common.BKProtocol])
+	process.Port = port         // getString(proc.data[common.BKPort])
+	process.PortEnable = enable
 	process.StartParamRegex = getString(proc.data[common.BKStartParamRegex])
 	return nil
 }

--- a/src/scene_server/event_server/identifier/identifier.go
+++ b/src/scene_server/event_server/identifier/identifier.go
@@ -17,9 +17,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 	"runtime/debug"
 	"strconv"
-	"strings"
 	"time"
 
 	"configcenter/src/apimachinery"
@@ -59,6 +59,7 @@ var hostIndentDiffFields = map[string][]string{
 		common.BKProtocol,
 		common.BKPort,
 		common.BKStartParamRegex,
+		common.BKProcBindInfo,
 	},
 	common.BKInnerObjIDHost: {
 		common.BKHostNameField,
@@ -119,7 +120,6 @@ func (ih *IdentifierHandler) handleInstFieldChange(event *metadata.EventInstCtx,
 			blog.Errorf("identifier: inst == nil, continue, rid:%s", rid)
 			continue
 		}
-
 		if common.BKInnerObjIDHost == event.ObjType {
 			// save previous host identifier data for later usage.
 			preInst := inst.copy()
@@ -141,6 +141,7 @@ func (ih *IdentifierHandler) handleInstFieldChange(event *metadata.EventInstCtx,
 			ih.cache.LPush(types.EventCacheEventQueueKey, &hostIdentify)
 			blog.InfoJSON("identifier: pushed event inst %s, rid: %s", hostIdentify, rid)
 		} else {
+			fmt.Println(event.ObjType, "handleRelatedInst")
 			if err := ih.handleRelatedInst(hostIdentify, event.ObjType, instID, preData, curData, diffFields); err != nil {
 				blog.Warnf("handleRelatedInst failed objType: %s, inst: %d, error: %v, rid: %s", event.ObjType, instID, err, rid)
 			}
@@ -370,24 +371,17 @@ func (ih *IdentifierHandler) handleRelatedInst(hostIdentify metadata.EventInst, 
 				if process.ProcessID != instID {
 					continue
 				}
-				for _, field := range diffFields {
-					switch field {
-					case common.BKProcessNameField:
-						process.ProcessName = getString(curData[field])
-					case common.BKFuncIDField:
-						process.FuncID = getString(curData[field])
-					case common.BKFuncName:
-						process.FuncName = getString(curData[field])
-					case common.BKBindIP:
-						process.BindIP = getString(curData[field])
-					case common.BKProtocol:
-						process.Protocol = getString(curData[field])
-					case common.BKPort:
-						process.Port = getString(curData[field])
-					case common.BKStartParamRegex:
-						process.StartParamRegex = getString(curData[field])
-					}
-				}
+				ip, port, protocol, enable, bindInfoArr := getBindInfo(curData[common.BKProcBindInfo])
+				process.BindIP = ip
+				process.Port = port
+				process.Protocol = protocol
+				process.PortEnable = enable
+				process.ProcessName = getString(curData[common.BKAppName])
+				process.FuncID = getString(curData[common.BKFuncIDField])
+				process.FuncName = getString(curData[common.BKFuncName])
+				process.StartParamRegex = getString(curData[common.BKStartParamRegex])
+				process.BindInfo = bindInfoArr
+
 				inst.ident.Process[index] = process
 			}
 		}
@@ -421,6 +415,7 @@ func (ih *IdentifierHandler) handleHostBatch(hostIdentify metadata.EventInst, ho
 			if nil == inst {
 				continue
 			}
+
 			preIdentifier := inst.copy()
 			err = handler(hostID, inst)
 			if err != nil {
@@ -635,6 +630,7 @@ func getCache(ctx context.Context, cache *redis.Client, clientSet apimachinery.C
 			blog.Errorf("search host with id: %d failed, err: %s", instID, err.Error())
 			return nil, err
 		}
+
 		if len(host) == 0 {
 			return nil, nil
 		}
@@ -865,10 +861,19 @@ func (ih *IdentifierHandler) popEvent() *metadata.EventInstCtx {
 }
 
 func hasChanged(curData, preData map[string]interface{}, fields ...string) (isDifferent bool) {
+
 	for _, field := range fields {
-		if curData[field] != preData[field] {
-			return true
+		switch field {
+		case common.BKProcBindInfo:
+			if !reflect.DeepEqual(curData[field], preData[field]) {
+				return true
+			}
+		default:
+			if curData[field] != preData[field] {
+				return true
+			}
 		}
+
 	}
 	return false
 }
@@ -895,47 +900,36 @@ func NewIdentifierHandler(ctx context.Context, cache *redis.Client, db dal.RDB, 
 	return &IdentifierHandler{ctx: ctx, cache: cache, db: db, clientSet: clientSet}
 }
 
-func getBindInfo(value interface{}) (ip, port, protocol string, enable bool) {
+func getBindInfo(value interface{}) (ip, port, protocol string, enable bool, bindInfoArr []metadata.ProcBindInfo) {
 	if value == nil {
-		return "", "", "", false
+		return
 	}
-	switch arr := value.(type) {
-	case []interface{}:
-		for _, row := range arr {
-			rowMap, ok := row.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			if ip == "" && getString(rowMap[common.BKIP]) != "" {
-				ip = getString(rowMap[common.BKIP])
-			}
-			if port == "" && getString(rowMap[common.BKPort]) != "" {
-				port = getString(rowMap[common.BKPort])
-			}
-			if protocol == "" && getString(rowMap[common.BKProtocol]) != "" {
-				ip = getString(rowMap[common.BKProtocol])
-			}
-			if strings.ToLower(getString(rowMap[common.BKIP])) == "true" {
-				enable = true
-
-			}
+	bindInfoByteArr, err := json.Marshal(value)
+	if err != nil {
+		blog.Errorf("%v marshal error.", value, err.Error())
+		return
+	}
+	bindInfoArr = make([]metadata.ProcBindInfo, 0)
+	if err := json.Unmarshal(bindInfoByteArr, &bindInfoArr); err != nil {
+		blog.Errorf("%s ummarshal error.", string(bindInfoByteArr), err.Error())
+		return
+	}
+	for _, row := range bindInfoArr {
+		if row.Std == nil {
+			continue
 		}
-	case []map[string]interface{}:
-		for _, row := range arr {
-			if ip == "" && getString(row[common.BKIP]) != "" {
-				ip = getString(row[common.BKIP])
-			}
-			if port == "" && getString(row[common.BKPort]) != "" {
-				port = getString(row[common.BKPort])
-			}
-			if protocol == "" && getString(row[common.BKProtocol]) != "" {
-				ip = getString(row[common.BKProtocol])
-			}
-			if strings.ToLower(getString(row[common.BKIP])) == "true" {
-				enable = true
-
-			}
+		if ip == "" && row.Std.IP != nil {
+			ip = *row.Std.IP
+		}
+		if port == "" && row.Std.Port != nil {
+			port = *row.Std.Port
+		}
+		if protocol == "" && row.Std.Protocol != nil {
+			protocol = *row.Std.Protocol
+		}
+		if row.Std.Enable != nil && *row.Std.Enable == true {
+			enable = true
 		}
 	}
-	return "", "", "", false
+	return
 }

--- a/src/scene_server/event_server/identifier/identifier.go
+++ b/src/scene_server/event_server/identifier/identifier.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"strconv"
+	"strings"
 	"time"
 
 	"configcenter/src/apimachinery"
@@ -892,4 +893,49 @@ func getInstCacheKey(objType string, instID int64) string {
 
 func NewIdentifierHandler(ctx context.Context, cache *redis.Client, db dal.RDB, clientSet apimachinery.ClientSetInterface) *IdentifierHandler {
 	return &IdentifierHandler{ctx: ctx, cache: cache, db: db, clientSet: clientSet}
+}
+
+func getBindInfo(value interface{}) (ip, port, protocol string, enable bool) {
+	if value == nil {
+		return "", "", "", false
+	}
+	switch arr := value.(type) {
+	case []interface{}:
+		for _, row := range arr {
+			rowMap, ok := row.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if ip == "" && getString(rowMap[common.BKIP]) != "" {
+				ip = getString(rowMap[common.BKIP])
+			}
+			if port == "" && getString(rowMap[common.BKPort]) != "" {
+				port = getString(rowMap[common.BKPort])
+			}
+			if protocol == "" && getString(rowMap[common.BKProtocol]) != "" {
+				ip = getString(rowMap[common.BKProtocol])
+			}
+			if strings.ToLower(getString(rowMap[common.BKIP])) == "true" {
+				enable = true
+
+			}
+		}
+	case []map[string]interface{}:
+		for _, row := range arr {
+			if ip == "" && getString(row[common.BKIP]) != "" {
+				ip = getString(row[common.BKIP])
+			}
+			if port == "" && getString(row[common.BKPort]) != "" {
+				port = getString(row[common.BKPort])
+			}
+			if protocol == "" && getString(row[common.BKProtocol]) != "" {
+				ip = getString(row[common.BKProtocol])
+			}
+			if strings.ToLower(getString(row[common.BKIP])) == "true" {
+				enable = true
+
+			}
+		}
+	}
+	return "", "", "", false
 }

--- a/src/scene_server/proc_server/logics/processinstance.go
+++ b/src/scene_server/proc_server/logics/processinstance.go
@@ -259,18 +259,18 @@ func (lgc *Logic) DiffWithProcessTemplate(t *metadata.ProcessProperty, i *metada
 		}
 	}
 
-	if metadata.IsAsDefaultValue(t.BindIP.AsDefaultValue) {
-		if (t.BindIP.Value == nil && i.BindIP != nil) ||
-			(t.BindIP.Value != nil && i.BindIP == nil) ||
-			(t.BindIP.Value != nil && i.BindIP != nil && t.BindIP.Value.IP() != *i.BindIP) {
+	if metadata.IsAsDefaultValue(t.BindInfo.AsDefaultValue) {
+		newBindInfo, change := t.BindInfo.DiffWithProcessTemplate(i.BindInfo)
+		if change {
 			changes = append(changes, metadata.ProcessChangedAttribute{
-				ID:                    attrMap["bind_ip"].ID,
-				PropertyID:            "bind_ip",
-				PropertyName:          attrMap["bind_ip"].PropertyName,
-				PropertyValue:         i.BindIP,
-				TemplatePropertyValue: t.BindIP.Value.IP(),
+				ID:                    attrMap[common.BKProcBindInfo].ID,
+				PropertyID:            common.BKProcBindInfo,
+				PropertyName:          attrMap[common.BKProcBindInfo].PropertyName,
+				PropertyValue:         i.BindInfo,
+				TemplatePropertyValue: newBindInfo,
 			})
 		}
+
 	}
 
 	if metadata.IsAsDefaultValue(t.Priority.AsDefaultValue) {
@@ -311,20 +311,6 @@ func (lgc *Logic) DiffWithProcessTemplate(t *metadata.ProcessProperty, i *metada
 				PropertyName:          attrMap["bk_process_name"].PropertyName,
 				PropertyValue:         i.ProcessName,
 				TemplatePropertyValue: t.ProcessName,
-			})
-		}
-	}
-
-	if metadata.IsAsDefaultValue(t.Port.AsDefaultValue) {
-		if (t.Port.Value == nil && i.Port != nil) ||
-			(t.Port.Value != nil && i.Port == nil) ||
-			(t.Port.Value != nil && i.Port != nil && *t.Port.Value != *i.Port) {
-			changes = append(changes, metadata.ProcessChangedAttribute{
-				ID:                    attrMap["port"].ID,
-				PropertyID:            "port",
-				PropertyName:          attrMap["port"].PropertyName,
-				PropertyValue:         i.Port,
-				TemplatePropertyValue: t.Port,
 			})
 		}
 	}
@@ -427,20 +413,6 @@ func (lgc *Logic) DiffWithProcessTemplate(t *metadata.ProcessProperty, i *metada
 		}
 	}
 
-	if metadata.IsAsDefaultValue(t.Protocol.AsDefaultValue) {
-		if (t.Protocol.Value == nil && i.Protocol != nil) ||
-			(t.Protocol.Value != nil && i.Protocol == nil) ||
-			(t.Protocol.Value != nil && i.Protocol != nil && *t.Protocol.Value != *i.Protocol) {
-			changes = append(changes, metadata.ProcessChangedAttribute{
-				ID:                    attrMap["protocol"].ID,
-				PropertyID:            "protocol",
-				PropertyName:          attrMap["protocol"].PropertyName,
-				PropertyValue:         i.Protocol,
-				TemplatePropertyValue: t.Protocol,
-			})
-		}
-	}
-
 	if metadata.IsAsDefaultValue(t.Description.AsDefaultValue) {
 		if (t.Description.Value == nil && i.Description != nil) ||
 			(t.Description.Value != nil && i.Description == nil) ||
@@ -465,76 +437,6 @@ func (lgc *Logic) DiffWithProcessTemplate(t *metadata.ProcessProperty, i *metada
 				PropertyName:          attrMap["bk_start_param_regex"].PropertyName,
 				PropertyValue:         i.StartParamRegex,
 				TemplatePropertyValue: t.StartParamRegex,
-			})
-		}
-	}
-
-	if metadata.IsAsDefaultValue(t.PortEnable.AsDefaultValue) {
-		if (t.PortEnable.Value == nil && i.PortEnable != nil) ||
-			(t.PortEnable.Value != nil && i.PortEnable == nil) ||
-			(t.PortEnable.Value != nil && i.PortEnable != nil && *t.PortEnable.Value != *i.PortEnable) {
-			changes = append(changes, metadata.ProcessChangedAttribute{
-				ID:                    attrMap[common.BKProcPortEnable].ID,
-				PropertyID:            common.BKProcPortEnable,
-				PropertyName:          attrMap[common.BKProcPortEnable].PropertyName,
-				PropertyValue:         i.PortEnable,
-				TemplatePropertyValue: t.PortEnable,
-			})
-		}
-	}
-
-	if metadata.IsAsDefaultValue(t.GatewayIP.AsDefaultValue) {
-		if (t.GatewayIP.Value == nil && i.GatewayIP != nil) ||
-			(t.GatewayIP.Value != nil && i.GatewayIP == nil) ||
-			(t.GatewayIP.Value != nil && i.GatewayIP != nil && *t.GatewayIP.Value != *i.GatewayIP) {
-			changes = append(changes, metadata.ProcessChangedAttribute{
-				ID:                    attrMap[common.BKProcGatewayIP].ID,
-				PropertyID:            common.BKProcGatewayIP,
-				PropertyName:          attrMap[common.BKProcGatewayIP].PropertyName,
-				PropertyValue:         i.GatewayIP,
-				TemplatePropertyValue: t.GatewayIP,
-			})
-		}
-	}
-
-	if metadata.IsAsDefaultValue(t.GatewayPort.AsDefaultValue) {
-		if (t.GatewayPort.Value == nil && i.GatewayPort != nil) ||
-			(t.GatewayPort.Value != nil && i.GatewayPort == nil) ||
-			(t.GatewayPort.Value != nil && i.GatewayPort != nil && *t.GatewayPort.Value != *i.GatewayPort) {
-			changes = append(changes, metadata.ProcessChangedAttribute{
-				ID:                    attrMap[common.BKProcGatewayPort].ID,
-				PropertyID:            common.BKProcGatewayPort,
-				PropertyName:          attrMap[common.BKProcGatewayPort].PropertyName,
-				PropertyValue:         i.GatewayPort,
-				TemplatePropertyValue: t.GatewayPort,
-			})
-		}
-	}
-
-	if metadata.IsAsDefaultValue(t.GatewayProtocol.AsDefaultValue) {
-		if (t.GatewayProtocol.Value == nil && i.GatewayProtocol != nil) ||
-			(t.GatewayProtocol.Value != nil && i.GatewayProtocol == nil) ||
-			(t.GatewayProtocol.Value != nil && i.GatewayProtocol != nil && *t.GatewayProtocol.Value != *i.GatewayProtocol) {
-			changes = append(changes, metadata.ProcessChangedAttribute{
-				ID:                    attrMap[common.BKProcGatewayProtocol].ID,
-				PropertyID:            common.BKProcGatewayProtocol,
-				PropertyName:          attrMap[common.BKProcGatewayProtocol].PropertyName,
-				PropertyValue:         i.GatewayProtocol,
-				TemplatePropertyValue: t.GatewayProtocol,
-			})
-		}
-	}
-
-	if metadata.IsAsDefaultValue(t.GatewayCity.AsDefaultValue) {
-		if (t.GatewayCity.Value == nil && i.GatewayCity != nil) ||
-			(t.GatewayCity.Value != nil && i.GatewayCity == nil) ||
-			(t.GatewayCity.Value != nil && i.GatewayCity != nil && *t.GatewayCity.Value != *i.GatewayCity) {
-			changes = append(changes, metadata.ProcessChangedAttribute{
-				ID:                    attrMap[common.BKProcGatewayCity].ID,
-				PropertyID:            common.BKProcGatewayCity,
-				PropertyName:          attrMap[common.BKProcGatewayCity].PropertyName,
-				PropertyValue:         i.GatewayCity,
-				TemplatePropertyValue: t.GatewayCity,
 			})
 		}
 	}

--- a/src/scene_server/proc_server/service/processinstance.go
+++ b/src/scene_server/proc_server/service/processinstance.go
@@ -457,7 +457,7 @@ func (ps *ProcServer) validateRawInstanceUnique(ctx *rest.Contexts, serviceInsta
 	rid := ctx.Kit.Rid
 
 	processInfo := metadata.Process{}
-	if err := mapstruct.Decode2Struct(processData, &processInfo); err != nil {
+	if err := mapstr.DecodeFromMapStr(&processInfo, processData); err != nil {
 		blog.ErrorJSON("validateRawInstanceUnique failed, Decode2Struct failed, process: %s, err: %s, rid: %s", processData, err.Error(), rid)
 		return ctx.Kit.CCError.CCErrorf(common.CCErrCommJSONUnmarshalFailed)
 	}

--- a/src/scene_server/proc_server/service/processtemplate.go
+++ b/src/scene_server/proc_server/service/processtemplate.go
@@ -64,7 +64,8 @@ func (ps *ProcServer) CreateProcessTemplateBatch(ctx *rest.Contexts) {
 			temp, err := ps.CoreAPI.CoreService().Process().CreateProcessTemplate(ctx.Kit.Ctx, ctx.Kit.Header, t)
 			if err != nil {
 				blog.Errorf("create process template failed, template: +%v", *t)
-				return ctx.Kit.CCError.CCError(common.CCErrProcCreateProcessTemplateFailed)
+
+				return err
 			}
 
 			ids = append(ids, temp.ID)

--- a/src/source_controller/coreservice/core/host/identifier/identifier.go
+++ b/src/source_controller/coreservice/core/host/identifier/identifier.go
@@ -272,6 +272,25 @@ func (i *Identifier) findHostServiceInst(kit *rest.Kit, hostIDs []int64) error {
 
 	procs := make(map[int64]metadata.HostIdentProcess, 0)
 	for _, procInfo := range procInfos {
+		// deprecated 为了保持兼容格式
+		for _, item := range procInfo.BindInfo {
+			if item.Std == nil {
+				continue
+			}
+			if procInfo.BindIP == "" && item.Std.IP != nil {
+				procInfo.BindIP = *item.Std.IP
+			}
+			if procInfo.Port == "" && item.Std.Port != nil {
+				procInfo.Port = *item.Std.Port
+			}
+			if procInfo.Protocol == "" && item.Std.Protocol != nil {
+				procInfo.Protocol = *item.Std.Protocol
+			}
+			if item.Std.Enable != nil && *item.Std.Enable {
+				procInfo.PortEnable = *item.Std.Enable
+			}
+		}
+
 		if moduleIDs, ok := procModuleRelation[procInfo.ProcessID]; ok {
 			procInfo.BindModules = moduleIDs
 		}

--- a/src/source_controller/coreservice/core/process/process_template.go
+++ b/src/source_controller/coreservice/core/process/process_template.go
@@ -85,7 +85,7 @@ func (p *processOperation) CreateProcessTemplate(kit *rest.Kit, template metadat
 	template.SupplierAccount = kit.SupplierAccount
 
 	if err := p.dbProxy.Table(common.BKTableNameProcessTemplate).Insert(kit.Ctx, &template); nil != err {
-		blog.Errorf("CreateProcessTemplate failed, mongodb failed, table: %s, template: %+v, err: %+v, rid: %s", common.BKTableNameProcessTemplate, template, err, kit.Rid)
+		blog.ErrorJSON("CreateProcessTemplate failed, mongodb failed, table: %s, template: %s, err: %s, rid: %s", common.BKTableNameProcessTemplate, template, err, kit.Rid)
 		return nil, kit.CCError.CCErrorf(common.CCErrCommDBInsertFailed)
 	}
 	return &template, nil

--- a/src/source_controller/coreservice/core/process/process_template.go
+++ b/src/source_controller/coreservice/core/process/process_template.go
@@ -1,4 +1,5 @@
 /*
+/*
  * Tencent is pleased to support the open source community by making 蓝鲸 available.,
  * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
  * Licensed under the MIT License (the ",License",); you may not use this file except
@@ -8,7 +9,7 @@
  * the License is distributed on an ",AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
  * either express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
- */
+*/
 
 package process
 
@@ -67,13 +68,6 @@ func (p *processOperation) CreateProcessTemplate(kit *rest.Kit, template metadat
 	if nil != err {
 		blog.Errorf("CreateProcessTemplate failed, generate id failed, err: %+v, rid: %s", err, kit.Rid)
 		return nil, kit.CCError.CCErrorf(common.CCErrCommGenerateRecordIDFailed)
-	}
-
-	// process template bk_enable_port not set vaule, default value must be true
-	if template.Property.PortEnable.AsDefaultValue == nil {
-		blTrue := true
-		template.Property.PortEnable.AsDefaultValue = &blTrue
-		template.Property.PortEnable.Value = &blTrue
 	}
 
 	template.ID = int64(id)

--- a/src/source_controller/coreservice/core/process/service_instance.go
+++ b/src/source_controller/coreservice/core/process/service_instance.go
@@ -543,9 +543,12 @@ func (p *processOperation) generateServiceInstanceName(kit *rest.Kit, instanceID
 		if process.ProcessName != nil && len(*process.ProcessName) > 0 {
 			instanceName += fmt.Sprintf("_%s", *process.ProcessName)
 		}
-		if process.Port != nil && len(*process.Port) > 0 {
-			instanceName += fmt.Sprintf("_%s", *process.Port)
+		for _, bindInfo := range process.BindInfo {
+			if bindInfo.Std != nil && bindInfo.Std.Port != nil {
+				instanceName += fmt.Sprintf("_%s", *bindInfo.Std.Port)
+			}
 		}
+
 	}
 	return instanceName, nil
 }

--- a/src/source_controller/coreservice/core/process/service_instance.go
+++ b/src/source_controller/coreservice/core/process/service_instance.go
@@ -546,6 +546,7 @@ func (p *processOperation) generateServiceInstanceName(kit *rest.Kit, instanceID
 		for _, bindInfo := range process.BindInfo {
 			if bindInfo.Std != nil && bindInfo.Std.Port != nil {
 				instanceName += fmt.Sprintf("_%s", *bindInfo.Std.Port)
+				break
 			}
 		}
 

--- a/src/test/proc_server/no_service_template_test.go
+++ b/src/test/proc_server/no_service_template_test.go
@@ -881,9 +881,7 @@ var _ = Describe("no service template test", func() {
 			json.Unmarshal(j, &data)
 			Expect(data.Count).To(Equal(int64(1)))
 			Expect(data.Info[0].Property[common.BKProcessNameField]).To(Equal("p3"))
-			Expect(data.Info[0].Property[common.BKProcPortEnable]).To(Equal(true))
 			Expect(data.Info[0].Property[common.BKDescriptionField]).To(Equal("aaa"))
-			Expect(data.Info[0].Property[common.BKProtocol]).To(Equal("1"))
 			bindInfo := map[string]interface{}{
 				"ip":       "127.0.0.1",
 				"port":     "1024",
@@ -892,8 +890,9 @@ var _ = Describe("no service template test", func() {
 			}
 			ExpectBindInfoArr, err := commonutil.GetMapInterfaceByInerface(data.Info[0].Property[common.BKProcBindInfo])
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(ExpectBindInfoArr)).To(Equal(int64(1)))
+			Expect(len(ExpectBindInfoArr)).To(Equal(int(1)))
 			expectBindInfo, ok := ExpectBindInfoArr[0].(map[string]interface{})
+			delete(expectBindInfo, "template_row_id")
 			Expect(ok).To(Equal(true))
 			Expect(expectBindInfo).To(Equal(bindInfo))
 

--- a/src/test/proc_server/no_service_template_test.go
+++ b/src/test/proc_server/no_service_template_test.go
@@ -1,3 +1,14 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package proc_server_test
 
 import (
@@ -686,6 +697,14 @@ var _ = Describe("no service template test", func() {
 						"bk_process_name":      "p3",
 						"bk_start_param_regex": "1234",
 						"bk_process_id":        processId,
+						"bind_info": []map[string]interface{}{
+							map[string]interface{}{
+								"ip":       "127.0.0.1",
+								"port":     "1024",
+								"protocol": "1",
+								"enable":   true,
+							},
+						},
 					},
 				},
 			}
@@ -831,9 +850,7 @@ var _ = Describe("no service template test", func() {
 				common.BKAppIDField: bizId,
 				"process_ids":       []int64{processId},
 				"update_data": map[string]interface{}{
-					common.BKProcPortEnable:   true,
 					common.BKDescriptionField: "aaa",
-					common.BKProtocol:         "1",
 				},
 			}
 			rsp, err := processClient.UpdateProcessInstancesByIDs(context.Background(), header, input)
@@ -867,6 +884,19 @@ var _ = Describe("no service template test", func() {
 			Expect(data.Info[0].Property[common.BKProcPortEnable]).To(Equal(true))
 			Expect(data.Info[0].Property[common.BKDescriptionField]).To(Equal("aaa"))
 			Expect(data.Info[0].Property[common.BKProtocol]).To(Equal("1"))
+			bindInfo := map[string]interface{}{
+				"ip":       "127.0.0.1",
+				"port":     "1024",
+				"protocol": "1",
+				"enable":   true,
+			}
+			ExpectBindInfoArr, err := commonutil.GetMapInterfaceByInerface(data.Info[0].Property[common.BKProcBindInfo])
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(ExpectBindInfoArr)).To(Equal(int64(1)))
+			expectBindInfo, ok := ExpectBindInfoArr[0].(map[string]interface{})
+			Expect(ok).To(Equal(true))
+			Expect(expectBindInfo).To(Equal(bindInfo))
+
 		})
 
 		It("delete process instance", func() {
@@ -988,14 +1018,14 @@ var _ = Describe("list_biz_host_process test", func() {
 					"processes": []map[string]interface{}{
 						{
 							"process_info": map[string]interface{}{
-								common.BKPort:             "123",
+								//common.BKPort:             "123",
 								common.BKFuncName:         "p11111",
 								common.BKProcessNameField: "p11111",
 							},
 						},
 						{
 							"process_info": map[string]interface{}{
-								common.BKProtocol:         "2",
+								//common.BKProtocol:         "2",
 								common.BKFuncName:         "p22222",
 								common.BKProcessNameField: "p22222",
 							},
@@ -1007,7 +1037,7 @@ var _ = Describe("list_biz_host_process test", func() {
 					"processes": []map[string]interface{}{
 						{
 							"process_info": map[string]interface{}{
-								common.BKBindIP:           "0.0.0.0",
+								//common.BKBindIP:           "0.0.0.0",
 								common.BKFuncName:         "p33333",
 								common.BKProcessNameField: "p33333",
 							},
@@ -1045,8 +1075,8 @@ var _ = Describe("list_biz_host_process test", func() {
 		Expect(data.Info[0].HostID).To(Or(Equal(hostId3), Equal(hostId4)))
 		Expect(data.Info[1].HostID).To(Or(Equal(hostId3), Equal(hostId4)))
 		Expect(data.Info[2].HostID).To(Or(Equal(hostId3), Equal(hostId4)))
-		Expect("0.0.0.0").To(Or(Equal(data.Info[0].BindIP), Equal(data.Info[1].BindIP), Equal(data.Info[2].BindIP)))
-		Expect("123").To(Or(Equal(data.Info[0].Port), Equal(data.Info[1].Port), Equal(data.Info[2].Port)))
-		Expect("2").To(Or(Equal(string(data.Info[0].Protocol)), Equal(string(data.Info[1].Protocol)), Equal(string(data.Info[2].Protocol))))
+		//Expect("0.0.0.0").To(Or(Equal(data.Info[0].BindIP), Equal(data.Info[1].BindIP), Equal(data.Info[2].BindIP)))
+		//Expect("123").To(Or(Equal(data.Info[0].Port), Equal(data.Info[1].Port), Equal(data.Info[2].Port)))
+		//Expect("2").To(Or(Equal(string(data.Info[0].Protocol)), Equal(string(data.Info[1].Protocol)), Equal(string(data.Info[2].Protocol))))
 	})
 })


### PR DESCRIPTION
### 新加的功能:
- 实现进程信息中的绑定信息在不同版本中数据定义格式不一致的方案
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx


实现方法

===========
version: 1.0 test

通过定义数据反序列化的方法来实现struct 的同一个属性在不同运行版本的环境上，实现进程绑定信息的多态。
主要是利用interface 的特性来实现，

_defaultPropertyBindInfoHandle，_defaultProcBindInfoHandle 是在使用反序列化 进程，进程模板中进程
绑定信息实际结构的对象

下面是_defaultPropertyBindInfoHandle，_defaultProcBindInfoHandle中UJSON和UBSON 含义的介绍
UJSON json反序列的方法，用于HTTP的消息处理,将数据解析到不同的struct上。 这个结构需要是ProcPropertyBindInfo，ProcBindInfoInterface interface 的实现
UBSON bson 反序列化的方法， 用于数据库存储,将数据解析到不同的struct上。这个结构需要是ProcPropertyBindInfo，ProcBindInfoInterface interface 的实现