### PR TITLE
修复excel导入模型实例失败的问题

### DIFF
--- a/src/apimachinery/apiserver/api.go
+++ b/src/apimachinery/apiserver/api.go
@@ -207,7 +207,7 @@ func (a *apiServer) AddInst(ctx context.Context, h http.Header, ownerID, objID s
 	err = a.client.Post().
 		WithContext(ctx).
 		Body(params).
-		SubResourcef(subPath, ownerID, objID).
+		SubResourcef(subPath, objID).
 		WithHeaders(h).
 		Do().
 		Into(resp)


### PR DESCRIPTION
# 修复的问题：
- 修复excel导入模型实例失败的问题
