### PR TITLE
禁止用模版来创建集群和模块时，默认集群和模块不受此限制

### DIFF
--- a/src/scene_server/topo_server/core/operation/inst_module.go
+++ b/src/scene_server/topo_server/core/operation/inst_module.go
@@ -127,6 +127,12 @@ func (m *module) CreateModule(kit *rest.Kit, obj model.Object, bizID, setID int6
 	if !data.Exists(common.BKDefaultField) {
 		data.Set(common.BKDefaultField, common.DefaultFlagDefaultValue)
 	}
+	defaultVal, err := data.Int64(common.BKDefaultField)
+	if err != nil {
+		blog.Errorf("parse default field into int failed, data: %+v, rid: %s", data, kit.Rid)
+		err := kit.CCError.CCErrorf(common.CCErrCommParamsNeedInt, common.BKDefaultField)
+		return nil, err
+	}
 
 	if err := m.validBizSetID(kit, bizID, setID); err != nil {
 		return nil, err
@@ -150,7 +156,6 @@ func (m *module) CreateModule(kit *rest.Kit, obj model.Object, bizID, setID int6
 	}
 
 	var serviceTemplateID int64
-	var err error
 	serviceTemplateIDIf, serviceTemplateFieldExist := data.Get(common.BKServiceTemplateIDField)
 	if serviceTemplateFieldExist == true {
 		serviceTemplateID, err = util.GetInt64ByInterface(serviceTemplateIDIf)
@@ -160,7 +165,7 @@ func (m *module) CreateModule(kit *rest.Kit, obj model.Object, bizID, setID int6
 	}
 
 	// if need create module using service template
-	if serviceTemplateID == 0 && !version.CanCreateSetModuleWithoutTemplate {
+	if serviceTemplateID == 0 && !version.CanCreateSetModuleWithoutTemplate && defaultVal == 0 {
 		return nil, kit.CCError.Errorf(common.CCErrCommParamsInvalid, "service_template_id can not be 0")
 	}
 

--- a/src/scene_server/topo_server/core/operation/inst_set.go
+++ b/src/scene_server/topo_server/core/operation/inst_set.go
@@ -87,6 +87,12 @@ func (s *set) CreateSet(kit *rest.Kit, obj model.Object, bizID int64, data mapst
 	if !data.Exists(common.BKDefaultField) {
 		data.Set(common.BKDefaultField, common.DefaultFlagDefaultValue)
 	}
+	defaultVal, err := data.Int64(common.BKDefaultField)
+	if err != nil {
+		blog.Errorf("parse default field into int failed, data: %+v, rid: %s", data, kit.Rid)
+		err := kit.CCError.CCErrorf(common.CCErrCommParamsNeedInt, common.BKDefaultField)
+		return nil, err
+	}
 
 	setTemplate := metadata.SetTemplate{}
 	// validate foreign key
@@ -108,7 +114,7 @@ func (s *set) CreateSet(kit *rest.Kit, obj model.Object, bizID int64, data mapst
 	}
 
 	// if need create set using set template
-	if setTemplate.ID == common.SetTemplateIDNotSet && !version.CanCreateSetModuleWithoutTemplate {
+	if setTemplate.ID == common.SetTemplateIDNotSet && !version.CanCreateSetModuleWithoutTemplate && defaultVal == 0 {
 		return nil, kit.CCError.Errorf(common.CCErrCommParamsInvalid, "set_template_id can not be 0")
 	}
 


### PR DESCRIPTION
### 修复的问题：
- 禁止用模版来创建集群和模块时，默认集群和模块不受此限制，防止创建业务失败