### PR TITLE
更新进程实例时增加进程数是否为0的判断，防止后续多余的操作

### DIFF
--- a/src/scene_server/host_server/service/transfer.go
+++ b/src/scene_server/host_server/service/transfer.go
@@ -311,6 +311,11 @@ func (s *Service) createOrUpdateServiceInstance(srvData *srvComm, bizID int64, h
 			process[common.BKProcessIDField] = processID
 			processes = append(processes, process)
 		}
+
+		if len(processes) == 0 {
+			return nil
+		}
+
 		updateProcessOption := map[string]interface{}{
 			"bk_biz_id": bizID,
 			"processes": processes,

--- a/src/scene_server/proc_server/service/processinstance.go
+++ b/src/scene_server/proc_server/service/processinstance.go
@@ -157,6 +157,11 @@ func (ps *ProcServer) UpdateProcessInstancesByIDs(ctx *rest.Contexts) {
 		raws = append(raws, process)
 	}
 
+	if len(raws) == 0 {
+		ctx.RespEntity([]int64{})
+		return
+	}
+
 	updateInput := metadata.UpdateRawProcessInstanceInput{
 		BizID: input.BizID,
 		Raw:   raws,
@@ -183,6 +188,11 @@ func (ps *ProcServer) UpdateProcessInstances(ctx *rest.Contexts) {
 	input := metadata.UpdateRawProcessInstanceInput{}
 	if err := ctx.DecodeInto(&input); err != nil {
 		ctx.RespAutoError(err)
+		return
+	}
+
+	if len(input.Raw) == 0 {
+		ctx.RespEntity([]int64{})
 		return
 	}
 


### PR DESCRIPTION
### 修复的问题：
- 更新进程实例时增加进程数是否为0的判断，防止后续多余的操作
