### PR TITLE
修复获取redis和mongo的配置产生异常

### DIFF
--- a/src/common/backbone/configcenter/viper.go
+++ b/src/common/backbone/configcenter/viper.go
@@ -299,6 +299,7 @@ func Redis(prefix string) redis.Config {
 	parser := getRedisParser()
 	// if the parser is empty, it means that the configuration has not been loaded asynchronously, sleep for one second until the configuration is loaded.
 	for parser == nil {
+		blog.Warn("the configuration of redis is not ready yet")
 		time.Sleep(time.Duration(1) * time.Second)
 	}
 	return redis.Config{
@@ -318,6 +319,7 @@ func Mongo(prefix string) mongo.Config {
 	parser := getMongodbParser()
 	// if the parser is empty, it means that the configuration has not been loaded asynchronously, sleep for one second until the configuration is loaded.
 	for parser == nil {
+		blog.Warn("the configuration of mongo is not ready yet")
 		time.Sleep(time.Duration(1) * time.Second)
 	}
 	c := mongo.Config{

--- a/src/common/backbone/configcenter/viper.go
+++ b/src/common/backbone/configcenter/viper.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"strings"
 	"sync"
+	"time"
 
 	"configcenter/src/common/blog"
 	"configcenter/src/common/errors"
@@ -296,6 +297,10 @@ func Redis(prefix string) redis.Config {
 	confLock.Lock()
 	defer confLock.Unlock()
 	parser := getRedisParser()
+	// if the parser is empty, it means that the configuration has not been loaded asynchronously, sleep for one second until the configuration is loaded.
+	for parser == nil {
+		time.Sleep(time.Duration(1) * time.Second)
+	}
 	return redis.Config{
 		Address:      parser.getString(prefix+".host"),
 		Password:     parser.getString(prefix+".pwd"),
@@ -306,11 +311,15 @@ func Redis(prefix string) redis.Config {
 	}
 }
 
-// Mongo return redis configuration information according to the prefix.
+// Mongo return mongo configuration information according to the prefix.
 func Mongo(prefix string) mongo.Config {
 	confLock.Lock()
 	defer confLock.Unlock()
 	parser := getMongodbParser()
+	// if the parser is empty, it means that the configuration has not been loaded asynchronously, sleep for one second until the configuration is loaded.
+	for parser == nil {
+		time.Sleep(time.Duration(1) * time.Second)
+	}
 	c := mongo.Config{
 		Address:   parser.getString(prefix+".host"),
 		Port:      parser.getString(prefix+".port"),


### PR DESCRIPTION
### 修复的问题：
- 在获取配置的时候，由于redis和mongodb的配置是异步加载，如果程序直接获取配置，可能配置还没有获取到，产生报错的现象，解决方式为在获取配置时如果配置为空，则睡眠一秒等待配置加入
close #4528 