### PR TITLE
让admin_server启动时指定的migrate路径带上.yaml后缀

### DIFF
--- a/scripts/init.py
+++ b/scripts/init.py
@@ -384,7 +384,7 @@ def update_start_script(rd_server, server_ports, enable_auth, log_level, registe
                 filedata = filedata.replace('cmdb-name-placeholder', d)
                 filedata = filedata.replace('cmdb-port-placeholder', str(server_ports.get(d, 9999)))
                 if d == "cmdb_adminserver":
-                    filedata = filedata.replace('rd_server_placeholder', "configures/migrate")
+                    filedata = filedata.replace('rd_server_placeholder', "configures/migrate.yaml")
                     filedata = filedata.replace('regdiscv', "config")
                 else:
                     filedata = filedata.replace('rd_server_placeholder', rd_server)

--- a/src/common/backbone/configcenter/viper.go
+++ b/src/common/backbone/configcenter/viper.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"configcenter/src/common"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/errors"
 	"configcenter/src/common/language"
@@ -79,10 +80,8 @@ func loadErrorAndLanguage(errorres string, languageres string, handler *CCHandle
 
 func LoadConfigFromLocalFile(confPath string, handler *CCHandler) error {
 
-	// if the loaded local file is migrate, skip the loading of other files,load only error and language.
-	split := strings.Split(confPath, "/")
-	fileName := split[len(split)-1]
-	if fileName == types.CC_MODULE_MIGRATE {
+	// if it is admin_server, skip the loading of other files,load only error and language.
+	if common.GetIdentification() == types.CC_MODULE_MIGRATE {
 		errorres, _ := String("errors.res")
 		languageres, _ := String("language.res")
 		return loadErrorAndLanguage(errorres, languageres, handler)
@@ -284,7 +283,10 @@ func SetMigrateFromFile(target string) error {
 	var err error
 	confLock.Lock()
 	defer confLock.Unlock()
-	migrateParser,err = newViperParserFromFile(target)
+	// /data/migrate.yaml -> /data/migrate
+	split := strings.Split(target, ".")
+	filePath := split[0]
+	migrateParser,err = newViperParserFromFile(filePath)
 	if err != nil {
 		blog.Errorf("fail to read configure from migrate")
 		return err


### PR DESCRIPTION
### 优化的功能:
- 让admin_server启动时指定的migrate路径带上.yaml后缀,通过设置文件时把后缀去掉即可
close #4539
