### PR TITLE
list_biz_host_topo 接口查询主机时添加bk_host_id字段，防止获取主机关系失败

### DIFF
--- a/src/scene_server/host_server/service/findhost.go
+++ b/src/scene_server/host_server/service/findhost.go
@@ -682,7 +682,7 @@ func (s *Service) ListBizHostsTopo(req *restful.Request, resp *restful.Response)
 	option := &meta.ListHosts{
 		BizID:              bizID,
 		HostPropertyFilter: parameter.HostPropertyFilter,
-		Fields:             parameter.Fields,
+		Fields:             append(parameter.Fields, common.BKHostIDField),
 		Page:               parameter.Page,
 	}
 	hosts, err := s.CoreAPI.CoreService().Host().ListHosts(ctx, header, option)


### PR DESCRIPTION
### 修复的问题：
- 修复 list_biz_host_topo 接口入参fields没有bk_host_id字段时报错的问题
