### PR TITLE
修复ListenIPOptions接口没指定feilds而查询主机失败的问题

### DIFF
--- a/src/web_server/service/host.go
+++ b/src/web_server/service/host.go
@@ -260,6 +260,12 @@ func (s *Service) ListenIPOptions(c *gin.Context) {
 				},
 			},
 		},
+		Fields: []string{
+			common.BKHostIDField,
+			common.BKHostNameField,
+			common.BKHostInnerIPField,
+			common.BKHostOuterIPField,
+		},
 		Page: metadata.BasePage{
 			Start: 0,
 			Limit: 1,


### PR DESCRIPTION
### 修复的问题：
- 修复ListenIPOptions接口没指定feilds而查询主机失败的问题
