### PR TITLE
为api请求增加超时时间，防止某些慢请求影响到服务整体的可用性

### DIFF
--- a/scripts/init.py
+++ b/scripts/init.py
@@ -123,6 +123,9 @@ pwd = $es_pass
 
 [api]
 version = v3
+# api请求默认超时时间,单位为秒，取值范围为10～120
+requestDefaultTimeoutSecond = 30
+
 [session]
 name = cc3
 defaultlanguage = zh-cn

--- a/src/apimachinery/rest/request.go
+++ b/src/apimachinery/rest/request.go
@@ -279,7 +279,7 @@ func (r *Request) Do() *Result {
 			}
 
 			if r.ctx != nil {
-				req.WithContext(r.ctx)
+				req = req.WithContext(r.ctx)
 			}
 
 			req.Header = commonUtil.CloneHeader(r.headers)

--- a/src/apiserver/service/auth.go
+++ b/src/apiserver/service/auth.go
@@ -67,7 +67,7 @@ func (s *service) AuthVerify(req *restful.Request, resp *restful.Response) {
 		}
 	}
 
-	ctx := context.WithValue(context.Background(), common.ContextRequestIDField, rid)
+	ctx := context.WithValue(req.Request.Context(), common.ContextRequestIDField, rid)
 	verifyResults, err := s.authorizer.AuthorizeBatch(ctx, user, attrs...)
 	if err != nil {
 		blog.Errorf("get user's resource auth verify status, but authorize batch failed, err: %v, rid: %s", err, rid)

--- a/src/apiserver/service/http.go
+++ b/src/apiserver/service/http.go
@@ -66,6 +66,8 @@ func (s *service) Do(req *restful.Request, resp *restful.Response) {
 		}
 	}
 
+	proxyReq = proxyReq.WithContext(req.Request.Context())
+
 	response, err := s.client.Do(proxyReq)
 	if err != nil {
 		blog.Errorf("*failed do request[%s url: %s] , err: %v, rid: %s", req.Request.Method, url, err, rid)

--- a/src/apiserver/service/service.go
+++ b/src/apiserver/service/service.go
@@ -61,6 +61,7 @@ func (s *service) WebServices(auth authcenter.AuthConfig) []*restful.WebService 
 	ws := &restful.WebService{}
 	ws.Path(rootPath)
 	ws.Filter(s.engine.Metric().RestfulMiddleWare)
+	ws.Filter(rdapi.RequestTimeoutFilter())
 	ws.Filter(rdapi.AllGlobalFilter(getErrFun))
 	ws.Filter(rdapi.RequestLogFilter())
 	ws.Filter(s.LimiterFilter())

--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -81,6 +81,12 @@ const (
 
 	// BKTopoBusinessLevelDefault the mainline topo level default level
 	BKTopoBusinessLevelDefault = 7
+
+	// BKMinRequestTimeout is the min timeout for a request, unit is second
+	BKMinRequestTimeout = 10
+
+	// BKMaxRequestTimeout is the max timeout for a request, unit is second
+	BKMaxRequestTimeout = 120
 )
 
 const (
@@ -931,6 +937,8 @@ const (
 	BKHTTPCCRequestID = "Cc_Request_Id"
 	// BKHTTPOtherRequestID esb request id  X-Bkapi-Request-Id
 	BKHTTPOtherRequestID = "X-Bkapi-Request-Id"
+
+	BKHTTPRequestDeadline = "HTTP_Request_Deadline"
 )
 
 // transaction related

--- a/src/common/http/rest/rest.go
+++ b/src/common/http/rest/rest.go
@@ -16,11 +16,14 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
+	"time"
 
 	"configcenter/src/common"
 	"configcenter/src/common/errors"
 	"configcenter/src/common/language"
 	"configcenter/src/common/util"
+
 	"github.com/emicklei/go-restful"
 )
 
@@ -103,6 +106,10 @@ func (r *RestUtility) wrapperAction(action Action) func(req *restful.Request, re
 		user := util.GetUser(header)
 		owner := util.GetOwnerID(header)
 		ctx := req.Request.Context()
+		if deadline := header.Get(common.BKHTTPRequestDeadline); len(deadline) > 0 {
+			deadlineStamp, _ := strconv.ParseInt(deadline, 10, 64)
+			ctx, _ = context.WithDeadline(ctx, time.Unix(deadlineStamp, 0))
+		}
 		ctx = context.WithValue(ctx, common.ContextRequestIDField, rid)
 		ctx = context.WithValue(ctx, common.ContextRequestUserField, user)
 		ctx = context.WithValue(ctx, common.ContextRequestOwnerField, owner)

--- a/src/scene_server/host_server/logics/host.go
+++ b/src/scene_server/host_server/logics/host.go
@@ -163,7 +163,7 @@ func (lgc *Logics) EnterIP(ctx context.Context, ownerID string, appID, moduleID 
 		if err != nil {
 			return err
 		}
-		aResult, err := lgc.CoreAPI.CoreService().Audit().SaveAuditLog(context.Background(), lgc.header, auditLog)
+		aResult, err := lgc.CoreAPI.CoreService().Audit().SaveAuditLog(ctx, lgc.header, auditLog)
 		if err != nil {
 			blog.Errorf("EnterIP AddHostLog http do error, err:%s, rid:%s", err.Error(), lgc.rid)
 			return lgc.ccErr.Error(common.CCErrCommHTTPDoRequestFailed)

--- a/src/scene_server/host_server/logics/import.go
+++ b/src/scene_server/host_server/logics/import.go
@@ -186,7 +186,7 @@ func (lgc *Logics) AddHost(ctx context.Context, appID int64, moduleIDs []int64, 
 	}
 
 	if len(logContents) > 0 {
-		_, err := lgc.CoreAPI.CoreService().Audit().SaveAuditLog(context.Background(), lgc.header, logContents...)
+		_, err := lgc.CoreAPI.CoreService().Audit().SaveAuditLog(ctx, lgc.header, logContents...)
 		if err != nil {
 			return hostIDs, successMsg, updateErrMsg, errMsg, fmt.Errorf("generate audit log, but get host instance defail failed, err: %v", err)
 		}

--- a/src/scene_server/host_server/logics/log.go
+++ b/src/scene_server/host_server/logics/log.go
@@ -322,7 +322,7 @@ func (h *HostModuleLog) SaveAudit(ctx context.Context) errors.CCError {
 		})
 	}
 
-	result, err := h.logic.CoreAPI.CoreService().Audit().SaveAuditLog(context.Background(), h.header, logs...)
+	result, err := h.logic.CoreAPI.CoreService().Audit().SaveAuditLog(ctx, h.header, logs...)
 	if err != nil {
 		blog.Errorf("AddHostLogs http do error, err:%s,input:%+v,rid:%s", err.Error(), logs, h.logic.rid)
 		return h.logic.ccErr.Error(common.CCErrAuditSaveLogFailed)

--- a/src/scene_server/host_server/service/service.go
+++ b/src/scene_server/host_server/service/service.go
@@ -15,6 +15,8 @@ package service
 import (
 	"context"
 	"net/http"
+	"strconv"
+	"time"
 
 	"configcenter/src/apimachinery/discovery"
 	"configcenter/src/auth/extensions"
@@ -60,6 +62,10 @@ func (s *Service) newSrvComm(header http.Header) *srvComm {
 	lang := util.GetLanguage(header)
 	user := util.GetUser(header)
 	ctx, cancel := s.Engine.CCCtx.WithCancel()
+	if deadline := header.Get(common.BKHTTPRequestDeadline); len(deadline) > 0 {
+		deadlineStamp, _ := strconv.ParseInt(deadline, 10, 64)
+		ctx, _ = context.WithDeadline(ctx, time.Unix(deadlineStamp, 0))
+	}
 	ctx = context.WithValue(ctx, common.ContextRequestIDField, rid)
 	ctx = context.WithValue(ctx, common.ContextRequestUserField, user)
 

--- a/src/scene_server/operation_server/service/service.go
+++ b/src/scene_server/operation_server/service/service.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"configcenter/src/auth/extensions"
 	"configcenter/src/common"
@@ -35,6 +36,7 @@ import (
 	"configcenter/src/common/util"
 	"configcenter/src/scene_server/operation_server/app/options"
 	"configcenter/src/scene_server/operation_server/logics"
+
 	"github.com/emicklei/go-restful"
 )
 
@@ -61,6 +63,10 @@ func (o *OperationServer) newSrvComm(header http.Header) *srvComm {
 	rid := util.GetHTTPCCRequestID(header)
 	lang := util.GetLanguage(header)
 	ctx, cancel := o.Engine.CCCtx.WithCancel()
+	if deadline := header.Get(common.BKHTTPRequestDeadline); len(deadline) > 0 {
+		deadlineStamp, _ := strconv.ParseInt(deadline, 10, 64)
+		ctx, _ = context.WithDeadline(ctx, time.Unix(deadlineStamp, 0))
+	}
 	ctx = context.WithValue(ctx, common.ContextRequestIDField, rid)
 
 	return &srvComm{

--- a/src/scene_server/proc_server/service/service.go
+++ b/src/scene_server/proc_server/service/service.go
@@ -60,26 +60,6 @@ type ProcServer struct {
 	EnableTxn          bool
 }
 
-func (ps *ProcServer) newSrvComm(header http.Header) *srvComm {
-	rid := util.GetHTTPCCRequestID(header)
-	lang := util.GetLanguage(header)
-	ctx, cancel := ps.Engine.CCCtx.WithCancel()
-	ctx = context.WithValue(ctx, common.ContextRequestIDField, rid)
-
-	errors.SetGlobalCCError(ps.CCErr)
-	return &srvComm{
-		header:        header,
-		rid:           util.GetHTTPCCRequestID(header),
-		ccErr:         ps.CCErr.CreateDefaultCCErrorIf(lang),
-		ccLang:        ps.Language.CreateDefaultCCLanguageIf(lang),
-		ctx:           ctx,
-		ctxCancelFunc: cancel,
-		user:          util.GetUser(header),
-		ownerID:       util.GetOwnerID(header),
-		lgc:           logics.NewLogics(ps.Engine, header, ps.EsbSrv, &ps.procHostInstConfig),
-	}
-}
-
 func (ps *ProcServer) WebService() *restful.Container {
 	getErrFunc := func() errors.CCErrorIf {
 		return ps.Engine.CCErr

--- a/src/scene_server/synchronize_server/service/service.go
+++ b/src/scene_server/synchronize_server/service/service.go
@@ -15,6 +15,8 @@ package service
 import (
 	"context"
 	"net/http"
+	"strconv"
+	"time"
 
 	"configcenter/src/apimachinery/discovery"
 	"configcenter/src/apimachinery/synchronize"
@@ -59,6 +61,10 @@ func (s *Service) SetSynchronizeServer(synchronizeSrv synchronize.SynchronizeCli
 func (s *Service) newSrvComm(header http.Header) *srvComm {
 	lang := util.GetLanguage(header)
 	ctx, cancel := s.Engine.CCCtx.WithCancel()
+	if deadline := header.Get(common.BKHTTPRequestDeadline); len(deadline) > 0 {
+		deadlineStamp, _ := strconv.ParseInt(deadline, 10, 64)
+		ctx, _ = context.WithDeadline(ctx, time.Unix(deadlineStamp, 0))
+	}
 	return &srvComm{
 		header:        header,
 		rid:           util.GetHTTPCCRequestID(header),

--- a/src/scene_server/task_server/service/service.go
+++ b/src/scene_server/task_server/service/service.go
@@ -15,6 +15,8 @@ package service
 import (
 	"context"
 	"net/http"
+	"strconv"
+	"time"
 
 	"configcenter/src/apimachinery/discovery"
 	"configcenter/src/common"
@@ -60,6 +62,10 @@ func (s *Service) newSrvComm(header http.Header) *srvComm {
 	lang := util.GetLanguage(header)
 	user := util.GetUser(header)
 	ctx, cancel := s.Engine.CCCtx.WithCancel()
+	if deadline := header.Get(common.BKHTTPRequestDeadline); len(deadline) > 0 {
+		deadlineStamp, _ := strconv.ParseInt(deadline, 10, 64)
+		ctx, _ = context.WithDeadline(ctx, time.Unix(deadlineStamp, 0))
+	}
 	ctx = context.WithValue(ctx, common.ContextRequestIDField, rid)
 	ctx = context.WithValue(ctx, common.ContextRequestUserField, user)
 

--- a/src/scene_server/topo_server/core/inst/association.go
+++ b/src/scene_server/topo_server/core/inst/association.go
@@ -13,7 +13,6 @@
 package inst
 
 import (
-	"context"
 	"io"
 
 	"configcenter/src/common"
@@ -44,7 +43,7 @@ func (cli *inst) updateMainlineAssociation(child Inst, parentID int64) error {
 		},
 		Condition: cond.ToMapStr(),
 	}
-	rsp, err := cli.clientSet.CoreService().Instance().UpdateInstance(context.Background(), cli.kit.Header, object.ObjectID, &input)
+	rsp, err := cli.clientSet.CoreService().Instance().UpdateInstance(cli.kit.Ctx, cli.kit.Header, object.ObjectID, &input)
 	if nil != err {
 		blog.Errorf("[inst-inst] failed to request object controller, error info %s, rid: %s", err.Error(), cli.kit.Rid)
 		return cli.kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -60,7 +59,7 @@ func (cli *inst) updateMainlineAssociation(child Inst, parentID int64) error {
 
 func (cli *inst) searchInstAssociation(cond condition.Condition) ([]metadata.InstAsst, error) {
 
-	rsp, err := cli.clientSet.CoreService().Association().ReadInstAssociation(context.Background(), cli.kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := cli.clientSet.CoreService().Association().ReadInstAssociation(cli.kit.Ctx, cli.kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("[inst-inst] failed to request the object controller , err: %s, rid: %s", err.Error(), cli.kit.Rid)
 		return nil, cli.kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -84,7 +83,7 @@ func (cli *inst) deleteInstAssociation(instID, asstInstID int64, objID, asstObjI
 	cond.Field(common.BKObjIDField).Eq(objID)
 	cond.Field(common.BKAsstObjIDField).Eq(asstObjID)
 
-	rsp, err := cli.clientSet.CoreService().Association().DeleteInstAssociation(context.Background(), cli.kit.Header, &metadata.DeleteOption{Condition: cond.ToMapStr()})
+	rsp, err := cli.clientSet.CoreService().Association().DeleteInstAssociation(cli.kit.Ctx, cli.kit.Header, &metadata.DeleteOption{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("[inst-inst] failed to request the object controller , err: %s, rid: %s", err.Error(), cli.kit.Rid)
 		return cli.kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)

--- a/src/scene_server/topo_server/core/model/attribute.go
+++ b/src/scene_server/topo_server/core/model/attribute.go
@@ -13,7 +13,6 @@
 package model
 
 import (
-	"context"
 	"encoding/json"
 
 	"configcenter/src/apimachinery"
@@ -65,7 +64,7 @@ func (a *attribute) searchObjects(objID string) ([]metadata.Object, error) {
 	input := metadata.QueryCondition{
 		Condition: cond.ToMapStr(),
 	}
-	rsp, err := a.clientSet.CoreService().Model().ReadModel(context.Background(), a.kit.Header, &input)
+	rsp, err := a.clientSet.CoreService().Model().ReadModel(a.kit.Ctx, a.kit.Header, &input)
 	if nil != err {
 		blog.Errorf("failed to request the object controller, err: %s, rid: %s", err.Error(), a.kit.Rid)
 		return nil, a.kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -230,7 +229,7 @@ func (a *attribute) Update(data mapstr.MapStr) error {
 		Condition: condition.CreateCondition().Field(common.BKFieldID).Eq(a.attr.ID).ToMapStr(),
 		Data:      data,
 	}
-	rsp, err := a.clientSet.CoreService().Model().UpdateModelAttrs(context.Background(), a.kit.Header, a.attr.ObjectID, &input)
+	rsp, err := a.clientSet.CoreService().Model().UpdateModelAttrs(a.kit.Ctx, a.kit.Header, a.attr.ObjectID, &input)
 	if nil != err {
 		blog.Errorf("failed to request object controller, err: %s, rid: %s", err.Error(), a.kit.Rid)
 		return err
@@ -244,7 +243,7 @@ func (a *attribute) Update(data mapstr.MapStr) error {
 }
 func (a *attribute) search(cond condition.Condition) ([]metadata.Attribute, error) {
 
-	rsp, err := a.clientSet.CoreService().Model().ReadModelAttr(context.Background(), a.kit.Header, a.attr.ObjectID, &metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := a.clientSet.CoreService().Model().ReadModelAttr(a.kit.Ctx, a.kit.Header, a.attr.ObjectID, &metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("failed to request to object controller, err: %s, rid: %s", err.Error(), a.kit.Rid)
 		return nil, err
@@ -321,7 +320,7 @@ func (a *attribute) GetGroup() (GroupInterface, error) {
 	cond.Field(metadata.GroupFieldGroupID).Eq(a.attr.PropertyGroup)
 	cond.Field(metadata.GroupFieldObjectID).Eq(a.attr.ObjectID)
 
-	rsp, err := a.clientSet.CoreService().Model().ReadAttributeGroup(context.Background(), a.kit.Header, a.attr.ObjectID, metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := a.clientSet.CoreService().Model().ReadAttributeGroup(a.kit.Ctx, a.kit.Header, a.attr.ObjectID, metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("[model-grp] failed to request the coreservice, err: %s, rid: %s", err.Error(), a.kit.Rid)
 		return nil, a.kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -333,7 +332,7 @@ func (a *attribute) GetGroup() (GroupInterface, error) {
 	}
 
 	if 0 == len(rsp.Data.Info) {
-		return CreateGroup(a.kit, a.clientSet, []metadata.Group{metadata.Group{GroupID: "default", GroupName: "Default", OwnerID: a.attr.OwnerID, ObjectID: a.attr.ObjectID}})[0], nil
+		return CreateGroup(a.kit, a.clientSet, []metadata.Group{{GroupID: "default", GroupName: "Default", OwnerID: a.attr.OwnerID, ObjectID: a.attr.ObjectID}})[0], nil
 	}
 
 	return CreateGroup(a.kit, a.clientSet, rsp.Data.Info)[0], nil // should be one group

--- a/src/scene_server/topo_server/core/model/classification.go
+++ b/src/scene_server/topo_server/core/model/classification.go
@@ -13,7 +13,6 @@
 package model
 
 import (
-	"context"
 	"encoding/json"
 
 	"configcenter/src/apimachinery"
@@ -67,7 +66,7 @@ func (cli *classification) GetObjects() ([]Object, error) {
 	cond := condition.CreateCondition()
 	cond.Field(metadata.ModelFieldObjCls).Eq(cli.cls.ClassificationID)
 
-	rsp, err := cli.clientSet.CoreService().Model().ReadModel(context.Background(), cli.kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := cli.clientSet.CoreService().Model().ReadModel(cli.kit.Ctx, cli.kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("failed to request the object controller, err: %s, rid: %s", err.Error(), cli.kit.Rid)
 		return nil, cli.kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -127,7 +126,7 @@ func (cli *classification) Create() error {
 	}
 
 	input := metadata.CreateOneModelClassification{Data: cli.cls}
-	rsp, err := cli.clientSet.CoreService().Model().CreateModelClassification(context.Background(), cli.kit.Header, &input)
+	rsp, err := cli.clientSet.CoreService().Model().CreateModelClassification(cli.kit.Ctx, cli.kit.Header, &input)
 	if nil != err {
 		blog.Errorf("failed to request object controller, err: %s, rid: %s", err.Error(), cli.kit.Rid)
 		return err
@@ -179,7 +178,7 @@ func (cli *classification) Update(data mapstr.MapStr) error {
 			Condition: cond.ToMapStr(),
 			Data:      data,
 		}
-		rsp, err := cli.clientSet.CoreService().Model().UpdateModelClassification(context.Background(), cli.kit.Header, &input)
+		rsp, err := cli.clientSet.CoreService().Model().UpdateModelClassification(cli.kit.Ctx, cli.kit.Header, &input)
 		if nil != err {
 			blog.Errorf("failed to request object controller, err: %s, rid: %s", err.Error(), cli.kit.Rid)
 			return err
@@ -200,7 +199,7 @@ func (cli *classification) search(cond condition.Condition) ([]metadata.Classifi
 	if nil != cli.metadata {
 		cond.Field(metadata.BKMetadata).Eq(*cli.metadata)
 	}
-	rsp, err := cli.clientSet.CoreService().Model().ReadModelClassification(context.Background(), cli.kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := cli.clientSet.CoreService().Model().ReadModelClassification(cli.kit.Ctx, cli.kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("failed to request the object controller, err: %s, rid: %s", err.Error(), cli.kit.Rid)
 		return nil, err

--- a/src/scene_server/topo_server/core/model/group.go
+++ b/src/scene_server/topo_server/core/model/group.go
@@ -13,7 +13,6 @@
 package model
 
 import (
-	"context"
 	"encoding/json"
 
 	"configcenter/src/apimachinery"
@@ -113,7 +112,7 @@ func (g *group) Create() error {
 		return err
 	}
 
-	rsp, err := g.clientSet.CoreService().Model().CreateAttributeGroup(context.Background(), g.kit.Header, g.GetObjectID(), metadata.CreateModelAttributeGroup{Data: g.grp})
+	rsp, err := g.clientSet.CoreService().Model().CreateAttributeGroup(g.kit.Ctx, g.kit.Header, g.GetObjectID(), metadata.CreateModelAttributeGroup{Data: g.grp})
 	if nil != err {
 		blog.Errorf("[model-grp] failed to request object controller, err: %s, rid: %s", err.Error(), g.kit.Rid)
 		return g.kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -160,7 +159,7 @@ func (g *group) Update(data mapstr.MapStr) error {
 			},
 		}
 
-		rsp, err := g.clientSet.CoreService().Model().UpdateAttributeGroup(context.Background(), g.kit.Header, g.GetObjectID(), input)
+		rsp, err := g.clientSet.CoreService().Model().UpdateAttributeGroup(g.kit.Ctx, g.kit.Header, g.GetObjectID(), input)
 		if nil != err {
 			blog.Errorf("[model-grp]failed to request object controller, err: %s, rid: %s", err.Error(), g.kit.Rid)
 			return err
@@ -221,7 +220,7 @@ func (g *group) GetAttributes() ([]AttributeInterface, error) {
 	cond.Field(metadata.AttributeFieldObjectID).Eq(g.grp.ObjectID).
 		Field(metadata.AttributeFieldPropertyGroup).Eq(g.grp.GroupID)
 
-	rsp, err := g.clientSet.CoreService().Model().ReadModelAttr(context.Background(), g.kit.Header, g.GetObjectID(), &metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := g.clientSet.CoreService().Model().ReadModelAttr(g.kit.Ctx, g.kit.Header, g.GetObjectID(), &metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("failed to request the object controller, err: %s, rid: %s", err.Error(), g.kit.Rid)
 		return nil, g.kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -251,7 +250,7 @@ func (g *group) search(cond condition.Condition) ([]metadata.Group, error) {
 	if nil != g.metadata {
 		cond.Field(metadata.BKMetadata).Eq(*g.metadata)
 	}
-	rsp, err := g.clientSet.CoreService().Model().ReadAttributeGroup(context.Background(), g.kit.Header, g.GetObjectID(), metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := g.clientSet.CoreService().Model().ReadAttributeGroup(g.kit.Ctx, g.kit.Header, g.GetObjectID(), metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("failed to request the object controller, err: %s, rid: %s", err.Error(), g.kit.Rid)
 		return nil, err

--- a/src/scene_server/topo_server/core/model/object.go
+++ b/src/scene_server/topo_server/core/model/object.go
@@ -13,7 +13,6 @@
 package model
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -133,7 +132,7 @@ func (o *object) IsMainlineObject() (bool, error) {
 }
 
 func (o *object) searchAttributes(cond condition.Condition) ([]AttributeInterface, error) {
-	rsp, err := o.clientSet.CoreService().Model().ReadModelAttr(context.Background(), o.kit.Header, o.obj.ObjectID, &metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := o.clientSet.CoreService().Model().ReadModelAttr(o.kit.Ctx, o.kit.Header, o.obj.ObjectID, &metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("failed to request the object controller, error info is %s, rid: %s", err.Error(), o.kit.Rid)
 		return nil, o.kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -162,7 +161,7 @@ func (o *object) searchAttributes(cond condition.Condition) ([]AttributeInterfac
 }
 
 func (o *object) search(cond condition.Condition) ([]meta.Object, error) {
-	rsp, err := o.clientSet.CoreService().Model().ReadModel(context.Background(), o.kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := o.clientSet.CoreService().Model().ReadModel(o.kit.Ctx, o.kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("failed to request the object controller, error info is %s, rid: %s", err.Error(), o.kit.Rid)
 		return nil, o.kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -188,7 +187,7 @@ func (o *object) GetMainlineParentObject() (Object, error) {
 	cond.Field(common.BKObjIDField).Eq(o.obj.ObjectID)
 	cond.Field(common.AssociationKindIDField).Eq(common.AssociationKindMainline)
 
-	rsp, err := o.clientSet.CoreService().Association().ReadModelAssociation(context.Background(), o.kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := o.clientSet.CoreService().Association().ReadModelAssociation(o.kit.Ctx, o.kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("[model-obj] failed to request the object controller, error info is %s, rid: %s", err.Error(), o.kit.Rid)
 		return nil, err
@@ -241,7 +240,7 @@ func (o *object) GetMainlineChildObject() (Object, error) {
 	cond.Field(common.BKAsstObjIDField).Eq(o.obj.ObjectID)
 	cond.Field(common.AssociationKindIDField).Eq(common.AssociationKindMainline)
 
-	rsp, err := o.clientSet.CoreService().Association().ReadModelAssociation(context.Background(), o.kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := o.clientSet.CoreService().Association().ReadModelAssociation(o.kit.Ctx, o.kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("[model-obj] failed to request the object controller, error info is %s, rid: %s", err.Error(), o.kit.Rid)
 		return nil, err
@@ -270,7 +269,7 @@ func (o *object) GetMainlineChildObject() (Object, error) {
 }
 
 func (o *object) searchAssoObjects(isNeedChild bool, cond condition.Condition) ([]ObjectAssoPair, error) {
-	rsp, err := o.clientSet.CoreService().Association().ReadModelAssociation(context.Background(), o.kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := o.clientSet.CoreService().Association().ReadModelAssociation(o.kit.Ctx, o.kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("[model-obj] failed to request the object controller, error info is %s, rid: %s", err.Error(), o.kit.Rid)
 		return nil, err
@@ -325,7 +324,7 @@ func (o *object) SetMainlineParentObject(relateToObjID string) error {
 	cond.Field(common.BKObjIDField).Eq(o.obj.ObjectID)
 	cond.Field(common.AssociationKindIDField).Eq(common.AssociationKindMainline)
 
-	resp, err := o.clientSet.CoreService().Association().DeleteModelAssociation(context.Background(), o.kit.Header, &metadata.DeleteOption{Condition: cond.ToMapStr()})
+	resp, err := o.clientSet.CoreService().Association().DeleteModelAssociation(o.kit.Ctx, o.kit.Header, &metadata.DeleteOption{Condition: cond.ToMapStr()})
 	if err != nil {
 		blog.Errorf("update mainline object[%s] association to %s, search object association failed, err: %v, rid: %s", o.kit.Rid,
 			o.obj.ObjectID, relateToObjID, err)
@@ -360,7 +359,7 @@ func (o *object) CreateMainlineObjectAssociation(relateToObjID string) error {
 		IsPre:      &defined,
 	}
 
-	result, err := o.clientSet.CoreService().Association().CreateMainlineModelAssociation(context.Background(), o.kit.Header, &metadata.CreateModelAssociation{Spec: association})
+	result, err := o.clientSet.CoreService().Association().CreateMainlineModelAssociation(o.kit.Ctx, o.kit.Header, &metadata.CreateModelAssociation{Spec: association})
 	if err != nil {
 		blog.Errorf("[model-obj] create mainline object association failed, err: %v, rid: %s", err, o.kit.Rid)
 		return err
@@ -466,7 +465,7 @@ func (o *object) Create() error {
 		return o.kit.CCError.Errorf(common.CCErrCommParamsNeedSet, common.BKObjIconField)
 	}
 
-	rsp, err := o.clientSet.CoreService().Model().CreateModel(context.Background(), o.kit.Header, &metadata.CreateModel{Spec: o.obj})
+	rsp, err := o.clientSet.CoreService().Model().CreateModel(o.kit.Ctx, o.kit.Header, &metadata.CreateModel{Spec: o.obj})
 	if nil != err {
 		blog.Errorf("failed to request the object controller, error info is %s, rid: %s", err.Error(), o.kit.Rid)
 		return o.kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -519,7 +518,7 @@ func (o *object) Update(data mapstr.MapStr) error {
 			Condition: condition.CreateCondition().Field(common.BKFieldID).Eq(item.ID).ToMapStr(),
 			Data:      data,
 		}
-		rsp, err := o.clientSet.CoreService().Model().UpdateModel(context.Background(), o.kit.Header, &input)
+		rsp, err := o.clientSet.CoreService().Model().UpdateModel(o.kit.Ctx, o.kit.Header, &input)
 		if nil != err {
 			blog.Errorf("failed to request the object controller, error info is %s, rid: %s", err.Error(), o.kit.Rid)
 			return o.kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -598,7 +597,7 @@ func (o *object) CreateUnique() Unique {
 
 func (o *object) GetUniques() ([]Unique, error) {
 	cond := condition.CreateCondition().Field(common.BKObjIDField).Eq(o.obj.ObjectID)
-	rsp, err := o.clientSet.CoreService().Model().ReadModelAttrUnique(context.Background(), o.kit.Header, metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := o.clientSet.CoreService().Model().ReadModelAttrUnique(o.kit.Ctx, o.kit.Header, metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("failed to request the object controller, error info is %s, rid: %s", err.Error(), o.kit.Rid)
 		return nil, o.kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -653,7 +652,7 @@ func (o *object) GetGroups() ([]GroupInterface, error) {
 	cond := condition.CreateCondition()
 	cond.Field(meta.GroupFieldObjectID).Eq(o.obj.ObjectID)
 
-	rsp, err := o.clientSet.CoreService().Model().ReadAttributeGroup(context.Background(), o.kit.Header, o.obj.ObjectID, metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := o.clientSet.CoreService().Model().ReadAttributeGroup(o.kit.Ctx, o.kit.Header, o.obj.ObjectID, metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("failed to request the object controller, error info is %s, rid: %s", err.Error(), o.kit.Rid)
 		return nil, o.kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -683,7 +682,7 @@ func (o *object) GetClassification() (Classification, error) {
 	cond := condition.CreateCondition()
 	cond.Field(meta.ClassFieldClassificationID).Eq(o.obj.ObjCls)
 
-	rsp, err := o.clientSet.CoreService().Model().ReadModelClassification(context.Background(), o.kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := o.clientSet.CoreService().Model().ReadModelClassification(o.kit.Ctx, o.kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("failed to request the object controller, error info is %s, rid: %s", err.Error(), o.kit.Rid)
 		return nil, o.kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)

--- a/src/scene_server/topo_server/core/model/unique.go
+++ b/src/scene_server/topo_server/core/model/unique.go
@@ -13,7 +13,6 @@
 package model
 
 import (
-	"context"
 	"encoding/json"
 
 	"configcenter/src/apimachinery"
@@ -82,7 +81,7 @@ func (g *unique) Create() error {
 		Keys:      g.data.Keys,
 	}
 
-	rsp, err := g.clientSet.CoreService().Model().CreateModelAttrUnique(context.Background(), g.kit.Header, g.data.ObjID, metadata.CreateModelAttrUnique{Data: data})
+	rsp, err := g.clientSet.CoreService().Model().CreateModelAttrUnique(g.kit.Ctx, g.kit.Header, g.data.ObjID, metadata.CreateModelAttrUnique{Data: data})
 	if nil != err {
 		blog.Errorf("[model-unique] failed to request object controller, err: %s, rid: %s", err.Error(), g.kit.Rid)
 		return g.kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -103,7 +102,7 @@ func (g *unique) Update(data mapstr.MapStr) error {
 		Keys:      g.data.Keys,
 	}
 
-	rsp, err := g.clientSet.CoreService().Model().UpdateModelAttrUnique(context.Background(), g.kit.Header, g.data.ObjID, g.data.ID, metadata.UpdateModelAttrUnique{Data: updateReq})
+	rsp, err := g.clientSet.CoreService().Model().UpdateModelAttrUnique(g.kit.Ctx, g.kit.Header, g.data.ObjID, g.data.ID, metadata.UpdateModelAttrUnique{Data: updateReq})
 	if nil != err {
 		blog.Errorf("[model-unique]failed to request object controller, err: %s, rid: %s", err.Error(), g.kit.Rid)
 		return err
@@ -118,7 +117,7 @@ func (g *unique) Update(data mapstr.MapStr) error {
 
 func (g *unique) Save(data mapstr.MapStr) error {
 	cond := condition.CreateCondition().Field(common.BKObjIDField).Eq(g.data.ObjID)
-	searchResp, err := g.clientSet.CoreService().Model().ReadModelAttrUnique(context.Background(), g.kit.Header, metadata.QueryCondition{Condition: cond.ToMapStr()})
+	searchResp, err := g.clientSet.CoreService().Model().ReadModelAttrUnique(g.kit.Ctx, g.kit.Header, metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("[model-unique]failed to request object controller, err: %s, rid: %s", err.Error(), g.kit.Rid)
 		return err
@@ -147,7 +146,7 @@ func (g *unique) Save(data mapstr.MapStr) error {
 
 func (g *unique) IsExists() (bool, error) {
 	cond := condition.CreateCondition().Field(common.BKObjIDField).Eq(g.data.ObjID)
-	searchResp, err := g.clientSet.CoreService().Model().ReadModelAttrUnique(context.Background(), g.kit.Header, metadata.QueryCondition{Condition: cond.ToMapStr()})
+	searchResp, err := g.clientSet.CoreService().Model().ReadModelAttrUnique(g.kit.Ctx, g.kit.Header, metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("[model-unique]failed to request object controller, err: %s, rid: %s", err.Error(), g.kit.Rid)
 		return false, err

--- a/src/scene_server/topo_server/core/operation/association.go
+++ b/src/scene_server/topo_server/core/operation/association.go
@@ -119,7 +119,7 @@ func (assoc *association) SearchObjectAssociation(kit *rest.Kit, objID string, m
 		fCond.Merge(metadata.BizLabelNotExist)
 	}
 
-	rsp, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(context.Background(), kit.Header, &metadata.QueryCondition{Condition: fCond})
+	rsp, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(kit.Ctx, kit.Header, &metadata.QueryCondition{Condition: fCond})
 	if nil != err {
 		blog.Errorf("[operation-asst] failed to request object controller, err: %s, rid: %s", err.Error(), kit.Rid)
 		return nil, kit.CCError.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
@@ -147,7 +147,7 @@ func (assoc *association) SearchObjectsAssociation(kit *rest.Kit, objIDs []strin
 		fCond.Merge(metadata.BizLabelNotExist)
 	}
 
-	rsp, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(context.Background(), kit.Header, &metadata.QueryCondition{Condition: fCond})
+	rsp, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(kit.Ctx, kit.Header, &metadata.QueryCondition{Condition: fCond})
 	if nil != err {
 		blog.Errorf("[operation-asst] failed to request object controller, err: %s, rid: %s", err.Error(), kit.Rid)
 		return nil, kit.CCError.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
@@ -163,7 +163,7 @@ func (assoc *association) SearchObjectsAssociation(kit *rest.Kit, objIDs []strin
 
 func (assoc *association) SearchInstAssociation(kit *rest.Kit, query *metadata.QueryInput) ([]metadata.InstAsst, error) {
 	intput, err := mapstr.NewFromInterface(query.Condition)
-	rsp, err := assoc.clientSet.CoreService().Association().ReadInstAssociation(context.Background(), kit.Header, &metadata.QueryCondition{Condition: intput})
+	rsp, err := assoc.clientSet.CoreService().Association().ReadInstAssociation(kit.Ctx, kit.Header, &metadata.QueryCondition{Condition: intput})
 	if nil != err {
 		blog.Errorf("[operation-asst] failed to request object controller, err: %s, rid: %s", err.Error(), kit.Rid)
 		return nil, kit.CCError.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
@@ -201,7 +201,7 @@ func (assoc *association) CreateCommonAssociation(kit *rest.Kit, data *metadata.
 	cond.Field(common.BKObjIDField).Eq(data.ObjectID)
 	cond.Field(common.AssociationKindIDField).Eq(data.AsstKindID)
 
-	rsp, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(context.Background(), kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(kit.Ctx, kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("[operation-asst] failed to request object controller, err: %s, rid: %s", err.Error(), kit.Rid)
 		return nil, kit.CCError.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
@@ -229,7 +229,7 @@ func (assoc *association) CreateCommonAssociation(kit *rest.Kit, data *metadata.
 	}
 
 	// create a new
-	rspAsst, err := assoc.clientSet.CoreService().Association().CreateModelAssociation(context.Background(), kit.Header, &metadata.CreateModelAssociation{Spec: *data})
+	rspAsst, err := assoc.clientSet.CoreService().Association().CreateModelAssociation(kit.Ctx, kit.Header, &metadata.CreateModelAssociation{Spec: *data})
 	if nil != err {
 		blog.Errorf("[operation-asst] failed to request object controller, err: %s, rid: %s", err.Error(), kit.Rid)
 		return nil, kit.CCError.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
@@ -246,7 +246,7 @@ func (assoc *association) CreateCommonAssociation(kit *rest.Kit, data *metadata.
 
 func (assoc *association) DeleteInstAssociation(kit *rest.Kit, cond condition.Condition) error {
 
-	rsp, err := assoc.clientSet.CoreService().Association().DeleteInstAssociation(context.Background(), kit.Header, &metadata.DeleteOption{Condition: cond.ToMapStr()})
+	rsp, err := assoc.clientSet.CoreService().Association().DeleteInstAssociation(kit.Ctx, kit.Header, &metadata.DeleteOption{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("[operation-asst] failed to request object controller, err: %s, rid: %s", err.Error(), kit.Rid)
 		return kit.CCError.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
@@ -262,7 +262,7 @@ func (assoc *association) DeleteInstAssociation(kit *rest.Kit, cond condition.Co
 
 func (assoc *association) CreateCommonInstAssociation(kit *rest.Kit, data *metadata.InstAsst) error {
 	// create a new
-	rspAsst, err := assoc.clientSet.CoreService().Association().CreateInstAssociation(context.Background(), kit.Header, &metadata.CreateOneInstanceAssociation{Data: *data})
+	rspAsst, err := assoc.clientSet.CoreService().Association().CreateInstAssociation(kit.Ctx, kit.Header, &metadata.CreateOneInstanceAssociation{Data: *data})
 	if nil != err {
 		blog.Errorf("[operation-asst] failed to request object controller, err: %s, rid: %s", err.Error(), kit.Rid)
 		return kit.CCError.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
@@ -278,7 +278,7 @@ func (assoc *association) CreateCommonInstAssociation(kit *rest.Kit, data *metad
 
 func (assoc *association) IsMainlineObject(kit *rest.Kit, objID string) (bool, error) {
 	cond := mapstr.MapStr{common.AssociationKindIDField: common.AssociationKindMainline}
-	asst, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(context.Background(), kit.Header,
+	asst, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(kit.Ctx, kit.Header,
 		&metadata.QueryCondition{Condition: cond})
 	if err != nil {
 		return false, err
@@ -306,7 +306,7 @@ func (assoc *association) DeleteAssociationWithPreCheck(kit *rest.Kit, associati
 	// get the association with id at first.
 	cond := condition.CreateCondition()
 	cond.Field(metadata.AssociationFieldAssociationId).Eq(associationID)
-	result, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(context.Background(), kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
+	result, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(kit.Ctx, kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if err != nil {
 		blog.Errorf("[operation-asst] delete association with id[%d], but get this association for pre check failed, err: %v, rid: %s", associationID, err, kit.Rid)
 		return kit.CCError.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
@@ -355,7 +355,7 @@ func (assoc *association) DeleteAssociationWithPreCheck(kit *rest.Kit, associati
 }
 
 func (assoc *association) DeleteAssociation(kit *rest.Kit, cond condition.Condition) error {
-	rsp, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(context.Background(), kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(kit.Ctx, kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("delete object association, but get association with cond[%v] failed, err: %v, rid: %s", cond.ToMapStr(), err, kit.Rid)
 		return kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -379,7 +379,7 @@ func (assoc *association) DeleteAssociation(kit *rest.Kit, cond condition.Condit
 	}
 
 	// delete the object association
-	result, err := assoc.clientSet.CoreService().Association().DeleteModelAssociation(context.Background(), kit.Header, &metadata.DeleteOption{Condition: cond.ToMapStr()})
+	result, err := assoc.clientSet.CoreService().Association().DeleteModelAssociation(kit.Ctx, kit.Header, &metadata.DeleteOption{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("[operation-asst] failed to request object controller, err: %s, rid: %s", err.Error(), kit.Rid)
 		return kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -409,7 +409,7 @@ func (assoc *association) UpdateAssociation(kit *rest.Kit, data mapstr.MapStr, a
 	cond := condition.CreateCondition()
 	cond.Field(metadata.AssociationFieldAssociationId).Eq(assoID)
 
-	rsp, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(context.Background(), kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(kit.Ctx, kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("[operation-asst] failed to request object controller, err: %s, rid: %s", err.Error(), kit.Rid)
 		return kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -446,7 +446,7 @@ func (assoc *association) UpdateAssociation(kit *rest.Kit, data mapstr.MapStr, a
 		Condition: condition.CreateCondition().Field(common.BKFieldID).Eq(assoID).ToMapStr(),
 		Data:      data,
 	}
-	rspAsst, err := assoc.clientSet.CoreService().Association().UpdateModelAssociation(context.Background(), kit.Header, &updateopt)
+	rspAsst, err := assoc.clientSet.CoreService().Association().UpdateModelAssociation(kit.Ctx, kit.Header, &updateopt)
 	if nil != err {
 		blog.Errorf("[operation-asst] failed to request object controller, err: %s, rid: %s", err.Error(), kit.Rid)
 		return kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -496,7 +496,7 @@ func (assoc *association) CheckAssociation(kit *rest.Kit, obj model.Object, obje
 
 func (assoc *association) CheckAssociationInstExist(kit *rest.Kit, objectID string, instID int64) (bool, error) {
 	instIDField := common.GetInstIDField(objectID)
-	instRsp, err := assoc.clientSet.CoreService().Instance().ReadInstance(context.Background(), kit.Header, objectID,
+	instRsp, err := assoc.clientSet.CoreService().Instance().ReadInstance(kit.Ctx, kit.Header, objectID,
 		&metadata.QueryCondition{Condition: mapstr.MapStr{instIDField: instID}})
 	if err != nil {
 		return false, kit.CCError.Error(common.CCErrObjectSelectInstFailed)
@@ -537,7 +537,7 @@ func (assoc *association) SearchObjectAssocWithAssocKindList(kit *rest.Kit, asst
 		cond := condition.CreateCondition()
 		cond.Field(common.AssociationKindIDField).Eq(id)
 
-		r, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(context.Background(), kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
+		r, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(kit.Ctx, kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
 		if err != nil {
 			blog.Errorf("get object association list with association kind[%s] failed, err: %v, rid: %s", id, err, kit.Rid)
 			return nil, kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -560,7 +560,7 @@ func (assoc *association) SearchType(kit *rest.Kit, request *metadata.SearchAsso
 		Page:      metadata.BasePage{Limit: request.Limit, Start: request.Start, Sort: request.Sort},
 	}
 
-	return assoc.clientSet.CoreService().Association().ReadAssociationType(context.Background(), kit.Header, &input)
+	return assoc.clientSet.CoreService().Association().ReadAssociationType(kit.Ctx, kit.Header, &input)
 }
 
 func (assoc *association) CreateType(kit *rest.Kit, request *metadata.AssociationKind) (resp *metadata.CreateAssociationTypeResult, err error) {
@@ -599,7 +599,7 @@ func (assoc *association) UpdateType(kit *rest.Kit, asstTypeID int64, request *m
 		Data:      mapstr.NewFromStruct(request, "json"),
 	}
 
-	rsp, err := assoc.clientSet.CoreService().Association().UpdateAssociationType(context.Background(), kit.Header, &input)
+	rsp, err := assoc.clientSet.CoreService().Association().UpdateAssociationType(kit.Ctx, kit.Header, &input)
 	if err != nil {
 		blog.Errorf("update association type failed, kind id: %d, err: %v, rid: %s", asstTypeID, err, kit.Rid)
 		return nil, kit.CCError.New(common.CCErrTopoCreateAssocKindFailed, err.Error())
@@ -647,7 +647,7 @@ func (assoc *association) DeleteType(kit *rest.Kit, asstTypeID int64) (resp *met
 	// a already used association kind can not be deleted.
 	cond = condition.CreateCondition()
 	cond.Field(common.AssociationKindIDField).Eq(result.Data.Info[0].AssociationKindID)
-	asso, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(context.Background(), kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
+	asso, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(kit.Ctx, kit.Header, &metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if err != nil {
 		blog.Errorf("delete association kind[%d], but get objects that used this asso kind failed, err: %v, rid: %s", asstTypeID, err, kit.Rid)
 		return nil, kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -664,7 +664,7 @@ func (assoc *association) DeleteType(kit *rest.Kit, asstTypeID int64) (resp *met
 	}
 
 	rsp, err := assoc.clientSet.CoreService().Association().DeleteAssociationType(
-		context.Background(), kit.Header, &metadata.DeleteOption{
+		kit.Ctx, kit.Header, &metadata.DeleteOption{
 			Condition: condition.CreateCondition().Field(common.BKFieldID).Eq(asstTypeID).ToMapStr(),
 		},
 	)
@@ -677,7 +677,7 @@ func (assoc *association) DeleteType(kit *rest.Kit, asstTypeID int64) (resp *met
 }
 
 func (assoc *association) SearchObject(kit *rest.Kit, request *metadata.SearchAssociationObjectRequest) (resp *metadata.SearchAssociationObjectResult, err error) {
-	rsp, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(context.Background(), kit.Header, &metadata.QueryCondition{Condition: request.Condition})
+	rsp, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(kit.Ctx, kit.Header, &metadata.QueryCondition{Condition: request.Condition})
 
 	resp = &metadata.SearchAssociationObjectResult{BaseResp: rsp.BaseResp, Data: []*metadata.Association{}}
 	for index := range rsp.Data.Info {
@@ -688,7 +688,7 @@ func (assoc *association) SearchObject(kit *rest.Kit, request *metadata.SearchAs
 }
 
 func (assoc *association) CreateObject(kit *rest.Kit, request *metadata.Association) (resp *metadata.CreateAssociationObjectResult, err error) {
-	rsp, err := assoc.clientSet.CoreService().Association().CreateModelAssociation(context.Background(), kit.Header, &metadata.CreateModelAssociation{Spec: *request})
+	rsp, err := assoc.clientSet.CoreService().Association().CreateModelAssociation(kit.Ctx, kit.Header, &metadata.CreateModelAssociation{Spec: *request})
 
 	resp = &metadata.CreateAssociationObjectResult{
 		BaseResp: rsp.BaseResp,
@@ -703,7 +703,7 @@ func (assoc *association) UpdateObject(kit *rest.Kit, asstID int, request *metad
 		Data:      mapstr.NewFromStruct(request, "json"),
 	}
 
-	rsp, err := assoc.clientSet.CoreService().Association().UpdateModelAssociation(context.Background(), kit.Header, &input)
+	rsp, err := assoc.clientSet.CoreService().Association().UpdateModelAssociation(kit.Ctx, kit.Header, &input)
 	resp = &metadata.UpdateAssociationObjectResult{
 		BaseResp: rsp.BaseResp,
 	}
@@ -715,13 +715,13 @@ func (assoc *association) DeleteObject(kit *rest.Kit, asstID int) (resp *metadat
 	input := metadata.DeleteOption{
 		Condition: condition.CreateCondition().Field(common.BKFieldID).Eq(asstID).ToMapStr(),
 	}
-	rsp, err := assoc.clientSet.CoreService().Association().DeleteModelAssociation(context.Background(), kit.Header, &input)
+	rsp, err := assoc.clientSet.CoreService().Association().DeleteModelAssociation(kit.Ctx, kit.Header, &input)
 	return &metadata.DeleteAssociationObjectResult{BaseResp: rsp.BaseResp}, err
 
 }
 
 func (assoc *association) SearchInst(kit *rest.Kit, request *metadata.SearchAssociationInstRequest) (resp *metadata.SearchAssociationInstResult, err error) {
-	rsp, err := assoc.clientSet.CoreService().Association().ReadInstAssociation(context.Background(), kit.Header, &metadata.QueryCondition{Condition: request.Condition})
+	rsp, err := assoc.clientSet.CoreService().Association().ReadInstAssociation(kit.Ctx, kit.Header, &metadata.QueryCondition{Condition: request.Condition})
 
 	resp = &metadata.SearchAssociationInstResult{BaseResp: rsp.BaseResp, Data: []*metadata.InstAsst{}}
 	for index := range rsp.Data.Info {
@@ -825,7 +825,7 @@ func (assoc *association) CreateInst(kit *rest.Kit, request *metadata.CreateAsso
 			AssociationKindID: objectAsst.AsstKindID,
 		},
 	}
-	createResult, err := assoc.clientSet.CoreService().Association().CreateInstAssociation(context.Background(), kit.Header, &input)
+	createResult, err := assoc.clientSet.CoreService().Association().CreateInstAssociation(kit.Ctx, kit.Header, &input)
 	if err != nil {
 		blog.Errorf("create instance association failed, do coreservice create failed, err: %+v, rid: %s", err, kit.Rid)
 		return nil, err
@@ -883,7 +883,7 @@ func (assoc *association) DeleteInst(kit *rest.Kit, assoID int64, metaData *meta
 	searchCondition := metadata.QueryCondition{
 		Condition: condition.CreateCondition().Field(common.BKFieldID).Eq(assoID).ToMapStr(),
 	}
-	data, err := assoc.clientSet.CoreService().Association().ReadInstAssociation(context.Background(), kit.Header, &searchCondition)
+	data, err := assoc.clientSet.CoreService().Association().ReadInstAssociation(kit.Ctx, kit.Header, &searchCondition)
 	if err != nil {
 		blog.Errorf("DeleteInst failed, get instance association failed, kit: %+v, err: %+v, rid: %s", kit, err, kit.Rid)
 		return nil, err
@@ -914,7 +914,7 @@ func (assoc *association) DeleteInst(kit *rest.Kit, assoID int64, metaData *meta
 	input := metadata.DeleteOption{
 		Condition: condition.CreateCondition().Field(common.BKFieldID).Eq(assoID).ToMapStr(),
 	}
-	rsp, err := assoc.clientSet.CoreService().Association().DeleteInstAssociation(context.Background(), kit.Header, &input)
+	rsp, err := assoc.clientSet.CoreService().Association().DeleteInstAssociation(kit.Ctx, kit.Header, &input)
 	if err != nil {
 		blog.ErrorJSON("DeleteInstAssociation failed, err: %s, input: %s, rid: %s", err, input, kit.Rid)
 		return nil, kit.CCError.CCError(common.CCErrCommHTTPDoRequestFailed)
@@ -966,7 +966,7 @@ func (assoc *association) DeleteInst(kit *rest.Kit, assoID int64, metaData *meta
 // SearchInstAssociationList 与实例有关系的实例关系数据,以分页的方式返回
 func (assoc *association) SearchInstAssociationList(kit *rest.Kit, query *metadata.QueryCondition) ([]metadata.InstAsst, uint64, error) {
 
-	rsp, err := assoc.clientSet.CoreService().Association().ReadInstAssociation(context.Background(), kit.Header, query)
+	rsp, err := assoc.clientSet.CoreService().Association().ReadInstAssociation(kit.Ctx, kit.Header, query)
 	if nil != err {
 		blog.Errorf("ReadInstAssociation http do error, err: %s, rid: %s", err.Error(), kit.Rid)
 		return nil, 0, kit.CCError.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
@@ -983,7 +983,7 @@ func (assoc *association) SearchInstAssociationList(kit *rest.Kit, query *metada
 // SearchInstAssociationUIList 与实例有关系的实例关系数据,以分页的方式返回
 func (assoc *association) SearchInstAssociationUIList(kit *rest.Kit, objID string, query *metadata.QueryCondition) (result interface{}, asstCnt uint64, err error) {
 
-	rsp, err := assoc.clientSet.CoreService().Association().ReadInstAssociation(context.Background(), kit.Header, query)
+	rsp, err := assoc.clientSet.CoreService().Association().ReadInstAssociation(kit.Ctx, kit.Header, query)
 	if nil != err {
 		blog.Errorf("ReadInstAssociation http do error, err: %s, rid: %s", err.Error(), kit.Rid)
 		return nil, 0, kit.CCError.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
@@ -1022,7 +1022,7 @@ func (assoc *association) SearchInstAssociationUIList(kit *rest.Kit, objID strin
 			Fields: []string{metadata.GetInstNameFieldName(instObjID), idField},
 		}
 		instResp, err := assoc.clientSet.CoreService().Instance().
-			ReadInstance(context.Background(), kit.Header, instObjID, input)
+			ReadInstance(kit.Ctx, kit.Header, instObjID, input)
 		if err != nil {
 			blog.Errorf("ReadInstance http do error, err: %s, input:%s, rid: %s", err.Error(), input, kit.Rid)
 			return nil, 0, kit.CCError.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
@@ -1051,7 +1051,7 @@ func (assoc *association) SearchInstAssociationUIList(kit *rest.Kit, objID strin
 // returnInstInfoObjID 根据条件查询出来关联关系，需要返回实例信息（实例名，实例ID）的模型ID
 func (assoc *association) SearchInstAssociationSingleObjectInstInfo(kit *rest.Kit, returnInstInfoObjID string, query *metadata.QueryCondition) (result []metadata.InstBaseInfo, cnt uint64, err error) {
 
-	rsp, err := assoc.clientSet.CoreService().Association().ReadInstAssociation(context.Background(), kit.Header, query)
+	rsp, err := assoc.clientSet.CoreService().Association().ReadInstAssociation(kit.Ctx, kit.Header, query)
 	if nil != err {
 		blog.Errorf("ReadInstAssociation http do error, err: %s, rid: %s", err.Error(), kit.Rid)
 		return nil, 0, kit.CCError.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
@@ -1092,7 +1092,7 @@ func (assoc *association) SearchInstAssociationSingleObjectInstInfo(kit *rest.Ki
 		Fields: []string{nameField, idField},
 	}
 	instResp, err := assoc.clientSet.CoreService().Instance().
-		ReadInstance(context.Background(), kit.Header, returnInstInfoObjID, input)
+		ReadInstance(kit.Ctx, kit.Header, returnInstInfoObjID, input)
 	if err != nil {
 		blog.Errorf("ReadInstance http do error, err: %s, input:%s, rid: %s", err.Error(), input, kit.Rid)
 		return nil, 0, kit.CCError.New(common.CCErrCommHTTPDoRequestFailed, err.Error())

--- a/src/scene_server/topo_server/core/operation/attribute.go
+++ b/src/scene_server/topo_server/core/operation/attribute.go
@@ -191,7 +191,7 @@ func (a *attribute) DeleteObjectAttribute(kit *rest.Kit, cond condition.Conditio
 		objAudit := NewObjectAttrAudit(kit, a.clientSet, attrItem.Attribute().ID).buildSnapshotForPre()
 
 		// delete the attribute
-		rsp, err := a.clientSet.CoreService().Model().DeleteModelAttr(context.Background(), kit.Header, attrItem.Attribute().ObjectID, &metadata.DeleteOption{Condition: cond.ToMapStr()})
+		rsp, err := a.clientSet.CoreService().Model().DeleteModelAttr(kit.Ctx, kit.Header, attrItem.Attribute().ObjectID, &metadata.DeleteOption{Condition: cond.ToMapStr()})
 		if nil != err {
 			blog.Errorf("[operation-attr] delete object attribute failed, request object controller with err: %v, rid: %s", err, kit.Rid)
 			return kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -290,7 +290,7 @@ func (a *attribute) FindObjectAttribute(kit *rest.Kit, cond condition.Condition,
 		Page:      metadata.BasePage{Limit: int(limits), Start: int(start), Sort: sort},
 	}
 
-	rsp, err := a.clientSet.CoreService().Model().ReadModelAttrByCondition(context.Background(), kit.Header, opt)
+	rsp, err := a.clientSet.CoreService().Model().ReadModelAttrByCondition(kit.Ctx, kit.Header, opt)
 	if nil != err {
 		blog.Errorf("[operation-attr] failed to request object controller, error info is %s, rid: %s", err.Error(), kit.Rid)
 		return nil, kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -321,7 +321,7 @@ func (a *attribute) UpdateObjectAttribute(kit *rest.Kit, data mapstr.MapStr, att
 	//get PreData
 	objAudit := NewObjectAttrAudit(kit, a.clientSet, attID).buildSnapshotForPre()
 
-	rsp, err := a.clientSet.CoreService().Model().UpdateModelAttrsByCondition(context.Background(), kit.Header, &input)
+	rsp, err := a.clientSet.CoreService().Model().UpdateModelAttrsByCondition(kit.Ctx, kit.Header, &input)
 	if nil != err {
 		blog.Errorf("[operation-attr] failed to request object controller, error info is %s, rid: %s", err.Error(), kit.Rid)
 		return kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -373,7 +373,7 @@ func (a *attribute) UpdateObjectAttributeIndex(kit *rest.Kit, objID string, data
 		Data:      data,
 	}
 
-	rsp, err := a.clientSet.CoreService().Model().UpdateModelAttrsIndex(context.Background(), kit.Header, objID, &input)
+	rsp, err := a.clientSet.CoreService().Model().UpdateModelAttrsIndex(kit.Ctx, kit.Header, objID, &input)
 	if nil != err {
 		blog.Errorf("[operation-attr] failed to request object CoreService, error info is %s, rid: %s", err.Error(), kit.Rid)
 		return nil, kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)

--- a/src/scene_server/topo_server/core/operation/audit.go
+++ b/src/scene_server/topo_server/core/operation/audit.go
@@ -13,8 +13,6 @@
 package operation
 
 import (
-	"context"
-
 	"configcenter/src/apimachinery"
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
@@ -38,7 +36,7 @@ type audit struct {
 }
 
 func (a *audit) Query(kit *rest.Kit, query metadata.QueryInput) (interface{}, error) {
-	rsp, err := a.clientSet.CoreService().Audit().SearchAuditLog(context.Background(), kit.Header, query)
+	rsp, err := a.clientSet.CoreService().Audit().SearchAuditLog(kit.Ctx, kit.Header, query)
 	if nil != err {
 		blog.Errorf("[audit] failed to request core service, error info is %s, rid: %s", err.Error(), kit.Rid)
 		return nil, kit.CCError.New(common.CCErrCommHTTPDoRequestFailed, err.Error())

--- a/src/scene_server/topo_server/core/operation/classification.go
+++ b/src/scene_server/topo_server/core/operation/classification.go
@@ -13,8 +13,6 @@
 package operation
 
 import (
-	"context"
-
 	"configcenter/src/apimachinery"
 	"configcenter/src/auth/extensions"
 	"configcenter/src/common"
@@ -147,7 +145,7 @@ func (c *classification) DeleteClassification(kit *rest.Kit, id int64, cond cond
 	//get PreData
 	objAudit := NewObjectClsAudit(kit, c.clientSet, id).buildSnapshotForPre()
 
-	rsp, err := c.clientSet.CoreService().Model().DeleteModelClassification(context.Background(), kit.Header, &metadata.DeleteOption{Condition: cond.ToMapStr()})
+	rsp, err := c.clientSet.CoreService().Model().DeleteModelClassification(kit.Ctx, kit.Header, &metadata.DeleteOption{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("[operation-cls]failed to request the object controller, error info is %s, rid: %s", err.Error(), kit.Rid)
 		return err
@@ -177,7 +175,7 @@ func (c *classification) FindClassificationWithObjects(kit *rest.Kit, cond condi
 		fCond.Merge(metadata.BizLabelNotExist)
 	}
 
-	rsp, err := c.clientSet.CoreService().Model().ReadModelClassification(context.Background(), kit.Header, &metadata.QueryCondition{Condition: fCond})
+	rsp, err := c.clientSet.CoreService().Model().ReadModelClassification(kit.Ctx, kit.Header, &metadata.QueryCondition{Condition: fCond})
 	if nil != err {
 		blog.Errorf("[operation-cls]failed to request the object controller, error info is %s, rid: %s", err.Error(), kit.Rid)
 		return nil, err
@@ -194,7 +192,7 @@ func (c *classification) FindClassificationWithObjects(kit *rest.Kit, cond condi
 	}
 	clsIDs = util.StrArrayUnique(clsIDs)
 	queryObjectCond := condition.CreateCondition().Field(common.BKClassificationIDField).In(clsIDs)
-	queryObjectResp, err := c.clientSet.CoreService().Model().ReadModel(context.Background(), kit.Header, &metadata.QueryCondition{Condition: queryObjectCond.ToMapStr()})
+	queryObjectResp, err := c.clientSet.CoreService().Model().ReadModel(kit.Ctx, kit.Header, &metadata.QueryCondition{Condition: queryObjectCond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("[operation-cls]failed to request the object controller, error info is %s, rid: %s", err.Error(), kit.Rid)
 		return nil, err
@@ -234,7 +232,7 @@ func (c *classification) FindClassification(kit *rest.Kit, cond condition.Condit
 		// fCond.Merge(metadata.BizLabelNotExist)
 	}
 
-	rsp, err := c.clientSet.CoreService().Model().ReadModelClassification(context.Background(), kit.Header, &metadata.QueryCondition{Condition: fCond})
+	rsp, err := c.clientSet.CoreService().Model().ReadModelClassification(kit.Ctx, kit.Header, &metadata.QueryCondition{Condition: fCond})
 	if nil != err {
 		blog.Errorf("[operation-cls]failed to request the object controller, error info is %s, rid: %s", err.Error(), kit.Rid)
 		return nil, err

--- a/src/scene_server/topo_server/core/operation/graphics.go
+++ b/src/scene_server/topo_server/core/operation/graphics.go
@@ -13,7 +13,6 @@
 package operation
 
 import (
-	"context"
 	"strconv"
 
 	"configcenter/src/apimachinery"
@@ -58,7 +57,7 @@ func (g *graphics) SelectObjectTopoGraphics(kit *rest.Kit, scopeType, scopeID st
 	if nil != metaData {
 		graphCondition.SetMetaData(*metaData)
 	}
-	rsp, err := g.clientSet.CoreService().TopoGraphics().SearchTopoGraphics(context.Background(), kit.Header, graphCondition)
+	rsp, err := g.clientSet.CoreService().TopoGraphics().SearchTopoGraphics(kit.Ctx, kit.Header, graphCondition)
 	if nil != err {
 		return nil, err
 	}
@@ -165,7 +164,7 @@ func (g *graphics) UpdateObjectTopoGraphics(kit *rest.Kit, scopeType, scopeID st
 		}
 	}
 
-	rsp, err := g.clientSet.CoreService().TopoGraphics().UpdateTopoGraphics(context.Background(), kit.Header, datas)
+	rsp, err := g.clientSet.CoreService().TopoGraphics().UpdateTopoGraphics(kit.Ctx, kit.Header, datas)
 	if err != nil {
 		blog.Errorf("UpdateGraphics failed %v, rid: %s", err.Error(), kit.Rid)
 		return kit.CCError.New(common.CCErrTopoGraphicsUpdateFailed, err.Error())

--- a/src/scene_server/topo_server/core/operation/group.go
+++ b/src/scene_server/topo_server/core/operation/group.go
@@ -13,8 +13,6 @@
 package operation
 
 import (
-	"context"
-
 	"configcenter/src/apimachinery"
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
@@ -96,7 +94,7 @@ func (g *group) DeleteObjectGroup(kit *rest.Kit, groupID int64) error {
 	//get PreData
 	objAudit := NewObjectAttrGroupAudit(kit, g.clientSet, groupID).buildSnapshotForPre()
 
-	rsp, err := g.clientSet.CoreService().Model().DeleteAttributeGroupByCondition(context.Background(), kit.Header, metadata.DeleteOption{Condition: cond.ToMapStr()})
+	rsp, err := g.clientSet.CoreService().Model().DeleteAttributeGroupByCondition(kit.Ctx, kit.Header, metadata.DeleteOption{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("[operation-grp]failed to request object controller, error info is %s, rid: %s", err.Error(), kit.Rid)
 		return err
@@ -124,7 +122,7 @@ func (g *group) FindObjectGroup(kit *rest.Kit, cond condition.Condition, metaDat
 	} else {
 		fCond.Merge(metadata.BizLabelNotExist)
 	}
-	rsp, err := g.clientSet.CoreService().Model().ReadAttributeGroupByCondition(context.Background(), kit.Header, metadata.QueryCondition{Condition: fCond})
+	rsp, err := g.clientSet.CoreService().Model().ReadAttributeGroupByCondition(kit.Ctx, kit.Header, metadata.QueryCondition{Condition: fCond})
 	if nil != err {
 		blog.Errorf("[operation-grp] failed to request the object controller, error info is %s, rid: %s", err.Error(), kit.Rid)
 		return nil, kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -147,7 +145,7 @@ func (g *group) FindGroupByObject(kit *rest.Kit, objID string, cond condition.Co
 		fCond.Merge(metadata.BizLabelNotExist)
 	}
 
-	rsp, err := g.clientSet.CoreService().Model().ReadAttributeGroup(context.Background(), kit.Header, objID, metadata.QueryCondition{Condition: fCond})
+	rsp, err := g.clientSet.CoreService().Model().ReadAttributeGroup(kit.Ctx, kit.Header, objID, metadata.QueryCondition{Condition: fCond})
 	if nil != err {
 		blog.Errorf("[operation-grp] failed to request the object controller, error info is %s, rid: %s", err.Error(), kit.Rid)
 		return nil, kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -184,7 +182,7 @@ func (g *group) UpdateObjectAttributeGroup(kit *rest.Kit, conds []metadata.Prope
 			Data:      mapstr.NewFromStruct(cond.Data, "json"),
 		}
 
-		rsp, err := g.clientSet.CoreService().Model().UpdateModelAttrsByCondition(context.Background(), kit.Header, &input)
+		rsp, err := g.clientSet.CoreService().Model().UpdateModelAttrsByCondition(kit.Ctx, kit.Header, &input)
 		if nil != err {
 			blog.Errorf("[operation-grp] failed to set the group  by the condition (%#v), error info is %s , rid: %s", cond, err.Error(), kit.Rid)
 			return kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -211,7 +209,7 @@ func (g *group) DeleteObjectAttributeGroup(kit *rest.Kit, objID, propertyID, gro
 		},
 	}
 
-	rsp, err := g.clientSet.CoreService().Model().UpdateModelAttrs(context.Background(), kit.Header, objID, &input)
+	rsp, err := g.clientSet.CoreService().Model().UpdateModelAttrs(kit.Ctx, kit.Header, objID, &input)
 	if nil != err {
 		blog.Errorf("[operation-grp] failed to set the group , error info is %s , rid: %s", err.Error(), kit.Rid)
 		return kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -238,7 +236,7 @@ func (g *group) UpdateObjectGroup(kit *rest.Kit, cond *metadata.UpdateGroupCondi
 	//get PreData
 	objAudit := NewObjectAttrGroupAudit(kit, g.clientSet, cond.Condition.ID).buildSnapshotForPre()
 
-	rsp, err := g.clientSet.CoreService().Model().UpdateAttributeGroupByCondition(context.Background(), kit.Header, input)
+	rsp, err := g.clientSet.CoreService().Model().UpdateAttributeGroupByCondition(kit.Ctx, kit.Header, input)
 	if nil != err {
 		blog.Errorf("[operation-grp] failed to set the group to the new data (%#v) by the condition (%#v), error info is %s , rid: %s", cond.Data, cond.Condition, err.Error(), kit.Rid)
 		return kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)

--- a/src/scene_server/topo_server/core/operation/identifier.go
+++ b/src/scene_server/topo_server/core/operation/identifier.go
@@ -13,8 +13,6 @@
 package operation
 
 import (
-	"context"
-
 	"configcenter/src/apimachinery"
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
@@ -68,7 +66,7 @@ func (g *identifier) SearchIdentifier(kit *rest.Kit, objType string, param *meta
 		Fields:    []string{common.BKHostIDField},
 		Page:      param.Page,
 	}
-	hostRet, err := g.clientSet.CoreService().Instance().ReadInstance(context.Background(), kit.Header, common.BKInnerObjIDHost, hostQuery)
+	hostRet, err := g.clientSet.CoreService().Instance().ReadInstance(kit.Ctx, kit.Header, common.BKInnerObjIDHost, hostQuery)
 	if nil != err {
 		blog.ErrorJSON("[identifier] ReadInstance query host  http do error. error:%s, input:%s,  rid:%s", err.Error(), kit, kit.Rid)
 		return nil, kit.CCError.CCErrorf(common.CCErrCommHTTPDoRequestFailed)
@@ -91,7 +89,7 @@ func (g *identifier) SearchIdentifier(kit *rest.Kit, objType string, param *meta
 		hostIDs = append(hostIDs, hostID)
 	}
 	queryHostIdentifier := &metadata.SearchHostIdentifierParam{HostIDs: hostIDs}
-	rsp, err := g.clientSet.CoreService().Host().FindIdentifier(context.Background(), kit.Header, queryHostIdentifier)
+	rsp, err := g.clientSet.CoreService().Host().FindIdentifier(kit.Ctx, kit.Header, queryHostIdentifier)
 	if nil != err {
 		blog.ErrorJSON("[identifier]  SearchIdentifier http do error. error:%s, input:%s,  rid:%s", err.Error(), kit, kit.Rid)
 		return nil, kit.CCError.CCErrorf(common.CCErrCommHTTPDoRequestFailed)

--- a/src/scene_server/topo_server/core/operation/inst.go
+++ b/src/scene_server/topo_server/core/operation/inst.go
@@ -13,7 +13,6 @@
 package operation
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"strconv"
@@ -258,7 +257,7 @@ func (c *commonInst) isValidBizInstID(kit *rest.Kit, obj metadata.Object, instID
 	query.Condition = cond.ToMapStr()
 	query.Limit = common.BKNoLimit
 
-	rsp, err := c.clientSet.CoreService().Instance().ReadInstance(context.Background(), kit.Header, obj.GetObjectID(), &metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := c.clientSet.CoreService().Instance().ReadInstance(kit.Ctx, kit.Header, obj.GetObjectID(), &metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("[operation-inst] failed to request object controller, err: %s, rid: %s", err.Error(), kit.Rid)
 		return kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -367,7 +366,7 @@ func (c *commonInst) innerHasHost(kit *rest.Kit, moduleIDS []int64) (bool, error
 		Fields:      []string{common.BKHostIDField},
 		Page:        metadata.BasePage{Limit: 1},
 	}
-	rsp, err := c.clientSet.CoreService().Host().GetHostModuleRelation(context.Background(), kit.Header, option)
+	rsp, err := c.clientSet.CoreService().Host().GetHostModuleRelation(kit.Ctx, kit.Header, option)
 	if nil != err {
 		blog.Errorf("[operation-module] failed to request the object controller, err: %s, rid: %s", err.Error(), kit.Rid)
 		return false, kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -599,7 +598,7 @@ func (c *commonInst) convertInstIDIntoStruct(kit *rest.Kit, asstObj metadata.Ass
 
 	query := &metadata.QueryCondition{}
 	query.Condition = cond.ToMapStr()
-	rsp, err := c.clientSet.CoreService().Instance().ReadInstance(context.Background(), kit.Header, obj.GetObjectID(), query)
+	rsp, err := c.clientSet.CoreService().Instance().ReadInstance(kit.Ctx, kit.Header, obj.GetObjectID(), query)
 
 	if nil != err {
 		blog.Errorf("[operation-inst] failed to request object controller, err: %s, rid: %s", err.Error(), kit.Rid)

--- a/src/scene_server/topo_server/core/operation/inst_business.go
+++ b/src/scene_server/topo_server/core/operation/inst_business.go
@@ -13,7 +13,6 @@
 package operation
 
 import (
-	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -74,7 +73,7 @@ func (b *business) HasHosts(kit *rest.Kit, bizID int64) (bool, error) {
 		Fields:        []string{common.BKHostIDField},
 		Page:          metadata.BasePage{Limit: 1},
 	}
-	rsp, err := b.clientSet.CoreService().Host().GetHostModuleRelation(context.Background(), kit.Header, option)
+	rsp, err := b.clientSet.CoreService().Host().GetHostModuleRelation(kit.Ctx, kit.Header, option)
 	if nil != err {
 		blog.Errorf("[operation-set] failed to request the object controller, error info is %s", err.Error())
 		return false, kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
@@ -103,7 +102,7 @@ func (b *business) CreateBusiness(kit *rest.Kit, obj model.Object, data mapstr.M
 		defaultOwnerHeader := util.CloneHeader(kit.Header)
 		defaultOwnerHeader.Set(common.BKHTTPOwnerID, common.BKDefaultOwnerID)
 
-		asstRsp, err := b.clientSet.CoreService().Association().ReadModelAssociation(context.Background(), defaultOwnerHeader, &metadata.QueryCondition{Condition: asstQuery})
+		asstRsp, err := b.clientSet.CoreService().Association().ReadModelAssociation(kit.Ctx, defaultOwnerHeader, &metadata.QueryCondition{Condition: asstQuery})
 		if nil != err {
 			blog.Errorf("create business failed to get default assoc, error info is %s, rid: %s", err.Error(), kit.Rid)
 			return nil, kit.CCError.New(common.CCErrTopoAppCreateFailed, err.Error())
@@ -114,7 +113,7 @@ func (b *business) CreateBusiness(kit *rest.Kit, obj model.Object, data mapstr.M
 		expectAssts := asstRsp.Data.Info
 		blog.Infof("copy asst for %s, %+v, rid: %s", kit.SupplierAccount, expectAssts, kit.Rid)
 
-		existAsstRsp, err := b.clientSet.CoreService().Association().ReadModelAssociation(context.Background(), kit.Header, &metadata.QueryCondition{Condition: asstQuery})
+		existAsstRsp, err := b.clientSet.CoreService().Association().ReadModelAssociation(kit.Ctx, kit.Header, &metadata.QueryCondition{Condition: asstQuery})
 		if nil != err {
 			blog.Errorf("create business failed to get default assoc, error info is %s, rid: %s", err.Error(), kit.Rid)
 			return nil, kit.CCError.New(common.CCErrTopoAppCreateFailed, err.Error())
@@ -140,9 +139,9 @@ func (b *business) CreateBusiness(kit *rest.Kit, obj model.Object, data mapstr.M
 			if asst.AsstKindID == common.AssociationKindMainline {
 				// bk_mainline is a inner association type that can only create in special case,
 				// so we separate bk_mainline association type creation with a independent method,
-				createAsstRsp, err = b.clientSet.CoreService().Association().CreateMainlineModelAssociation(context.Background(), kit.Header, &metadata.CreateModelAssociation{Spec: asst})
+				createAsstRsp, err = b.clientSet.CoreService().Association().CreateMainlineModelAssociation(kit.Ctx, kit.Header, &metadata.CreateModelAssociation{Spec: asst})
 			} else {
-				createAsstRsp, err = b.clientSet.CoreService().Association().CreateModelAssociation(context.Background(), kit.Header, &metadata.CreateModelAssociation{Spec: asst})
+				createAsstRsp, err = b.clientSet.CoreService().Association().CreateModelAssociation(kit.Ctx, kit.Header, &metadata.CreateModelAssociation{Spec: asst})
 			}
 			if nil != err {
 				blog.Errorf("create business failed to copy default assoc, error info is %s, rid: %s", err.Error(), kit.Rid)

--- a/src/scene_server/topo_server/core/operation/inst_module.go
+++ b/src/scene_server/topo_server/core/operation/inst_module.go
@@ -13,7 +13,6 @@
 package operation
 
 import (
-	"context"
 	"strconv"
 
 	"configcenter/src/apimachinery"
@@ -104,7 +103,7 @@ func (m *module) validBizSetID(kit *rest.Kit, bizID int64, setID int64) error {
 	query.Condition = cond.ToMapStr()
 	query.Limit = common.BKNoLimit
 
-	rsp, err := m.clientSet.CoreService().Instance().ReadInstance(context.Background(), kit.Header, common.BKInnerObjIDSet, &metadata.QueryCondition{Condition: cond.ToMapStr()})
+	rsp, err := m.clientSet.CoreService().Instance().ReadInstance(kit.Ctx, kit.Header, common.BKInnerObjIDSet, &metadata.QueryCondition{Condition: cond.ToMapStr()})
 	if nil != err {
 		blog.Errorf("[operation-inst] failed to request object controller, err: %s, rid: %s", err.Error(), kit.Rid)
 		return kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)

--- a/src/scene_server/topo_server/core/operation/inst_set.go
+++ b/src/scene_server/topo_server/core/operation/inst_set.go
@@ -13,8 +13,6 @@
 package operation
 
 import (
-	"context"
-
 	"configcenter/src/apimachinery"
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
@@ -66,7 +64,7 @@ func (s *set) hasHost(kit *rest.Kit, bizID int64, setIDS []int64) (bool, error) 
 		ApplicationID: bizID,
 		SetIDArr:      setIDS,
 	}
-	rsp, err := s.clientSet.CoreService().Host().GetHostModuleRelation(context.Background(), kit.Header, option)
+	rsp, err := s.clientSet.CoreService().Host().GetHostModuleRelation(kit.Ctx, kit.Header, option)
 	if nil != err {
 		blog.Errorf("[operation-set] failed to request the object controller, error info is %s, rid: %s", err.Error(), kit.Rid)
 		return false, kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)

--- a/src/scene_server/topo_server/core/operation/object.go
+++ b/src/scene_server/topo_server/core/operation/object.go
@@ -13,7 +13,6 @@
 package operation
 
 import (
-	"context"
 	"fmt"
 
 	"configcenter/src/apimachinery"
@@ -735,7 +734,7 @@ func (o *object) FindObject(kit *rest.Kit, cond condition.Condition, metaData *m
 		// search global shared model
 		fCond.Merge(metadata.BizLabelNotExist)
 	}
-	rsp, err := o.clientSet.CoreService().Model().ReadModel(context.Background(), kit.Header, &metadata.QueryCondition{Condition: fCond})
+	rsp, err := o.clientSet.CoreService().Model().ReadModel(kit.Ctx, kit.Header, &metadata.QueryCondition{Condition: fCond})
 	if nil != err {
 		blog.Errorf("[operation-obj] find object failed, cond: %+v, err: %s, rid: %s", fCond, err.Error(), kit.Rid)
 		return nil, kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)

--- a/src/scene_server/topo_server/core/operation/supplementary_audit.go
+++ b/src/scene_server/topo_server/core/operation/supplementary_audit.go
@@ -187,7 +187,7 @@ func (a *auditLog) commitSnapshot(preData, currData *WrapperResult, action metad
 			}
 		}
 
-		auditResp, err := a.client.CoreService().Audit().SaveAuditLog(context.Background(), a.kit.Header, auditLog)
+		auditResp, err := a.client.CoreService().Audit().SaveAuditLog(a.kit.Ctx, a.kit.Header, auditLog)
 		if err != nil {
 			blog.ErrorJSON("[audit] failed to save audit log(%s), err: %s, rid: %s", auditLog, err.Error(), a.kit.Rid)
 			return

--- a/src/scene_server/topo_server/core/operation/unique.go
+++ b/src/scene_server/topo_server/core/operation/unique.go
@@ -13,8 +13,6 @@
 package operation
 
 import (
-	"context"
-
 	"configcenter/src/apimachinery"
 	"configcenter/src/auth/extensions"
 	"configcenter/src/common"
@@ -56,7 +54,7 @@ func (a *unique) Create(kit *rest.Kit, objectID string, request *metadata.Create
 	if nil != metaData {
 		unique.Metadata = *metaData
 	}
-	resp, err := a.clientSet.CoreService().Model().CreateModelAttrUnique(context.Background(), kit.Header, objectID, metadata.CreateModelAttrUnique{Data: unique})
+	resp, err := a.clientSet.CoreService().Model().CreateModelAttrUnique(kit.Ctx, kit.Header, objectID, metadata.CreateModelAttrUnique{Data: unique})
 	if err != nil {
 		blog.Errorf("[UniqueOperation] create for %s, %#v failed %v, rid: %s", objectID, request, err, kit.Rid)
 		return nil, kit.CCError.Error(common.CCErrTopoObjectUniqueCreateFailed)
@@ -72,7 +70,7 @@ func (a *unique) Update(kit *rest.Kit, objectID string, id uint64, request *meta
 	update := metadata.UpdateModelAttrUnique{
 		Data: *request,
 	}
-	resp, err := a.clientSet.CoreService().Model().UpdateModelAttrUnique(context.Background(), kit.Header, objectID, id, update)
+	resp, err := a.clientSet.CoreService().Model().UpdateModelAttrUnique(kit.Ctx, kit.Header, objectID, id, update)
 	if err != nil {
 		blog.Errorf("[UniqueOperation] update for %s, %d, %#v failed %v, rid: %s", objectID, id, request, err, kit.Rid)
 		return kit.CCError.Error(common.CCErrTopoObjectUniqueUpdateFailed)
@@ -94,7 +92,7 @@ func (a *unique) Delete(kit *rest.Kit, objectID string, id uint64, metaData *met
 	if metaData != nil {
 		meta = *metaData
 	}
-	resp, err := a.clientSet.CoreService().Model().DeleteModelAttrUnique(context.Background(), kit.Header, objectID, id, metadata.DeleteModelAttrUnique{Metadata: meta})
+	resp, err := a.clientSet.CoreService().Model().DeleteModelAttrUnique(kit.Ctx, kit.Header, objectID, id, metadata.DeleteModelAttrUnique{Metadata: meta})
 	if err != nil {
 		blog.Errorf("[UniqueOperation] delete for %s, %d failed %v, rid: %s", objectID, id, err, kit.Rid)
 		return kit.CCError.Error(common.CCErrTopoObjectUniqueDeleteFailed)
@@ -122,7 +120,7 @@ func (a *unique) Search(kit *rest.Kit, objectID string, metaData *metadata.Metad
 	cond := metadata.QueryCondition{
 		Condition: fCond,
 	}
-	resp, err := a.clientSet.CoreService().Model().ReadModelAttrUnique(context.Background(), kit.Header, cond)
+	resp, err := a.clientSet.CoreService().Model().ReadModelAttrUnique(kit.Ctx, kit.Header, cond)
 	if err != nil {
 		blog.Errorf("[UniqueOperation] search for %s, failed %v, rid: %s", objectID, err, kit.Rid)
 		return nil, kit.CCError.Error(common.CCErrTopoObjectUniqueSearchFailed)

--- a/src/scene_server/topo_server/service/object_association.go
+++ b/src/scene_server/topo_server/service/object_association.go
@@ -13,7 +13,6 @@
 package service
 
 import (
-	"context"
 	"strconv"
 
 	"configcenter/src/common"
@@ -192,7 +191,7 @@ func (s *Service) ImportInstanceAssociation(ctx *rest.Contexts) {
 	var ret metadata.ResponeImportAssociationData
 	txnErr := s.Engine.CoreAPI.CoreService().Txn().AutoRunTxn(ctx.Kit.Ctx, s.EnableTxn, ctx.Kit.Header, func() error {
 		var err error
-		ret, err = s.Core.AssociationOperation().ImportInstAssociation(context.Background(), ctx.Kit, objID, request.AssociationInfoMap, s.Language)
+		ret, err = s.Core.AssociationOperation().ImportInstAssociation(ctx.Kit.Ctx, ctx.Kit, objID, request.AssociationInfoMap, s.Language)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### 优化的功能:
- 为api请求增加超时时间，防止某些慢请求影响到服务整体的可用性

从api层为请求设置超时deadline，从api层->scene层->coreservice层->db，通过http的header传递deadline，再将deadline设置到各http请求处理函数的首个参数ctx里。使得请求超时，所有的goroutine都马上退出并且释放相关的资源。

close #4572 