### PR TITLE
feature: list  host without biz  fixed sort field(bk_host_id).  issue…

### DIFF
--- a/src/scene_server/host_server/service/findhost.go
+++ b/src/scene_server/host_server/service/findhost.go
@@ -688,6 +688,7 @@ func (s *Service) ListHostsWithNoBiz(req *restful.Request, resp *restful.Respons
 		return
 	}
 
+	parameter.Page.Sort = common.BKHostIDField
 	option := &meta.ListHosts{
 		HostPropertyFilter: parameter.HostPropertyFilter,
 		Fields:             parameter.Fields,


### PR DESCRIPTION



### 新加的功能:
-  list_hosts_without_biz 删除排序字段，所有的请求都是用bk_host_id 排序
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx


close  #4605