### PR TITLE
当没有快照数据时，返回数据值为null

### DIFF
--- a/src/scene_server/host_server/service/host.go
+++ b/src/scene_server/host_server/service/host.go
@@ -361,7 +361,7 @@ func (s *Service) HostSnapInfo(req *restful.Request, resp *restful.Response) {
 	if result.Data.Data == "" {
 		_ = resp.WriteEntity(meta.HostSnapResult{
 			BaseResp: meta.SuccessBaseResp,
-			Data:     map[string]interface{}{},
+			Data:     nil,
 		})
 		return
 	}


### PR DESCRIPTION
### 修复的问题：
- 当没有快照数据时，返回数据值为null，以保证前端显示正常