### PR TITLE
调整批量查询主机快照的数量限制为200

### DIFF
--- a/src/common/metadata/hostcontroller.go
+++ b/src/common/metadata/hostcontroller.go
@@ -15,6 +15,8 @@ package metadata
 import (
 	"time"
 
+	"configcenter/src/common"
+	"configcenter/src/common/errors"
 	"configcenter/src/common/mapstr"
 )
 
@@ -91,6 +93,30 @@ type HostSnap struct {
 type GetHostSnapResult struct {
 	BaseResp `json:",inline"`
 	Data     HostSnap `json:"data"`
+}
+
+type HostSnapBatchOption struct {
+	IDs    []int64  `json:"bk_ids"`
+	Fields []string `json:"fields"`
+}
+
+func (h *HostSnapBatchOption) Validate() (rawError errors.RawErrorInfo) {
+	maxLimit := 200
+	if len(h.IDs) == 0 || len(h.IDs) > maxLimit {
+		return errors.RawErrorInfo{
+			ErrCode: common.CCErrArrayLengthWrong,
+			Args:    []interface{}{"bk_ids", maxLimit},
+		}
+	}
+
+	if len(h.Fields) == 0 {
+		return errors.RawErrorInfo{
+			ErrCode: common.CCErrCommParamsInvalid,
+			Args:    []interface{}{"fields"},
+		}
+	}
+
+	return errors.RawErrorInfo{}
 }
 
 type HostSnapBatchInput struct {

--- a/src/scene_server/host_server/service/host.go
+++ b/src/scene_server/host_server/service/host.go
@@ -361,7 +361,7 @@ func (s *Service) HostSnapInfo(ctx *rest.Contexts) {
 // HostSnapInfoBatch get the host snapshot in batch
 func (s *Service) HostSnapInfoBatch(ctx *rest.Contexts) {
 
-	option := meta.SearchInstBatchOption{}
+	option := meta.HostSnapBatchOption{}
 	if err := json.NewDecoder(ctx.Request.Request.Body).Decode(&option); err != nil {
 		blog.Errorf("HostSnapInfoBatch failed, decode body err: %v, rid:%s", err, ctx.Kit.Rid)
 		ctx.RespAutoError(ctx.Kit.CCError.CCError(common.CCErrCommJSONUnmarshalFailed))


### PR DESCRIPTION
### 优化的功能:
- 调整批量查询主机快照的数量限制为200
