### PR TITLE
服务模版绑定IP为内外网IP， 但主机没有相应的IP时，进程绑定127.0.0.1

### DIFF
--- a/src/common/metadata/process.go
+++ b/src/common/metadata/process.go
@@ -463,6 +463,10 @@ func (p *SocketBindType) IP(host map[string]interface{}) string {
 		return ""
 	}
 
+	if ip == "" {
+		return "127.0.0.1"
+	}
+
 	index := strings.Index(strings.Trim(ip, ","), ",")
 	if index == -1 {
 		return ip


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
