### PR TITLE
fix: sync  proc bind info and diff bind info not equal  issue #4468

### DIFF
--- a/src/common/metadata/process_bind_info.go
+++ b/src/common/metadata/process_bind_info.go
@@ -348,10 +348,11 @@ func cloneProcBindInfoArr(procBindInfoArr []ProcBindInfo) (newData []ProcBindInf
 
 		newData[idx] = ProcBindInfo{
 			Std: &stdProcBindInfo{
-				IP:       bindInfo.Std.IP,
-				Port:     bindInfo.Std.Port,
-				Protocol: bindInfo.Std.Protocol,
-				Enable:   bindInfo.Std.Enable,
+				IP:            bindInfo.Std.IP,
+				Port:          bindInfo.Std.Port,
+				Protocol:      bindInfo.Std.Protocol,
+				Enable:        bindInfo.Std.Enable,
+				TemplateRowID: bindInfo.Std.TemplateRowID,
 			},
 			extra: extra,
 		}


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- 修复进程同步和进程对比数据不一致的情况
