### PR TITLE
修复当主机没有安装agent时，快照实时页面显示不对的问题

### DIFF
--- a/src/scene_server/host_server/service/host.go
+++ b/src/scene_server/host_server/service/host.go
@@ -335,7 +335,7 @@ func (s *Service) HostSnapInfo(ctx *rest.Contexts) {
 	}
 
 	if result.Data.Data == "" {
-		ctx.RespEntity(map[string]interface{}{})
+		ctx.RespEntity(nil)
 		return
 	}
 


### PR DESCRIPTION
### 修复的问题：
- 修复当主机没有安装agent时，快照实时页面显示不对的问题
