### PR TITLE
feature: send query command to secondary  nodes by scenario issue #4663

### DIFF
--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -929,6 +929,40 @@ const (
 	BKHTTPSecretsToken   = "BK-Secrets-Token"
 	BKHTTPSecretsProject = "BK-Secrets-Project"
 	BKHTTPSecretsEnv     = "BK-Secrets-Env"
+	// BKHTTPReadRefernce  query db use secondary node
+	BKHTTPReadPrefernce = "Cc_Read_Preference"
+)
+
+type ReadPrefernceMode string
+
+func (r ReadPrefernceMode) String() string {
+	return string(r)
+}
+
+// BKHTTPReadRefernceMode constants  这个位置对应的是mongodb 的read preference 的mode，如果driver 没有变化这里是不需要变更的，
+// 新增mode 需要修改src/storage/dal/mongo/local/mongo.go 中的getCollectionOption 方法来支持
+const (
+
+	// NilMode not set
+	NilMode ReadPrefernceMode = ""
+	// PrimaryMode indicates that only a primary is
+	// considered for reading. This is the default
+	// mode.
+	PrimaryMode ReadPrefernceMode = "1"
+	// PrimaryPreferredMode indicates that if a primary
+	// is available, use it; otherwise, eligible
+	// secondaries will be considered.
+	PrimaryPreferredMode ReadPrefernceMode = "2"
+	// SecondaryMode indicates that only secondaries
+	// should be considered.
+	SecondaryMode ReadPrefernceMode = "3"
+	// SecondaryPreferredMode indicates that only secondaries
+	// should be considered when one is available. If none
+	// are available, then a primary will be considered.
+	SecondaryPreferredMode ReadPrefernceMode = "4"
+	// NearestMode indicates that all primaries and secondaries
+	// will be considered.
+	NearestMode ReadPrefernceMode = "5"
 )
 
 // transaction related

--- a/src/common/http/rest/contexts.go
+++ b/src/common/http/rest/contexts.go
@@ -417,6 +417,10 @@ func (c *Contexts) NewHeader() http.Header {
 	return util.CCHeader(c.Kit.Header)
 }
 
+func (c *Contexts) SetReadPreference(mode common.ReadPrefernceMode) {
+	c.Kit.Ctx, c.Kit.Header = util.SetReadPreference(c.Kit.Ctx, c.Kit.Header, mode)
+}
+
 // NewKit 产生一个新的kit， 一般用于在创建新的协程的时候，这个时候会对header 做处理，删除不必要的http header。
 func (kit *Kit) NewKit() *Kit {
 	newHeader := util.CCHeader(kit.Header)

--- a/src/common/http/rest/rest.go
+++ b/src/common/http/rest/rest.go
@@ -21,6 +21,7 @@ import (
 	"configcenter/src/common/errors"
 	"configcenter/src/common/language"
 	"configcenter/src/common/util"
+
 	"github.com/emicklei/go-restful"
 )
 
@@ -111,6 +112,11 @@ func (r *RestUtility) wrapperAction(action Action) func(req *restful.Request, re
 			ctx = context.WithValue(ctx, common.TransactionIdHeader, txnID)
 			ctx = context.WithValue(ctx, common.TransactionTimeoutHeader, header.Get(common.TransactionTimeoutHeader))
 		}
+		if mode := util.GetHTTPReadPreference(header); mode != common.NilMode {
+			ctx = util.SetDBReadPreference(ctx, mode)
+			header = util.SetHTTPReadPreference(header, mode)
+		}
+
 		restContexts.Kit = &Kit{
 			Header:          header,
 			Rid:             rid,

--- a/src/scene_server/auth_server/service/service.go
+++ b/src/scene_server/auth_server/service/service.go
@@ -89,6 +89,8 @@ func (s *AuthService) checkRequestFromIamFilter() func(req *restful.Request, res
 		// use iam language as cc language
 		req.Request.Header.Set(common.BKHTTPLanguage, req.Request.Header.Get("Blueking-Language"))
 
+		req.Request.Header = util.SetHTTPReadPreference(req.Request.Header, common.SecondaryPreferredMode)
+
 		// set supplierID
 		setSupplierID(req.Request)
 

--- a/src/scene_server/host_server/service/findhost.go
+++ b/src/scene_server/host_server/service/findhost.go
@@ -388,7 +388,7 @@ func (s *Service) FindHostsByTopo(ctx *rest.Contexts) {
 		ctx.RespAutoError(err)
 		return
 	}
-	
+
 	if rawErr := option.Validate(); rawErr.ErrCode != 0 {
 		blog.Errorf("find hosts by topo failed, validate err: %v, option: %#v, rid: %s", rawErr, *option, ctx.Kit.Rid)
 		ctx.RespAutoError(rawErr.ToCCError(ctx.Kit.CCError))
@@ -413,7 +413,7 @@ func (s *Service) FindHostsByTopo(ctx *rest.Contexts) {
 	} else {
 		setIDArr, err := s.Logic.GetSetIDsByTopo(ctx.Kit, option.ObjID, option.InstID)
 		if err != nil {
-			blog.Errorf("find hosts by topo failed, get set ID by topo err: %v, objID: %s, instID: %d, rid: %s", 
+			blog.Errorf("find hosts by topo failed, get set ID by topo err: %v, objID: %s, instID: %d, rid: %s",
 				err, option.ObjID, option.InstID, ctx.Kit.Rid)
 			ctx.RespAutoError(err)
 			return
@@ -434,12 +434,12 @@ func (s *Service) FindHostsByTopo(ctx *rest.Contexts) {
 
 	result, err := s.findDistinctHostInfo(ctx, distinctHostCond, searchHostCond)
 	if err != nil {
-		blog.Errorf("find hosts by topo failed, cond: %#v, search cond: %#v, er: %v, rid: %s", err, *distinctHostCond, 
+		blog.Errorf("find hosts by topo failed, cond: %#v, search cond: %#v, er: %v, rid: %s", err, *distinctHostCond,
 			*searchHostCond, ctx.Kit.Rid)
 		ctx.RespAutoError(err)
 		return
 	}
-	
+
 	ctx.RespEntity(result.Data)
 }
 
@@ -558,7 +558,7 @@ func (s *Service) ListBizHosts(ctx *rest.Contexts) {
 }
 
 func (s *Service) listBizHosts(ctx *rest.Contexts, bizID int64, parameter meta.ListHostsParameter) (result *meta.ListHostResult, ccErr errors.CCErrorCoder) {
-	header:=ctx.Kit.Header
+	header := ctx.Kit.Header
 	rid := ctx.Kit.Rid
 	defErr := ctx.Kit.CCError
 
@@ -658,6 +658,8 @@ func (s *Service) ListHostsWithNoBiz(ctx *rest.Contexts) {
 		Fields:             parameter.Fields,
 		Page:               parameter.Page,
 	}
+
+	ctx.SetReadPreference(common.SecondaryPreferredMode)
 	host, err := s.CoreAPI.CoreService().Host().ListHosts(ctx.Kit.Ctx, header, option)
 	if err != nil {
 		blog.Errorf("find host failed, err: %s, input:%#v, rid:%s", err.Error(), parameter, rid)


### PR DESCRIPTION
### 新加的功能:
- 将authserver中操作的查询数据方法放到mongodb的secondary 节点中执行
- 将 /api/v3/hosts/list_hosts_without_app 操作的查询数据方法放到mongodb的secondary 节点中执行
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
