### PR TITLE
feature: add dynamic service discoery issue #4675

### DIFF
--- a/src/apimachinery/discovery/discovery.go
+++ b/src/apimachinery/discovery/discovery.go
@@ -14,7 +14,6 @@ package discovery
 
 import (
 	"fmt"
-	"strings"
 
 	"configcenter/src/common"
 	"configcenter/src/common/backbone/service_mange/zk"
@@ -58,8 +57,14 @@ func NewServiceDiscovery(client *zk.ZkClient) (DiscoveryInterface, error) {
 	d := &discover{
 		servers: make(map[string]*server),
 	}
-	for component := range types.AllModule {
-		if component == types.CC_MODULE_WEBSERVER {
+
+	curServiceName := common.GetIdentification()
+	services := types.GetDiscoveryService()
+	// 将当前服务也放到需要发现中
+	services[curServiceName] = struct{}{}
+	for component := range services {
+		// 如果所有服务都按需发现服务。这个地方时不需要配置
+		if component == types.CC_MODULE_WEBSERVER && curServiceName != types.CC_MODULE_WEBSERVER {
 			continue
 		}
 		path := fmt.Sprintf("%s/%s", types.CC_SERV_BASEPATH, component)
@@ -69,22 +74,6 @@ func NewServiceDiscovery(client *zk.ZkClient) (DiscoveryInterface, error) {
 		}
 
 		d.servers[component] = svr
-	}
-	// 如果要支持第三方服务自动发现，
-	// 需要watch  types.CC_SERV_BASEPATH 节点。发现有新的节点加入，
-	//  对改节点执行newServerDiscover 方法。 这个操作d 对象需要加锁
-
-	//  如果当前服务不是标准服务，发现自己的服务其他节点
-	component := common.GetIdentification()
-	if strings.HasPrefix(common.GetIdentification(), types.CC_DISCOVERY_PREFIX) {
-		path := fmt.Sprintf("%s/%s", types.CC_SERV_BASEPATH, component)
-		svr, err := newServerDiscover(disc, path, component)
-		if err != nil {
-			return nil, fmt.Errorf("discover %s failed, err: %v", component, err)
-		}
-
-		d.servers[component] = svr
-
 	}
 
 	return d, nil

--- a/src/common/types/manager.go
+++ b/src/common/types/manager.go
@@ -1,0 +1,40 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types
+
+var (
+	// needDiscoveryServiceName 服务依赖的第三方服务名字的配置
+	needDiscoveryServiceName map[string]struct{} = make(map[string]struct{}, 0)
+)
+
+// DiscoveryAllService 发现所有定义的服务
+func DiscoveryAllService() {
+	for name := range AllModule {
+		needDiscoveryServiceName[name] = struct{}{}
+	}
+}
+
+// AddDiscoveryService 新加需要发现服务的名字
+func AddDiscoveryService(name ...string) {
+	for _, name := range name {
+		needDiscoveryServiceName[name] = struct{}{}
+	}
+}
+
+func GetDiscoveryService() map[string]struct{} {
+	// compatible 如果没配置,发现所有的服务
+	if len(needDiscoveryServiceName) == 0 {
+		DiscoveryAllService()
+	}
+	return needDiscoveryServiceName
+}


### PR DESCRIPTION
### 新加的功能:
- 服务发现支持动态服务发现 
### 优化的功能:
- xxxx
### 修复的问题：



实现思路:

- 服务发现实现按需发现服务的能力
  
    通过再代码中定义依赖的服务，然后服务发现发现服务的地址， 最后通过定义规则转发。 
      1. src/common/types/manager.go中的AddDiscoveryService 方法用来设置当前服务需要发现的服务。 （已提交pr）
      2.  src/apimachinery/discovery/discovery.go 新加支持根据服务名发现服务。 （未开始）
      3. 支持根据规则转发请求 （未开始）

功能的优点：
- 按需发现，减少资源浪费
- 服务依赖更明确
- 模块化设计， 减少代码
- 为后续apiserver， sdk 支持非标准组件做准备


