### PR TITLE
查询接口默认使用精确匹配

### DIFF
--- a/src/common/metadata/cloud.go
+++ b/src/common/metadata/cloud.go
@@ -114,8 +114,8 @@ type SearchCloudOption struct {
 	Condition mapstr.MapStr `json:"condition" bson:"condition" field:"condition"`
 	Page      BasePage      `json:"page" bson:"page" field:"page"`
 	Fields    []string      `json:"fields,omitempty" bson:"fields,omitempty"`
-	// 对于condition里的属性值是否精确匹配，默认为false，即使用模糊匹配和忽略大小写
-	Exact bool `json:"exact" bson:"exact"`
+	// 对于condition里的属性值是否模糊匹配，默认为false，即不采用模糊匹配，而使用精确匹配
+	IsFuzzy bool `json:"is_fuzzy" bson:"is_fuzzy"`
 }
 
 type SearchSyncTaskOption struct {

--- a/src/common/metadata/toposerver.go
+++ b/src/common/metadata/toposerver.go
@@ -78,7 +78,7 @@ type SearchResourceDirParams struct {
 	Fields    []string      `json:"fields"`
 	Page      BasePage      `json:"page"`
 	Condition mapstr.MapStr `json:"condition"`
-	Exact     bool          `json:"exact"`
+	IsFuzzy   bool          `json:"is_fuzzy"`
 }
 
 type SearchResourceDirResult struct {

--- a/src/scene_server/cloud_server/logics/synctask.go
+++ b/src/scene_server/cloud_server/logics/synctask.go
@@ -146,8 +146,8 @@ func (lgc *Logics) SearchSyncTask(kit *rest.Kit, option *metadata.SearchSyncTask
 		option.Page.Sort = "-" + common.CreateTimeField
 	}
 
-	// if not exact search, change the string query to regexp
-	if option.Exact != true {
+	// if fuzzy search, change the string query to regexp
+	if option.IsFuzzy == true {
 		for k, v := range option.Condition {
 			field, ok := v.(string)
 			if ok {
@@ -326,8 +326,8 @@ func (lgc *Logics) SearchSyncHistory(kit *rest.Kit, option *metadata.SearchSyncH
 		option.Page.Sort = "-" + common.CreateTimeField
 	}
 
-	// if not exact search, change the string query to regexp
-	if option.Exact != true {
+	// if fuzzy search, change the string query to regexp
+	if option.IsFuzzy == true {
 		for k, v := range option.Condition {
 			field, ok := v.(string)
 			if ok {

--- a/src/scene_server/cloud_server/service/account.go
+++ b/src/scene_server/cloud_server/service/account.go
@@ -191,8 +191,8 @@ func (s *Service) SearchAccount(ctx *rest.Contexts) {
 		option.Page.Sort = "-" + common.CreateTimeField
 	}
 
-	// if not exact search, change the string query to regexp
-	if option.Exact != true {
+	// if fuzzy search, change the string query to regexp
+	if option.IsFuzzy == true {
 		for k, v := range option.Condition {
 			field, ok := v.(string)
 			if ok {

--- a/src/scene_server/host_server/service/cloudarea.go
+++ b/src/scene_server/host_server/service/cloudarea.go
@@ -54,11 +54,10 @@ func (s *Service) FindManyCloudArea(ctx *rest.Contexts) {
 		input.Page.Sort = "-" + common.CreateTimeField
 	}
 
-
-	// if not exact search, change the string query to regexp
-	if input.Exact != true {
+	// if fuzzy search, change the string query to regexp
+	if input.IsFuzzy == true {
 		for k, v := range input.Condition {
-			field,ok := v.(string)
+			field, ok := v.(string)
 			if ok {
 				input.Condition[k] = mapstr.MapStr{
 					common.BKDBLIKE: params.SpecialCharChange(field),
@@ -121,7 +120,7 @@ func (s *Service) CreatePlatBatch(ctx *rest.Contexts) {
 	}
 
 	user := util.GetUser(ctx.Request.Request.Header)
-	for i, _ := range input.Data {
+	for i := range input.Data {
 		input.Data[i][common.BKCreator] = user
 		input.Data[i][common.BKLastEditor] = user
 	}

--- a/src/scene_server/topo_server/service/resource_directory.go
+++ b/src/scene_server/topo_server/service/resource_directory.go
@@ -253,7 +253,9 @@ func (s *Service) SearchResourceDirectory(ctx *rest.Contexts) {
 		ctx.RespErrorCodeOnly(common.CCErrCommJSONUnmarshalFailed, "")
 		return
 	}
-	if input.Exact == false {
+
+	// if fuzzy search, change the string query to regexp
+	if input.IsFuzzy == true {
 		for k, v := range input.Condition {
 			field, ok := v.(string)
 			if ok {

--- a/src/test/cloud_server/cloud_account_test.go
+++ b/src/test/cloud_server/cloud_account_test.go
@@ -54,7 +54,7 @@ func clearAccountData() {
 // 准备测试用例需要的数据
 func prepareAccountData() {
 	accountData := []map[string]interface{}{accountData1, accountData2}
-	for i, _ := range accountData {
+	for i := range accountData {
 		rsp, err := cloudServerClient.CreateAccount(context.Background(), header, accountData[i])
 		util.RegisterResponse(rsp)
 		Expect(err).NotTo(HaveOccurred())
@@ -208,15 +208,15 @@ var _ = Describe("cloud account test", func() {
 			Expect(len(rsp.Data.Info)).To(Equal(1))
 		})
 
-		It("search with configured exact is true", func() {
-			queryData := map[string]interface{}{"exact": true, "condition": map[string]interface{}{"bk_account_name": "aws"}}
+		It("search with configured is_fuzzy is false", func() {
+			queryData := map[string]interface{}{"is_fuzzy": false, "condition": map[string]interface{}{"bk_account_name": "aws"}}
 			rsp, err := cloudServerClient.SearchAccount(context.Background(), header, queryData)
 			util.RegisterResponse(rsp)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rsp.Result).To(Equal(true))
 			Expect(rsp.Data.Count).To(Equal(int64(0)))
 
-			queryData = map[string]interface{}{"exact": true, "condition": map[string]interface{}{"bk_account_name": "awsAccount1"}}
+			queryData = map[string]interface{}{"is_fuzzy": false, "condition": map[string]interface{}{"bk_account_name": "awsAccount1"}}
 			rsp, err = cloudServerClient.SearchAccount(context.Background(), header, queryData)
 			util.RegisterResponse(rsp)
 			Expect(err).NotTo(HaveOccurred())
@@ -225,8 +225,8 @@ var _ = Describe("cloud account test", func() {
 			Expect(rsp.Data.Info[0].String("bk_account_name")).To(Equal("awsAccount1"))
 		})
 
-		It("search with configured exact is false", func() {
-			queryData := map[string]interface{}{"exact": false, "condition": map[string]interface{}{"bk_account_name": "aws"}}
+		It("search with configured is_fuzzy is true", func() {
+			queryData := map[string]interface{}{"is_fuzzy": true, "condition": map[string]interface{}{"bk_account_name": "aws"}}
 			rsp, err := cloudServerClient.SearchAccount(context.Background(), header, queryData)
 			util.RegisterResponse(rsp)
 			Expect(err).NotTo(HaveOccurred())

--- a/src/test/cloud_server/cloud_sync_task_test.go
+++ b/src/test/cloud_server/cloud_sync_task_test.go
@@ -259,15 +259,15 @@ var _ = Describe("cloud sync task test", func() {
 			Expect(len(rsp.Data.Info)).To(Equal(1))
 		})
 
-		It("search with configured exact is true", func() {
-			queryData := map[string]interface{}{"exact": true, "condition": map[string]interface{}{"bk_task_name": "王者荣耀"}}
+		It("search with configured is_fuzzy is false", func() {
+			queryData := map[string]interface{}{"is_fuzzy": false, "condition": map[string]interface{}{"bk_task_name": "王者荣耀"}}
 			rsp, err := cloudServerClient.SearchSyncTask(context.Background(), header, queryData)
 			util.RegisterResponse(rsp)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rsp.Result).To(Equal(true))
 			Expect(rsp.Data.Count).To(Equal(int64(0)))
 
-			queryData = map[string]interface{}{"exact": true, "condition": map[string]interface{}{"bk_task_name": testData1["bk_task_name"]}}
+			queryData = map[string]interface{}{"is_fuzzy": false, "condition": map[string]interface{}{"bk_task_name": testData1["bk_task_name"]}}
 			rsp, err = cloudServerClient.SearchSyncTask(context.Background(), header, queryData)
 			util.RegisterResponse(rsp)
 			Expect(err).NotTo(HaveOccurred())
@@ -276,8 +276,8 @@ var _ = Describe("cloud sync task test", func() {
 			Expect(rsp.Data.Info[0].String("bk_task_name")).To(Equal(testData1["bk_task_name"]))
 		})
 
-		It("search with configured exact is false", func() {
-			queryData := map[string]interface{}{"exact": false, "condition": map[string]interface{}{"bk_task_name": "王者荣耀"}}
+		It("search with configured is_fuzzy is true", func() {
+			queryData := map[string]interface{}{"is_fuzzy": true, "condition": map[string]interface{}{"bk_task_name": "王者荣耀"}}
 			rsp, err := cloudServerClient.SearchSyncTask(context.Background(), header, queryData)
 			util.RegisterResponse(rsp)
 			Expect(err).NotTo(HaveOccurred())

--- a/src/test/host_server/cloudarea_test.go
+++ b/src/test/host_server/cloudarea_test.go
@@ -207,15 +207,15 @@ var _ = Describe("cloud area test", func() {
 			Expect(len(rsp.Data.Info)).To(Equal(int(1)))
 		})
 
-		It("search with configured exact is true", func() {
-			queryData := map[string]interface{}{"exact": true, "condition": map[string]interface{}{"bk_cloud_name": "LPL"}}
+		It("search with configured is_fuzzy is false", func() {
+			queryData := map[string]interface{}{"is_fuzzy": false, "condition": map[string]interface{}{"bk_cloud_name": "LPL"}}
 			rsp, err := hostServerClient.SearchCloudArea(context.Background(), header, queryData)
 			util.RegisterResponse(rsp)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rsp.Result).To(Equal(true))
 			Expect(rsp.Data.Count).To(Equal(int64(0)))
 
-			queryData = map[string]interface{}{"exact": true, "condition": map[string]interface{}{"bk_cloud_name": testData2["bk_cloud_name"]}}
+			queryData = map[string]interface{}{"is_fuzzy": false, "condition": map[string]interface{}{"bk_cloud_name": testData2["bk_cloud_name"]}}
 			rsp, err = hostServerClient.SearchCloudArea(context.Background(), header, queryData)
 			util.RegisterResponse(rsp)
 			Expect(err).NotTo(HaveOccurred())
@@ -224,8 +224,8 @@ var _ = Describe("cloud area test", func() {
 			Expect(rsp.Data.Info[0].String("bk_cloud_name")).To(Equal(testData2["bk_cloud_name"]))
 		})
 
-		It("search with configured exact is false", func() {
-			queryData := map[string]interface{}{"exact": false, "condition": map[string]interface{}{"bk_cloud_name": "LPL"}}
+		It("search with configured is_fuzzy is true", func() {
+			queryData := map[string]interface{}{"is_fuzzy": true, "condition": map[string]interface{}{"bk_cloud_name": "LPL"}}
 			rsp, err := hostServerClient.SearchCloudArea(context.Background(), header, queryData)
 			util.RegisterResponse(rsp)
 			Expect(err).NotTo(HaveOccurred())

--- a/src/test/topo_server/resource_dir_test.go
+++ b/src/test/topo_server/resource_dir_test.go
@@ -103,15 +103,15 @@ var _ = Describe("resource pool directory test", func() {
 			Expect(rsp.Data.Info[0].String("bk_module_name")).To(Equal(testData2["bk_module_name"]))
 		})
 
-		It("search with configured exact is true", func() {
-			queryData := map[string]interface{}{"exact": true, "condition": map[string]interface{}{"bk_module_name": "qq"}}
+		It("search with configured is_fuzzy is false", func() {
+			queryData := map[string]interface{}{"is_fuzzy": false, "condition": map[string]interface{}{"bk_module_name": "qq"}}
 			rsp, err := topoServerClient.ResourceDirectory().SearchResourceDirectory(context.Background(), header, queryData)
 			util.RegisterResponse(rsp)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rsp.Result).To(Equal(true))
 			Expect(rsp.Data.Count).To(Equal(int64(0)))
 
-			queryData = map[string]interface{}{"exact": true, "condition": map[string]interface{}{"bk_module_name": testData1["bk_module_name"]}}
+			queryData = map[string]interface{}{"is_fuzzy": false, "condition": map[string]interface{}{"bk_module_name": testData1["bk_module_name"]}}
 			rsp, err = topoServerClient.ResourceDirectory().SearchResourceDirectory(context.Background(), header, queryData)
 			util.RegisterResponse(rsp)
 			Expect(err).NotTo(HaveOccurred())
@@ -120,8 +120,8 @@ var _ = Describe("resource pool directory test", func() {
 			Expect(rsp.Data.Info[0].String("bk_module_name")).To(Equal(testData1["bk_module_name"]))
 		})
 
-		It("search with configured exact is false", func() {
-			queryData := map[string]interface{}{"exact": false, "condition": map[string]interface{}{"bk_module_name": "qwq"}}
+		It("search with configured is_fuzzy is true", func() {
+			queryData := map[string]interface{}{"is_fuzzy": true, "condition": map[string]interface{}{"bk_module_name": "qwq"}}
 			rsp, err := topoServerClient.ResourceDirectory().SearchResourceDirectory(context.Background(), header, queryData)
 			util.RegisterResponse(rsp)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
- 不指定模糊查询的情况下，查询云区域、云账户、云同步任务、云同步历史记录、资源池目录的接口默认使用精确匹配查询
