### PR TITLE
让mongodb连接池配置生效

### DIFF
--- a/src/scene_server/admin_server/app/server.go
+++ b/src/scene_server/admin_server/app/server.go
@@ -87,7 +87,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 		}
 		var db dal.RDB
 		if process.Config.MongoDB.Enable == "true" {
-			db, err = local.NewMgo(process.Config.MongoDB.BuildURI(), time.Minute)
+			db, err = local.NewMgo(process.Config.MongoDB.BuildURI(), process.Config.MongoDB.MaxOpenConns, time.Minute)
 		} else {
 			db, err = remote.NewWithDiscover(process.Core)
 		}

--- a/src/scene_server/admin_server/command/command.go
+++ b/src/scene_server/admin_server/command/command.go
@@ -73,7 +73,7 @@ func Parse(args []string) error {
 	mongoConfig := mongo.ParseConfigFromKV("mongodb", config.ConfigMap)
 
 	// connect to mongo db
-	db, err := local.NewMgo(mongoConfig.BuildURI(), 0)
+	db, err := local.NewMgo(mongoConfig.BuildURI(), mongoConfig.MaxOpenConns, 0)
 	if err != nil {
 		return fmt.Errorf("connect mongo server failed %s", err.Error())
 	}

--- a/src/scene_server/datacollection/app/server.go
+++ b/src/scene_server/datacollection/app/server.go
@@ -76,7 +76,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 
 		var mgoCli dal.RDB
 		if process.Config.MongoDB.Enable == "true" {
-			mgoCli, err = local.NewMgo(process.Config.MongoDB.BuildURI(), time.Minute)
+			mgoCli, err = local.NewMgo(process.Config.MongoDB.BuildURI(), process.Config.MongoDB.MaxOpenConns, time.Minute)
 		} else {
 			mgoCli, err = remote.NewWithDiscover(process.Core)
 		}

--- a/src/scene_server/event_server/app/server.go
+++ b/src/scene_server/event_server/app/server.go
@@ -72,7 +72,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 		var db dal.RDB
 		var rpcCli rpc.Client
 		if process.Config.MongoDB.Enable == "true" {
-			db, err = local.NewMgo(process.Config.MongoDB.BuildURI(), time.Minute)
+			db, err = local.NewMgo(process.Config.MongoDB.BuildURI(), process.Config.MongoDB.MaxOpenConns, time.Minute)
 		} else {
 			rpcCli, err = rpc.NewClientPool("tcp", engine.ServiceManageInterface.TMServer().GetServers, "/txn/v3/rpc")
 			if err != nil {

--- a/src/scene_server/topo_server/app/server.go
+++ b/src/scene_server/topo_server/app/server.go
@@ -102,7 +102,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 
 	var txn dal.Transcation
 	if server.Config.Mongo.Enable == "true" {
-		txn, err = local.NewMgo(server.Config.Mongo.BuildURI(), time.Second*5)
+		txn, err = local.NewMgo(server.Config.Mongo.BuildURI(), server.Config.Mongo.MaxOpenConns, time.Second*5)
 	} else {
 		txn, err = remote.NewWithDiscover(engine)
 	}

--- a/src/source_controller/coreservice/core/association/mock_test.go
+++ b/src/source_controller/coreservice/core/association/mock_test.go
@@ -81,21 +81,21 @@ func (m *mockDependences) IsInstanceExist(ctx core.ContextParams, objID string, 
 
 func newModel(t *testing.T) core.ModelOperation {
 
-	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", time.Minute)
+	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", "1500", time.Minute)
 	require.NoError(t, err)
 	return model.New(db, &mockDependences{})
 }
 
 func newAssociation(t *testing.T) core.AssociationOperation {
 
-	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", time.Minute)
+	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", "1500", time.Minute)
 	require.NoError(t, err)
 	return association.New(db, &mockDependences{})
 }
 
 func newInstances(t *testing.T) core.InstanceOperation {
 
-	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", time.Minute)
+	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", "1500", time.Minute)
 	require.NoError(t, err)
 	return instances.New(db, &instDependences{})
 }

--- a/src/source_controller/coreservice/core/instances/mock_test.go
+++ b/src/source_controller/coreservice/core/instances/mock_test.go
@@ -53,7 +53,7 @@ func (s *mockDependences) SearchUnique(ctx core.ContextParams, objID string) (un
 
 func newInstances(t *testing.T) core.InstanceOperation {
 
-	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", time.Minute)
+	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", "1500", time.Minute)
 	require.NoError(t, err)
 	return instances.New(db, &mockDependences{})
 }

--- a/src/source_controller/coreservice/core/model/mock_test.go
+++ b/src/source_controller/coreservice/core/model/mock_test.go
@@ -52,7 +52,7 @@ func (s *mockDependences) CascadeDeleteInstances(ctx core.ContextParams, objIDS 
 
 func newModel(t *testing.T) core.ModelOperation {
 
-	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", time.Minute)
+	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", "1500", time.Minute)
 	require.NoError(t, err)
 	return model.New(db, &mockDependences{})
 }

--- a/src/source_controller/coreservice/service/service.go
+++ b/src/source_controller/coreservice/service/service.go
@@ -91,7 +91,7 @@ func (s *coreService) SetConfig(cfg options.Config, engin *backbone.Engine, err 
 	var dbErr error
 	var db dal.RDB
 	if s.cfg.Mongo.Enable == "true" {
-		db, dbErr = local.NewMgo(s.cfg.Mongo.BuildURI(), time.Minute)
+		db, dbErr = local.NewMgo(s.cfg.Mongo.BuildURI(), s.cfg.Mongo.MaxOpenConns, time.Minute)
 	} else {
 		db, dbErr = remote.NewWithDiscover(s.engin)
 	}

--- a/src/storage/dal/mongo/config.go
+++ b/src/storage/dal/mongo/config.go
@@ -93,7 +93,7 @@ func ParseConfigFromKV(prefix string, conifgmap map[string]string) Config {
 
 func (c Config) GetMongoClient(engine *backbone.Engine) (db dal.RDB, err error) {
 	if c.Enable == "true" {
-		db, err = local.NewMgo(c.BuildURI(), time.Minute)
+		db, err = local.NewMgo(c.BuildURI(), c.MaxOpenConns, time.Minute)
 	} else {
 		db, err = remote.NewWithDiscover(engine)
 	}
@@ -105,7 +105,7 @@ func (c Config) GetMongoClient(engine *backbone.Engine) (db dal.RDB, err error) 
 
 func (c Config) GetTransactionClient(engine *backbone.Engine) (client dal.Transcation, err error) {
 	if c.Enable == "true" {
-		client, err = local.NewMgo(c.BuildURI(), time.Minute)
+		client, err = local.NewMgo(c.BuildURI(), c.MaxOpenConns, time.Minute)
 	} else {
 		client, err = remote.NewWithDiscover(engine)
 	}

--- a/src/storage/dal/mongo/local/mongo_test.go
+++ b/src/storage/dal/mongo/local/mongo_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func BenchmarkLocalCUD(b *testing.B) {
-	db, err := NewMgo("192.168.100.130:27010", time.Second*5)
+	db, err := NewMgo("192.168.100.130:27010", "1500", time.Second*5)
 	require.NoError(b, err)
 
 	header := http.Header{}

--- a/src/test/test.go
+++ b/src/test/test.go
@@ -81,7 +81,7 @@ func GetHeader() http.Header {
 
 func ClearDatabase() {
 	// clientSet.AdminServer().ClearDatabase(context.Background(), GetHeader())
-	db, err := local.NewMgo(tConfig.MongoURI, time.Minute)
+	db, err := local.NewMgo(tConfig.MongoURI, "1500", time.Minute)
 	Expect(err).Should(BeNil())
 	for _, tableName := range common.AllTables {
 		db.DropTable(tableName)

--- a/src/tools/cmdb_ctl/app/config/config.go
+++ b/src/tools/cmdb_ctl/app/config/config.go
@@ -61,7 +61,7 @@ func NewMongoService(mongoURI string) (*Service, error) {
 	if mongoURI == "" {
 		return nil, errors.New("mongo-uri must set via flag or environment variable")
 	}
-	db, err := local.NewMgo(mongoURI, time.Minute)
+	db, err := local.NewMgo(mongoURI, "1500", time.Minute)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### 优化的功能:
- 将原来连接数写死的代码，改为读取配置的连接数，并设置默认为1500，最大为3000连接

close #4711