### PR TITLE
修复用户传多次相同节点时执行多次反向排序导致查询的拓扑路径顺序错误的问题

### DIFF
--- a/src/source_controller/coreservice/cache/topo_tree/path.go
+++ b/src/source_controller/coreservice/cache/topo_tree/path.go
@@ -113,6 +113,13 @@ func (t *TopologyTree) SearchNodePath(ctx context.Context, opt *SearchNodePathOp
 		}
 	}
 
+	for obj, paths := range all {
+		for id, nodes := range paths {
+			paths[id] = reverseNode(nodes)
+		}
+		all[obj] = paths
+	}
+
 	nodePath := make([]NodePaths, 0)
 	for _, node := range opt.Nodes {
 		// 过滤掉不存在的实例
@@ -122,7 +129,7 @@ func (t *TopologyTree) SearchNodePath(ctx context.Context, opt *SearchNodePathOp
 		nodePath = append(nodePath, NodePaths{
 			MainlineNode: node,
 			InstanceName: objNameMap[node.Object][node.InstanceID],
-			Paths:        [][]Node{reverseNode(all[node.Object][node.InstanceID])},
+			Paths:        [][]Node{all[node.Object][node.InstanceID]},
 		})
 	}
 


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
