### PR TITLE
v3.5.x中添加mongo中的超时时间的配置

### DIFF
--- a/scripts/init.py
+++ b/scripts/init.py
@@ -72,6 +72,8 @@ maxOpenConns = 3000
 maxIdleConns = 1000
 mechanism = SCRAM-SHA-1
 enable = true
+#mongo连接的超时时间，以秒为单位，默认10s，最小5s，最大30s。
+timeout = 10
 
 [snap-redis]
 host = $redis_host
@@ -119,6 +121,8 @@ port = $mongo_port
 maxOpenConns = 3000
 maxIDleConns = 1000
 mechanism = SCRAM-SHA-1
+#mongo连接的超时时间，以秒为单位，默认10s，最小5s，最大30s。
+timeout = 10
 
 [redis]
 host = $redis_host
@@ -184,6 +188,8 @@ maxOpenConns = 3000
 maxIDleConns = 1000
 mechanism = SCRAM-SHA-1
 enable=true
+#mongo连接的超时时间，以秒为单位，默认10s，最小5s，最大30s。
+timeout = 10
 
 [confs]
 dir = $configures_dir
@@ -218,6 +224,9 @@ maxOpenConns = 3000
 maxIDleConns = 1000
 mechanism = SCRAM-SHA-1
 enable = true
+#mongo连接的超时时间，以秒为单位，默认10s，最小5s，最大30s。
+timeout = 10
+
 
 [redis]
 host = $redis_host
@@ -251,6 +260,8 @@ port = $mongo_port
 maxOpenConns = 3000
 maxIDleConns = 1000
 enable = true
+#mongo连接的超时时间，以秒为单位，默认10s，最小5s，最大30s。
+timeout = 10
 '''
     template = FileTemplate(proc_file_template_str)
     result = template.substitute(**context)
@@ -268,6 +279,8 @@ port = $mongo_port
 maxOpenConns = 3000
 maxIDleConns = 1000
 enable = true
+#mongo连接的超时时间，以秒为单位，默认10s，最小5s，最大30s。
+timeout = 10
 '''
     template = FileTemplate(operation_file_template_str)
     result = template.substitute(**context)
@@ -284,6 +297,8 @@ database = $db
 port = $mongo_port
 maxOpenConns = 3000
 maxIDleConns = 1000
+#mongo连接的超时时间，以秒为单位，默认10s，最小5s，最大30s。
+timeout = 10
 
 [transaction]
 enable = false
@@ -307,6 +322,8 @@ maxOpenConns = 3000
 maxIDleConns = 1000
 mechanism = SCRAM-SHA-1
 enable = true
+#mongo连接的超时时间，以秒为单位，默认10s，最小5s，最大30s。
+timeout = 10
 
 [level]
 businessTopoMax = 7

--- a/src/scene_server/admin_server/app/server.go
+++ b/src/scene_server/admin_server/app/server.go
@@ -87,7 +87,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 		}
 		var db dal.RDB
 		if process.Config.MongoDB.Enable == "true" {
-			db, err = local.NewMgo(process.Config.MongoDB.BuildURI(), process.Config.MongoDB.MaxOpenConns, time.Minute)
+			db, err = local.NewMgo(process.Config.MongoDB.BuildURI(), process.Config.MongoDB.MaxOpenConns, process.Config.MongoDB.Timeout)
 		} else {
 			db, err = remote.NewWithDiscover(process.Core)
 		}

--- a/src/scene_server/admin_server/command/command.go
+++ b/src/scene_server/admin_server/command/command.go
@@ -73,7 +73,7 @@ func Parse(args []string) error {
 	mongoConfig := mongo.ParseConfigFromKV("mongodb", config.ConfigMap)
 
 	// connect to mongo db
-	db, err := local.NewMgo(mongoConfig.BuildURI(), mongoConfig.MaxOpenConns, 0)
+	db, err := local.NewMgo(mongoConfig.BuildURI(), mongoConfig.MaxOpenConns, mongoConfig.Timeout)
 	if err != nil {
 		return fmt.Errorf("connect mongo server failed %s", err.Error())
 	}

--- a/src/scene_server/datacollection/app/server.go
+++ b/src/scene_server/datacollection/app/server.go
@@ -76,7 +76,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 
 		var mgoCli dal.RDB
 		if process.Config.MongoDB.Enable == "true" {
-			mgoCli, err = local.NewMgo(process.Config.MongoDB.BuildURI(), process.Config.MongoDB.MaxOpenConns, time.Minute)
+			mgoCli, err = local.NewMgo(process.Config.MongoDB.BuildURI(), process.Config.MongoDB.MaxOpenConns, process.Config.MongoDB.Timeout)
 		} else {
 			mgoCli, err = remote.NewWithDiscover(process.Core)
 		}

--- a/src/scene_server/event_server/app/server.go
+++ b/src/scene_server/event_server/app/server.go
@@ -72,7 +72,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 		var db dal.RDB
 		var rpcCli rpc.Client
 		if process.Config.MongoDB.Enable == "true" {
-			db, err = local.NewMgo(process.Config.MongoDB.BuildURI(), process.Config.MongoDB.MaxOpenConns, time.Minute)
+			db, err = local.NewMgo(process.Config.MongoDB.BuildURI(), process.Config.MongoDB.MaxOpenConns, process.Config.MongoDB.Timeout)
 		} else {
 			rpcCli, err = rpc.NewClientPool("tcp", engine.ServiceManageInterface.TMServer().GetServers, "/txn/v3/rpc")
 			if err != nil {

--- a/src/scene_server/topo_server/app/server.go
+++ b/src/scene_server/topo_server/app/server.go
@@ -102,7 +102,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 
 	var txn dal.Transcation
 	if server.Config.Mongo.Enable == "true" {
-		txn, err = local.NewMgo(server.Config.Mongo.BuildURI(), server.Config.Mongo.MaxOpenConns, time.Second*5)
+		txn, err = local.NewMgo(server.Config.Mongo.BuildURI(), server.Config.Mongo.MaxOpenConns, server.Config.Mongo.Timeout)
 	} else {
 		txn, err = remote.NewWithDiscover(engine)
 	}

--- a/src/source_controller/coreservice/core/association/mock_test.go
+++ b/src/source_controller/coreservice/core/association/mock_test.go
@@ -15,7 +15,6 @@ package association_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"configcenter/src/common/errors"
 	"configcenter/src/common/language"
@@ -81,21 +80,21 @@ func (m *mockDependences) IsInstanceExist(ctx core.ContextParams, objID string, 
 
 func newModel(t *testing.T) core.ModelOperation {
 
-	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", "1500", time.Minute)
+	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", "1500", "60")
 	require.NoError(t, err)
 	return model.New(db, &mockDependences{})
 }
 
 func newAssociation(t *testing.T) core.AssociationOperation {
 
-	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", "1500", time.Minute)
+	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", "1500", "60")
 	require.NoError(t, err)
 	return association.New(db, &mockDependences{})
 }
 
 func newInstances(t *testing.T) core.InstanceOperation {
 
-	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", "1500", time.Minute)
+	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", "1500", "60")
 	require.NoError(t, err)
 	return instances.New(db, &instDependences{})
 }

--- a/src/source_controller/coreservice/core/instances/mock_test.go
+++ b/src/source_controller/coreservice/core/instances/mock_test.go
@@ -15,7 +15,6 @@ package instances_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"configcenter/src/common/errors"
 	"configcenter/src/common/language"
@@ -53,7 +52,7 @@ func (s *mockDependences) SearchUnique(ctx core.ContextParams, objID string) (un
 
 func newInstances(t *testing.T) core.InstanceOperation {
 
-	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", "1500", time.Minute)
+	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", "1500", "60")
 	require.NoError(t, err)
 	return instances.New(db, &mockDependences{})
 }

--- a/src/source_controller/coreservice/core/model/mock_test.go
+++ b/src/source_controller/coreservice/core/model/mock_test.go
@@ -15,7 +15,6 @@ package model_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"configcenter/src/common/errors"
 	"configcenter/src/common/language"
@@ -52,7 +51,7 @@ func (s *mockDependences) CascadeDeleteInstances(ctx core.ContextParams, objIDS 
 
 func newModel(t *testing.T) core.ModelOperation {
 
-	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", "1500", time.Minute)
+	db, err := local.NewMgo("mongodb://cc:cc@localhost:27010,localhost:27011,localhost:27012,localhost:27013/cmdb", "1500", "60")
 	require.NoError(t, err)
 	return model.New(db, &mockDependences{})
 }

--- a/src/source_controller/coreservice/service/service.go
+++ b/src/source_controller/coreservice/service/service.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"time"
 
 	"configcenter/src/common"
 	"configcenter/src/common/backbone"
@@ -91,7 +90,7 @@ func (s *coreService) SetConfig(cfg options.Config, engin *backbone.Engine, err 
 	var dbErr error
 	var db dal.RDB
 	if s.cfg.Mongo.Enable == "true" {
-		db, dbErr = local.NewMgo(s.cfg.Mongo.BuildURI(), s.cfg.Mongo.MaxOpenConns, time.Minute)
+		db, dbErr = local.NewMgo(s.cfg.Mongo.BuildURI(), s.cfg.Mongo.MaxOpenConns, s.cfg.Mongo.Timeout)
 	} else {
 		db, dbErr = remote.NewWithDiscover(s.engin)
 	}

--- a/src/storage/dal/mongo/config.go
+++ b/src/storage/dal/mongo/config.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"configcenter/src/common/backbone"
 	"configcenter/src/storage/dal"
@@ -36,6 +35,7 @@ type Config struct {
 	MaxOpenConns string
 	MaxIdleConns string
 	Enable       string
+	Timeout		 string
 }
 
 // BuildURI return mongo uri according to  https://docs.mongodb.com/manual/reference/connection-string/
@@ -88,12 +88,13 @@ func ParseConfigFromKV(prefix string, conifgmap map[string]string) Config {
 		MaxIdleConns: conifgmap[prefix+".maxIDleConns"],
 		Mechanism:    conifgmap[prefix+".mechanism"],
 		Enable:       conifgmap[prefix+".enable"],
+		Timeout:      conifgmap[prefix+".timeout"],
 	}
 }
 
 func (c Config) GetMongoClient(engine *backbone.Engine) (db dal.RDB, err error) {
 	if c.Enable == "true" {
-		db, err = local.NewMgo(c.BuildURI(), c.MaxOpenConns, time.Minute)
+		db, err = local.NewMgo(c.BuildURI(), c.MaxOpenConns, c.Timeout)
 	} else {
 		db, err = remote.NewWithDiscover(engine)
 	}
@@ -105,7 +106,7 @@ func (c Config) GetMongoClient(engine *backbone.Engine) (db dal.RDB, err error) 
 
 func (c Config) GetTransactionClient(engine *backbone.Engine) (client dal.Transcation, err error) {
 	if c.Enable == "true" {
-		client, err = local.NewMgo(c.BuildURI(), c.MaxOpenConns, time.Minute)
+		client, err = local.NewMgo(c.BuildURI(), c.MaxOpenConns, c.Timeout)
 	} else {
 		client, err = remote.NewWithDiscover(engine)
 	}

--- a/src/storage/dal/mongo/local/mongo_test.go
+++ b/src/storage/dal/mongo/local/mongo_test.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
 	"configcenter/src/common"
 	"configcenter/src/storage/dal"
@@ -25,7 +24,7 @@ import (
 )
 
 func BenchmarkLocalCUD(b *testing.B) {
-	db, err := NewMgo("192.168.100.130:27010", "1500", time.Second*5)
+	db, err := NewMgo("192.168.100.130:27010", "1500", "5")
 	require.NoError(b, err)
 
 	header := http.Header{}

--- a/src/test/test.go
+++ b/src/test/test.go
@@ -81,7 +81,7 @@ func GetHeader() http.Header {
 
 func ClearDatabase() {
 	// clientSet.AdminServer().ClearDatabase(context.Background(), GetHeader())
-	db, err := local.NewMgo(tConfig.MongoURI, "1500", time.Minute)
+	db, err := local.NewMgo(tConfig.MongoURI, "1500","60")
 	Expect(err).Should(BeNil())
 	for _, tableName := range common.AllTables {
 		db.DropTable(tableName)

--- a/src/tools/cmdb_ctl/app/config/config.go
+++ b/src/tools/cmdb_ctl/app/config/config.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"os"
 	"strings"
-	"time"
 
 	"configcenter/src/common/zkclient"
 	"configcenter/src/storage/dal"
@@ -61,7 +60,7 @@ func NewMongoService(mongoURI string) (*Service, error) {
 	if mongoURI == "" {
 		return nil, errors.New("mongo-uri must set via flag or environment variable")
 	}
-	db, err := local.NewMgo(mongoURI, "1500", time.Minute)
+	db, err := local.NewMgo(mongoURI, "1500", "60")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### 优化的功能:
-  在配置文件中支持超时时间的配置， 默认10s，最小5s，最大30s。
