### PR TITLE
ui: 限制操作审计最大查询数量为200

### DIFF
--- a/src/ui/src/utils/tools.js
+++ b/src/ui/src/utils/tools.js
@@ -345,8 +345,8 @@ export function transformHostSearchParams (params) {
 const defaultPaginationConfig = window.innerHeight > 750
     ? { limit: 20, 'limit-list': [20, 50, 100, 500] }
     : { limit: 10, 'limit-list': [10, 50, 100, 500] }
-export function getDefaultPaginationConfig () {
-    return { ...defaultPaginationConfig }
+export function getDefaultPaginationConfig (customConfig = {}) {
+    return { ...defaultPaginationConfig, ...customConfig }
 }
 
 export default {

--- a/src/ui/src/views/audit/index.vue
+++ b/src/ui/src/views/audit/index.vue
@@ -167,7 +167,7 @@
                     pagination: {
                         current: 1,
                         count: 0,
-                        ...this.$tools.getDefaultPaginationConfig()
+                        ...this.$tools.getDefaultPaginationConfig({ 'limit-list': [10, 50, 100, 200] })
                     },
                     defaultSort: '-op_time',
                     sort: '-op_time'


### PR DESCRIPTION

### 优化的功能:
- 限制操作审计最大查询数量为200

