### PR TITLE
fix: 修改原先的依照模型实例删除关联关系的接口，改为按照id批量删除关联关系

### DIFF
--- a/src/apimachinery/coreservice/association/api.go
+++ b/src/apimachinery/coreservice/association/api.go
@@ -313,9 +313,9 @@ func (asst *association) DeleteInstAssociation(ctx context.Context, h http.Heade
 	return
 }
 
-func (asst *association) DeleteInstAssociationRelated(ctx context.Context, h http.Header, input *metadata.DeleteOption) (resp *metadata.DeletedOptionResult, err error) {
+func (asst *association) DeleteInstAssociationBatch(ctx context.Context, h http.Header, input *metadata.DeleteOption) (resp *metadata.DeletedOptionResult, err error) {
 	resp = new(metadata.DeletedOptionResult)
-	subPath := "/delete/instanceassociation/related"
+	subPath := "/delete/instanceassociation/batch"
 
 	err = asst.client.Delete().
 		WithContext(ctx).

--- a/src/apimachinery/coreservice/association/association.go
+++ b/src/apimachinery/coreservice/association/association.go
@@ -43,7 +43,7 @@ type AssociationClientInterface interface {
 	ReadInstAssociation(ctx context.Context, h http.Header, input *metadata.QueryCondition) (resp *metadata.ReadInstAssociationResult, err error)
 	ReadInstAssociationRelated(ctx context.Context, h http.Header, input *metadata.QueryCondition) (resp *metadata.ReadInstAssociationResult, err error)
 	DeleteInstAssociation(ctx context.Context, h http.Header, input *metadata.DeleteOption) (resp *metadata.DeletedOptionResult, err error)
-	DeleteInstAssociationRelated(ctx context.Context, h http.Header, input *metadata.DeleteOption) (resp *metadata.DeletedOptionResult, err error)
+	DeleteInstAssociationBatch(ctx context.Context, h http.Header, input *metadata.DeleteOption) (resp *metadata.DeletedOptionResult, err error)
 }
 
 func NewAssociationClientInterface(client rest.ClientInterface) AssociationClientInterface {

--- a/src/auth/parser/topology.go
+++ b/src/auth/parser/topology.go
@@ -605,10 +605,10 @@ func (ps *parseStream) objectAssociation() *parseStream {
 }
 
 const (
-	findObjectInstanceAssociationPattern          = "/api/v3/inst/association/action/search"
-	findObjectInstanceAssociationRelatedPattern   = "/api/v3/inst/association/related/action/search"
-	createObjectInstanceAssociationPattern        = "/api/v3/inst/association/action/create"
-	deleteObjectInstanceAssociationRelatedPattern = "/api/v3/inst/association/related/action/delete"
+	findObjectInstanceAssociationPattern        = "/api/v3/inst/association/action/search"
+	findObjectInstanceAssociationRelatedPattern = "/api/v3/inst/association/related/action/search"
+	createObjectInstanceAssociationPattern      = "/api/v3/inst/association/action/create"
+	deleteObjectInstanceAssociationBatchPattern = "/api/v3/inst/association/batch/action/delete"
 )
 
 var (
@@ -660,8 +660,8 @@ func (ps *parseStream) objectInstanceAssociation() *parseStream {
 		return ps
 	}
 
-	// delete object's instance associations operation.
-	if ps.RequestCtx.URI == deleteObjectInstanceAssociationRelatedPattern && ps.RequestCtx.Method == http.MethodDelete {
+	// delete object's instance associations.
+	if ps.RequestCtx.URI == deleteObjectInstanceAssociationBatchPattern && ps.RequestCtx.Method == http.MethodDelete {
 		ps.Attribute.Resources = []meta.ResourceAttribute{
 			{
 				Basic: meta.Basic{

--- a/src/common/metadata/association.go
+++ b/src/common/metadata/association.go
@@ -148,8 +148,8 @@ type DeleteAssociationInstRequest struct {
 	Condition mapstr.MapStr `json:"condition"`
 }
 
-type DeleteAssociationRelatedInstRequest struct {
-	AssociationRelatedInstRequestCond `json:",inline"`
+type DeleteAssociationInstBatchRequest struct {
+	ID []int64 `json:"id"`
 }
 
 type DeleteAssociationInstResult struct {
@@ -157,7 +157,7 @@ type DeleteAssociationInstResult struct {
 	Data     string `json:"data"`
 }
 
-type DeleteAssociationRelatedInstResult struct {
+type DeleteAssociationInstBatchResult struct {
 	BaseResp `json:",inline"`
 }
 

--- a/src/scene_server/topo_server/core/operation/association.go
+++ b/src/scene_server/topo_server/core/operation/association.go
@@ -99,7 +99,7 @@ type AssociationOperationInterface interface {
 	SearchInstAssociationRelated(params types.ContextParams, request *metadata.SearchAssociationRelatedInstRequest) (resp *metadata.ReadInstAssociationResult, err error)
 	CreateInst(params types.ContextParams, request *metadata.CreateAssociationInstRequest) (resp *metadata.CreateAssociationInstResult, err error)
 	DeleteInst(params types.ContextParams, assoID int64) (resp *metadata.DeleteAssociationInstResult, err error)
-	DeleteInstAssociationRelated(params types.ContextParams, request *metadata.DeleteAssociationRelatedInstRequest) (resp *metadata.DeleteAssociationRelatedInstResult, err error)
+	DeleteInstAssociationBatch(params types.ContextParams, request *metadata.DeleteAssociationInstBatchRequest) (resp *metadata.DeleteAssociationInstBatchResult, err error)
 
 	ImportInstAssociation(ctx context.Context, params types.ContextParams, objID string, importData map[int]metadata.ExcelAssocation) (resp metadata.ResponeImportAssociationData, err error)
 
@@ -1018,25 +1018,24 @@ func (assoc *association) DeleteInst(params types.ContextParams, assoID int64) (
 	return resp, err
 }
 
-//Delete all associations of certain model instance,by regarding the instance as both Association source and Association target.
-func (assoc *association) DeleteInstAssociationRelated(params types.ContextParams, request *metadata.DeleteAssociationRelatedInstRequest) (resp *metadata.DeleteAssociationRelatedInstResult, err error) {
+//Delete instance association batch
+func (assoc *association) DeleteInstAssociationBatch(params types.ContextParams, request *metadata.DeleteAssociationInstBatchRequest) (resp *metadata.DeleteAssociationInstBatchResult, err error) {
 
 	cond := mapstr.MapStr{
-		common.BKObjIDField:  request.ObjectID,
-		common.BKInstIDField: request.InstID,
+		common.BKFieldID: request.ID,
 	}
-	rsp, err := assoc.clientSet.CoreService().Association().DeleteInstAssociationRelated(context.Background(), params.Header, &metadata.DeleteOption{Condition: cond})
+	rsp, err := assoc.clientSet.CoreService().Association().DeleteInstAssociationBatch(context.Background(), params.Header, &metadata.DeleteOption{Condition: cond})
 	if nil != err {
-		blog.Errorf("delete instance related association failed, err: %s, rid: %s", err.Error(), params.ReqID)
+		blog.Errorf("delete instance association batch failed, err: %s, rid: %s", err.Error(), params.ReqID)
 		return nil, params.Err.New(common.CCErrCommHTTPDoRequestFailed, err.Error())
 	}
 
 	if !rsp.Result {
-		blog.Errorf("delete instance related association failed, err: %s, rid: %s", rsp.ErrMsg, params.ReqID)
+		blog.Errorf("delete instance association batch failed, err: %s, rid: %s", rsp.ErrMsg, params.ReqID)
 		return nil, params.Err.New(rsp.Code, rsp.ErrMsg)
 	}
 
-	resp = &metadata.DeleteAssociationRelatedInstResult{
+	resp = &metadata.DeleteAssociationInstBatchResult{
 		BaseResp: rsp.BaseResp,
 	}
 

--- a/src/scene_server/topo_server/service/association.go
+++ b/src/scene_server/topo_server/service/association.go
@@ -397,17 +397,20 @@ func (s *Service) DeleteAssociationInst(params types.ContextParams, pathParams, 
 	}
 }
 
-//Delete all associations of certain model instance,by regarding the instance as both Association source and Association target.
-func (s *Service) DeleteAssociationRelatedInst(params types.ContextParams, pathParams, queryParams ParamsGetter, data mapstr.MapStr) (interface{}, error) {
-	request := &metadata.DeleteAssociationRelatedInstRequest{}
+//Delete association batch by ID.
+func (s *Service) DeleteAssociationInstBatch(params types.ContextParams, pathParams, queryParams ParamsGetter, data mapstr.MapStr) (interface{}, error) {
+	request := &metadata.DeleteAssociationInstBatchRequest{}
 	if err := data.MarshalJSONInto(request); err != nil {
 		return nil, params.Err.New(common.CCErrCommParamsInvalid, err.Error())
 	}
-	if request.InstID == 0 || request.ObjectID == "" {
+	if len(request.ID) == 0 {
 		return nil, params.Err.Error(common.CCErrCommHTTPInputInvalid)
 	}
-
-	_, err := s.Core.AssociationOperation().DeleteInstAssociationRelated(params, &metadata.DeleteAssociationRelatedInstRequest{AssociationRelatedInstRequestCond: request.AssociationRelatedInstRequestCond})
+	//check Maximum limit
+	if len(request.ID) > 500 {
+		return nil, params.Err.New(common.CCErrCommParamsInvalid, "The number of ID should be less than 500")
+	}
+	_, err := s.Core.AssociationOperation().DeleteInstAssociationBatch(params, &metadata.DeleteAssociationInstBatchRequest{ID: request.ID})
 	if err != nil {
 		return nil, err
 	}

--- a/src/scene_server/topo_server/service/service_business_initfunc.go
+++ b/src/scene_server/topo_server/service/service_business_initfunc.go
@@ -91,7 +91,7 @@ func (s *Service) initBusinessAssociation() {
 	s.addAction(http.MethodPost, "/find/instassociation/related", s.SearchAssociationRelatedInst, nil)
 	s.addAction(http.MethodPost, "/create/instassociation", s.CreateAssociationInst, nil)
 	s.addAction(http.MethodDelete, "/delete/instassociation/{association_id}", s.DeleteAssociationInst, nil)
-	s.addAction(http.MethodDelete, "/delete/instassociation/related", s.DeleteAssociationRelatedInst, nil)
+	s.addAction(http.MethodDelete, "/delete/instassociation/batch", s.DeleteAssociationInstBatch, nil)
 
 	// topo search methods
 	s.addAction(http.MethodPost, "/find/instassociation/object/{bk_obj_id}", s.SearchInstByAssociation, nil)

--- a/src/scene_server/topo_server/service/service_initfunc.go
+++ b/src/scene_server/topo_server/service/service_initfunc.go
@@ -49,7 +49,7 @@ func (s *Service) initAssociation() {
 	s.addAction(http.MethodPost, "/inst/association/related/action/search", s.SearchAssociationRelatedInst, nil)
 	s.addAction(http.MethodPost, "/inst/association/action/create", s.CreateAssociationInst, nil)
 	s.addAction(http.MethodDelete, "/inst/association/{association_id}/action/delete", s.DeleteAssociationInst, nil)
-	s.addAction(http.MethodDelete, "/inst/association/related/action/delete", s.DeleteAssociationRelatedInst, nil)
+	s.addAction(http.MethodDelete, "/inst/association/batch/action/delete", s.DeleteAssociationInstBatch, nil)
 
 	// topo search methods
 	s.addAction(http.MethodPost, "/inst/association/search/owner/{owner_id}/object/{bk_obj_id}", s.SearchInstByAssociation, nil)

--- a/src/source_controller/coreservice/service/service_initfunc.go
+++ b/src/source_controller/coreservice/service/service_initfunc.go
@@ -103,7 +103,7 @@ func (s *coreService) initInstanceAssociation() {
 	s.addAction(http.MethodPost, "/read/instanceassociation", s.SearchInstanceAssociation, nil)
 	s.addAction(http.MethodPost, "/read/instanceassociation/related", s.SearchInstanceAssociationRelated, nil)
 	s.addAction(http.MethodDelete, "/delete/instanceassociation", s.DeleteInstanceAssociation, nil)
-	s.addAction(http.MethodDelete, "/delete/instanceassociation/related", s.DeleteInstanceAssociationRelated, nil)
+	s.addAction(http.MethodDelete, "/delete/instanceassociation/batch", s.DeleteInstanceAssociationBatch, nil)
 }
 
 func (s *coreService) initMainline() {


### PR DESCRIPTION
### 修复的问题：
- 现有通过某实例查询相关关联关系，并批量删除这些关联关系的接口；
此接口如果命中条目过多，会对cmdb造成很大压力；
现修正为依照id删除。

close #4743 
