### PR TITLE
datacollection添加时间窗口功能

### DIFF
--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -901,8 +901,6 @@ const (
 	EventCacheEventTxnCommitQueueKey = BKCacheKeyV3Prefix + "event:inst_txn_commit_queue"
 	EventCacheEventTxnAbortQueueKey  = BKCacheKeyV3Prefix + "event:inst_txn_abort_queue"
 	RedisSnapKeyPrefix               = BKCacheKeyV3Prefix + "snapshot:"
-	// this is the prefix of a key used to record the number of executions of the host snapshot
-	RedisSnapCountPrefix             = RedisSnapKeyPrefix + "count:"
 )
 
 // api cache keys

--- a/src/scene_server/datacollection/collections/hostsnap/hostsnap.go
+++ b/src/scene_server/datacollection/collections/hostsnap/hostsnap.go
@@ -43,7 +43,7 @@ const (
 	// defaultChangeRangePercent is the value of the default percentage of data fluctuation
 	defaultChangeRangePercent 	    = 10
 	// minChangeRangePercent is the value of the minimum percentage of data fluctuation
-	minChangeRangePercent            = 5
+	minChangeRangePercent            = 1
 	// defaultRateLimiterQPS is the default value of rateLimiter qps
 	defaultRateLimiterQPS   = 40
 	// defaultRateLimiterBurst is the default value of rateLimiter burst

--- a/src/scene_server/datacollection/collections/hostsnap/hostsnap.go
+++ b/src/scene_server/datacollection/collections/hostsnap/hostsnap.go
@@ -44,10 +44,6 @@ const (
 	defaultChangeRangePercent 	    = 10
 	// minChangeRangePercent is the value of the minimum percentage of data fluctuation
 	minChangeRangePercent            = 5
-	// deafultChangeCountExpireMinute is the default value of update time
-	deafultChangeCountExpireMinute        = 10
-	// minChangeCountExpireMinute is the minimum value of update time
-	minChangeCountExpireMinute            = 5
 	// defaultRateLimiterQPS is the default value of rateLimiter qps
 	defaultRateLimiterQPS   = 40
 	// defaultRateLimiterBurst is the default value of rateLimiter burst
@@ -73,6 +69,7 @@ type HostSnap struct {
 	filter *filter
 	ctx    context.Context
 	db     dal.RDB
+	window *Window
 }
 
 func NewHostSnap(ctx context.Context, redisCli *redis.Client, db dal.RDB, engine *backbone.Engine, authManager *extensions.AuthManager) *HostSnap {
@@ -85,6 +82,7 @@ func NewHostSnap(ctx context.Context, redisCli *redis.Client, db dal.RDB, engine
 		authManager: authManager,
 		Engine:      engine,
 		filter:      newFilter(),
+		window:      newWindow(),
 	}
 	return h
 }
@@ -186,6 +184,12 @@ func (h *HostSnap) Analyze(msg *string) error {
 	// save host snapshot in redis
 	h.saveHostsnap(header, &val, hostID)
 
+	// window restriction on request
+	if !h.window.canPassWindow() {
+		blog.Warnf("not within the time window that can pass, skip host snapshot data update due to request limit, host id: %d, ip: %s, cloud id: %d, rid: %s",
+			hostID, innerIP, cloudID, rid)
+		return nil
+	}
 	setter, raw := parseSetter(&val, innerIP, outerIP)
 	// no need to update
 	if !needToUpdate(raw, host) {
@@ -196,11 +200,6 @@ func (h *HostSnap) Analyze(msg *string) error {
 	if !h.rateLimit.TryAccept() {
 		blog.Warnf("skip host snapshot data update due to request limit, host id: %d, ip: %s, cloud id: %d, rid: %s",
 			hostID, innerIP, cloudID, rid)
-		return nil
-	}
-
-	key := common.RedisSnapCountPrefix + strconv.FormatInt(hostID, 10)
-	if h.needToSkip(key, rid) {
 		return nil
 	}
 
@@ -260,29 +259,6 @@ func (h *HostSnap) Analyze(msg *string) error {
 		hostID, innerIP, cloudID, rid)
 
 	return nil
-}
-
-func (h *HostSnap) needToSkip(key string, rid string) bool {
-	value, err := h.redisCli.Incr(key).Result()
-	if err != nil {
-		blog.Errorf("an error occurred while increasing the redis value, key: %s, rid: %s", key, rid)
-	}
-	// if it is greater than 1, it means that the data has been updated within the specified time and does not need to be updated this time
-	if value > 1 {
-		return true
-	}
-
-	// get time on redis ttl
-	changeCountExpireMinute := getLimitConfig("datacollection.hostsnap.changeCountExpireMinute", deafultChangeCountExpireMinute, minChangeCountExpireMinute)
-	minTime := 0.5 * float64(changeCountExpireMinute)
-	maxTime := 1.5 * float64(changeCountExpireMinute)
-	randTime := util.RandInt64WithRange(int64(minTime), int64(maxTime))
-	// expire redis key
-	if err := h.redisCli.Expire(key, time.Minute*time.Duration(randTime)).Err(); err != nil {
-		blog.Errorf("an error occurred while expire the redis key, key: %s, rid: %s", key, rid)
-	}
-
-	return false
 }
 
 func needToUpdate(src, toCompare string) bool {

--- a/src/scene_server/datacollection/collections/hostsnap/hostsnap.go
+++ b/src/scene_server/datacollection/collections/hostsnap/hostsnap.go
@@ -186,7 +186,7 @@ func (h *HostSnap) Analyze(msg *string) error {
 
 	// window restriction on request
 	if !h.window.canPassWindow() {
-		blog.Warnf("not within the time window that can pass, skip host snapshot data update due to request limit, host id: %d, ip: %s, cloud id: %d, rid: %s",
+		blog.V(4).Info("not within the time window that can pass, skip host snapshot data update due to request limit, host id: %d, ip: %s, cloud id: %d, rid: %s",
 			hostID, innerIP, cloudID, rid)
 		return nil
 	}

--- a/src/scene_server/datacollection/collections/hostsnap/window.go
+++ b/src/scene_server/datacollection/collections/hostsnap/window.go
@@ -10,6 +10,23 @@
  * limitations under the License.
  */
 
+/*
+ 主机快照属性，如cpu,bk_cpu_mhz,bk_disk,bk_mem等数据的处理时间窗口,用于限制在指定周期的前多少分钟可以让请求通过,超过限定时间将不会处理请求。
+ 有三个参数，atTime,checkIntervalHours,windowMinute
+
+ 当不配置windowMinute，窗口不生效。当配置了windowMinute,至少配置atTime或者checkIntervalHours中的一个,否则不生效。
+ 当atTime和checkIntervalHours都配置时，取atTime这个配置的语义功能
+
+ 如果窗口生效,启动的时候,会先跑完windowMinutes。然后再生效
+
+ atTime,设置一天中,几点开启时间窗口,如配置成14:40,表示14:40开启窗口,如果配置格式不正确,默认值为1:00
+
+ checkIntervalHours,规定每隔几个小时窗口开启,单位为小时,如配置成 3,表示每隔3个小时,开启时间窗口,如果配置格式不正确,默认值为 1。
+
+ windowMinutes,代表开启时间窗口后,多长时间内请求可以通过,单位为分钟。如配置成 60,表示开启窗口时间60分钟内请求可以通过。
+ 注意：该时间不能大于窗口每次开启的间隔时间，取值范围不能小于等于0，如果配置不正确，默认值为15
+ */
+
 package hostsnap
 
 import (
@@ -99,7 +116,7 @@ func (w *Window) doTimedTasks(intervalTimeIntVal int) {
 // canPassWindow used to judge whether the request can be passed
 func (w *Window) canPassWindow() bool {
 	// exist time window requires time judgment
-	if w.exist == true {
+	if w.exist {
 		now := time.Now()
 		stopTime := w.getStartTime().Add(time.Duration(w.windowMinutes) * time.Minute)
 		// not within the time window, unable to pass through the window

--- a/src/scene_server/datacollection/collections/hostsnap/window.go
+++ b/src/scene_server/datacollection/collections/hostsnap/window.go
@@ -1,0 +1,175 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hostsnap
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	cc "configcenter/src/common/backbone/configcenter"
+	"configcenter/src/common/blog"
+)
+
+const (
+	// oneDayToMinutes the value of one day converted into minutes. 24 * 60
+	oneDayToMinutes = 1440
+
+	// oneDayToHours the value of one day converted into hours.
+	oneDayToHours = 24
+)
+
+type Window struct {
+	// exist time window exists as true, does not exist as false
+	exist bool
+	// startTime the start time of each timed task
+	startTime time.Time
+	// durationInMinutes duration of each timed task
+	durationInMinutes  int
+	changeTimeLock sync.RWMutex
+}
+
+// doFixedTimeTasks do tasks based on a fixed hour each day
+func (w *Window) doFixedTimeTasks(hour int) {
+	now := time.Now()
+	targetTime := time.Date(now.Year(), now.Month(), now.Day(), hour, 0, 0, 0, now.Location())
+	if hour > now.Hour() {
+		beforeOneDay, _ := time.ParseDuration("-24h")
+		w.changeTimeLock.Lock()
+		w.startTime = targetTime.Add(beforeOneDay)
+		w.changeTimeLock.Unlock()
+
+		time.Sleep(targetTime.Sub(now))
+
+		w.changeTimeLock.Lock()
+		w.startTime = targetTime
+		w.changeTimeLock.Unlock()
+	} else {
+		w.changeTimeLock.Lock()
+		w.startTime = targetTime
+		w.changeTimeLock.Unlock()
+
+		afterOneDay, _ := time.ParseDuration("24h")
+		time.Sleep(targetTime.Add(afterOneDay).Sub(now))
+
+		w.changeTimeLock.Lock()
+		w.startTime = targetTime.Add(afterOneDay)
+		w.changeTimeLock.Unlock()
+	}
+
+	w.doTimedTasks(oneDayToHours)
+}
+
+// doTimedTasks do tasks according to a certain time interval
+func (w *Window) doTimedTasks(intervalTimeIntVal int) {
+	timer := time.NewTicker(time.Hour*time.Duration(intervalTimeIntVal))
+	for {
+		select {
+		case <-timer.C:
+			w.changeTimeLock.Lock()
+			w.startTime = time.Now()
+			w.changeTimeLock.Unlock()
+		}
+	}
+}
+
+// NewWindow create a time window
+func newWindow() *Window {
+	w := &Window{}
+	// if the parameters are configured, the time window is valid
+	if cc.IsExist("datacollection.hostsnap.timeWindow.hourRule") && cc.IsExist("datacollection.hostsnap.timeWindow.durationInMinutes") {
+
+		hourRule, _ := cc.String("datacollection.hostsnap.timeWindow.hourRule")
+		durationInMinutes, _ := cc.Int("datacollection.hostsnap.timeWindow.durationInMinutes")
+
+		w.durationInMinutes = durationInMinutes
+		w.exist = true
+
+		splitVal := strings.Split(hourRule, "/")
+
+		// means to be executed regularly at a fixed time every day
+		if len(splitVal) == 1 {
+			hour, err := strconv.Atoi(hourRule)
+			if err != nil {
+				blog.Errorf("parse hourRule config %s error: %s", hourRule, err.Error())
+				os.Exit(1)
+			}
+
+			if hour > 24 || hour < 0 {
+				blog.Errorf("the current time value is %d, the value range is 0-24, need to reset the value.", hour)
+				os.Exit(1)
+			}
+
+			checkDurationInMinutes(durationInMinutes, oneDayToMinutes)
+
+			go w.doFixedTimeTasks(hour)
+			return w
+		}
+
+		// means that the execution is an interval of cyclic tasks
+		if len(splitVal) == 2 {
+			intervalTimeIntVal, err := strconv.Atoi(splitVal[1])
+			if err != nil {
+				blog.Errorf("parse hourRule config %s error: %s", hourRule, err.Error())
+				os.Exit(1)
+			}
+
+			if intervalTimeIntVal <= 0 {
+				blog.Errorf("the current time value is %d, value needs to be greater than 0", intervalTimeIntVal)
+				os.Exit(1)
+			}
+
+			checkDurationInMinutes(durationInMinutes, intervalTimeIntVal*60)
+
+			w.startTime = time.Now()
+			go w.doTimedTasks(intervalTimeIntVal)
+
+			return w
+
+		}
+
+		// means that the rules are wrong and need to exit
+		blog.Errorf("the hourRule rule is wrong and needs to be checked.")
+		os.Exit(1)
+	}
+
+	return w
+}
+
+// judge whether the time of each cycle of the timed task is less than the time that the window can pass
+func checkDurationInMinutes(durationInMinutes, intervalTime int) {
+	if durationInMinutes > intervalTime {
+		blog.Errorf("the value of the task cycle %d min is less than the window time value %d min.", intervalTime, durationInMinutes)
+		os.Exit(1)
+	}
+}
+
+// canPassWindow used to judge whether the request can be passed
+func (w *Window) canPassWindow() bool {
+	w.changeTimeLock.RLock()
+	defer w.changeTimeLock.RUnlock()
+	// exist time window requires time judgment
+	if w.exist == true {
+		now := time.Now()
+		unit, _ := time.ParseDuration("1m")
+		stopTime := w.startTime.Add(time.Duration(w.durationInMinutes)*unit)
+		// not within the time window, unable to pass through the window
+		if now.Before(w.startTime) || now.After(stopTime) {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
### 新加的功能:
-   主机快照属性，如cpu,bk_cpu_mhz,bk_disk,bk_mem等数据的处理时间窗口，用于限制在指定周期的前多少分钟可以让请求通过，超过限定时间将不会处理请求。它的下一级有三个参数，atTime,checkIntervalHours，windowMinute

     当不配置windowMinute，窗口不生效。当配置了windowMinute,至少配置atTime或者checkIntervalHours中的一个，否则不生效。当atTime和checkIntervalHours都配置时，取atTime这个配置的语义功能

     如果窗口生效，启动的时候，会先跑完windowMinutes。然后再生效

    atTime，设置一天中，几点开启时间窗口，如配置成14:40，表示14:40开启窗口，如果配置格式不正确，默认值为1:00

    checkIntervalHours，规定每隔几个小时窗口开启，单位为小时，如配置成 3，表示每隔3个小时，开启时间窗口，如果配置格式不正确，默认值为 1

    windowMinutes，代表开启时间窗口后，多长时间内请求可以通过，单位为分钟。如配置成 60，表示开启窗口时间60分钟内请求可以通过。注意：该时间不能大于窗口每次开启的间隔时间，取值范围不能小于等于0，如果配置不正确，默认值为15
