### PR TITLE
coreservice增加获取mongo任意表字段dintinct值的通用接口

### DIFF
--- a/src/apimachinery/coreservice/common/api.go
+++ b/src/apimachinery/coreservice/common/api.go
@@ -1,0 +1,45 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	"configcenter/src/common/blog"
+	"configcenter/src/common/errors"
+	"configcenter/src/common/metadata"
+)
+
+func (p *common) GetDistinctField(ctx context.Context, h http.Header, option *metadata.DistinctFieldOption) ([]interface{}, errors.CCErrorCoder) {
+	ret := new(metadata.ArrayResponse)
+	subPath := "/findmany/common/distinct_field"
+
+	err := p.client.Post().
+		WithContext(ctx).
+		Body(option).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(ret)
+
+	if err != nil {
+		blog.Errorf("CreateServiceCategory failed, http request failed, err: %+v", err)
+		return nil, errors.CCHttpError
+	}
+	if ret.Result == false || ret.Code != 0 {
+		return nil, errors.New(ret.Code, ret.ErrMsg)
+	}
+
+	return ret.Data, nil
+}

--- a/src/apimachinery/coreservice/common/common.go
+++ b/src/apimachinery/coreservice/common/common.go
@@ -1,0 +1,34 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	"configcenter/src/common/metadata"
+	"configcenter/src/apimachinery/rest"
+	"configcenter/src/common/errors"
+)
+
+type CommonInterface interface {
+	GetDistinctField(ctx context.Context, h http.Header, option *metadata.DistinctFieldOption) ([]interface{}, errors.CCErrorCoder)
+}
+
+func NewCommonInterfaceClient(client rest.ClientInterface) CommonInterface {
+	return &common{client: client}
+}
+
+type common struct {
+	client rest.ClientInterface
+}

--- a/src/apimachinery/coreservice/coreservice.go
+++ b/src/apimachinery/coreservice/coreservice.go
@@ -19,8 +19,9 @@ import (
 	"configcenter/src/apimachinery/coreservice/auditlog"
 	"configcenter/src/apimachinery/coreservice/auth"
 	"configcenter/src/apimachinery/coreservice/cache"
-	"configcenter/src/apimachinery/coreservice/count"
 	"configcenter/src/apimachinery/coreservice/cloud"
+	"configcenter/src/apimachinery/coreservice/common"
+	"configcenter/src/apimachinery/coreservice/count"
 	"configcenter/src/apimachinery/coreservice/host"
 	"configcenter/src/apimachinery/coreservice/hostapplyrule"
 	"configcenter/src/apimachinery/coreservice/instance"
@@ -58,6 +59,7 @@ type CoreServiceClientInterface interface {
 	Cache() cache.Interface
 	Cloud() cloud.CloudInterface
 	Auth() auth.AuthClientInterface
+	Common() common.CommonInterface
 }
 
 func NewCoreServiceClient(c *util.Capability, version string) CoreServiceClientInterface {
@@ -146,4 +148,8 @@ func (c *coreService) Cloud() cloud.CloudInterface {
 
 func (c *coreService) Auth() auth.AuthClientInterface {
 	return auth.NewAuthClientInterface(c.restCli)
+}
+
+func (c *coreService) Common() common.CommonInterface {
+	return common.NewCommonInterfaceClient(c.restCli)
 }

--- a/src/common/metadata/common.go
+++ b/src/common/metadata/common.go
@@ -85,6 +85,11 @@ type CoreUint64Response struct {
 	Data     uint64 `json:"data"`
 }
 
+type ArrayResponse struct {
+	BaseResp `json:",inline"`
+	Data     []interface{} `json:"data"`
+}
+
 type MapArrayResponse struct {
 	BaseResp `json:",inline"`
 	Data     []mapstr.MapStr `json:"data"`

--- a/src/common/metadata/core_service.go
+++ b/src/common/metadata/core_service.go
@@ -17,6 +17,7 @@ import (
 
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
+	"configcenter/src/common/errors"
 	"configcenter/src/common/mapstr"
 	"configcenter/src/common/selector"
 	"configcenter/src/common/util"
@@ -587,4 +588,28 @@ type MultipleSyncHistoryResult struct {
 type MultipleSyncRegionResult struct {
 	BaseResp `json:",inline"`
 	Data     []*Region `json:"data"`
+}
+
+type DistinctFieldOption struct {
+	TableName string                 `json:"table_name"`
+	Field     string                 `json:"field"`
+	Filter    map[string]interface{} `json:"filter"`
+}
+
+func (d *DistinctFieldOption) Validate() (rawError errors.RawErrorInfo) {
+	if d.TableName == "" {
+		return errors.RawErrorInfo{
+			ErrCode: common.CCErrCommParamsInvalid,
+			Args:    []interface{}{"table_name"},
+		}
+	}
+
+	if d.Field == "" {
+		return errors.RawErrorInfo{
+			ErrCode: common.CCErrCommParamsInvalid,
+			Args:    []interface{}{"Field"},
+		}
+	}
+
+	return errors.RawErrorInfo{}
 }

--- a/src/source_controller/coreservice/core/common/common.go
+++ b/src/source_controller/coreservice/core/common/common.go
@@ -1,0 +1,44 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.,
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the ",License",); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an ",AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"configcenter/src/common"
+	"configcenter/src/common/blog"
+	"configcenter/src/common/errors"
+	"configcenter/src/common/http/rest"
+	"configcenter/src/common/metadata"
+	"configcenter/src/source_controller/coreservice/core"
+	"configcenter/src/storage/driver/mongodb"
+)
+
+var _ core.CommonOperation = (*commonOperation)(nil)
+
+type commonOperation struct {
+}
+
+// New create a new instance manager instance
+func New() core.CommonOperation {
+	return &commonOperation{}
+}
+
+func (c *commonOperation) GetDistinctField(kit *rest.Kit, option *metadata.DistinctFieldOption) ([]interface{}, errors.CCErrorCoder) {
+
+	ret, err := mongodb.Client().Table(option.TableName).Distinct(kit.Ctx, option.Field, option.Filter)
+	if err != nil {
+		blog.Errorf("get distinct field failed, err: %v, option:%#v, rid: %s", err, *option, kit.Rid)
+		return nil, kit.CCError.CCError(common.CCErrCommDBSelectFailed)
+	}
+
+	return ret, nil
+}

--- a/src/source_controller/coreservice/core/core.go
+++ b/src/source_controller/coreservice/core/core.go
@@ -204,6 +204,7 @@ type Core interface {
 	SystemOperation() SystemOperation
 	CloudOperation() CloudOperation
 	AuthOperation() AuthOperation
+	CommonOperation() CommonOperation
 }
 
 // ProcessOperation methods
@@ -311,6 +312,10 @@ type AuthOperation interface {
 	SearchAuthResource(kit *rest.Kit, param metadata.PullResourceParam) (int64, []map[string]interface{}, errors.CCErrorCoder)
 }
 
+type CommonOperation interface {
+	GetDistinctField(kit *rest.Kit, param *metadata.DistinctFieldOption) ([]interface{}, errors.CCErrorCoder)
+}
+
 type core struct {
 	model           ModelOperation
 	instance        InstanceOperation
@@ -327,6 +332,7 @@ type core struct {
 	hostApplyRule   HostApplyRuleOperation
 	cloud           CloudOperation
 	auth            AuthOperation
+	common          CommonOperation
 }
 
 // New create core
@@ -345,6 +351,7 @@ func New(
 	sys SystemOperation,
 	cloud CloudOperation,
 	auth AuthOperation,
+	common CommonOperation,
 ) Core {
 	return &core{
 		model:           model,
@@ -362,6 +369,7 @@ func New(
 		hostApplyRule:   hostApplyRule,
 		cloud:           cloud,
 		auth:            auth,
+		common:          common,
 	}
 }
 
@@ -423,4 +431,8 @@ func (m *core) CloudOperation() CloudOperation {
 
 func (m *core) AuthOperation() AuthOperation {
 	return m.auth
+}
+
+func (m *core) CommonOperation() CommonOperation {
+	return m.common
 }

--- a/src/source_controller/coreservice/service/common.go
+++ b/src/source_controller/coreservice/service/common.go
@@ -1,0 +1,41 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"configcenter/src/common/http/rest"
+	"configcenter/src/common/metadata"
+)
+
+func (s *coreService) GetDistinctField(ctx *rest.Contexts) {
+	option := new(metadata.DistinctFieldOption)
+	if err := ctx.DecodeInto(option); err != nil {
+		ctx.RespAutoError(err)
+		return
+	}
+
+	rawErr := option.Validate()
+	if rawErr.ErrCode != 0 {
+		ctx.RespAutoError(rawErr.ToCCError(ctx.Kit.CCError))
+		return
+	}
+
+	ret, err := s.core.CommonOperation().GetDistinctField(ctx.Kit, option)
+
+	if err != nil {
+		ctx.RespAutoError(err)
+		return
+	}
+
+	ctx.RespEntity(ret)
+}

--- a/src/source_controller/coreservice/service/service.go
+++ b/src/source_controller/coreservice/service/service.go
@@ -30,6 +30,7 @@ import (
 	"configcenter/src/source_controller/coreservice/core/auditlog"
 	"configcenter/src/source_controller/coreservice/core/auth"
 	"configcenter/src/source_controller/coreservice/core/cloud"
+	coreCommon "configcenter/src/source_controller/coreservice/core/common"
 	"configcenter/src/source_controller/coreservice/core/datasynchronize"
 	"configcenter/src/source_controller/coreservice/core/host"
 	"configcenter/src/source_controller/coreservice/core/hostapplyrule"
@@ -138,6 +139,7 @@ func (s *coreService) SetConfig(cfg options.Config, engine *backbone.Engine, err
 		dbSystem.New(),
 		cloud.New(mongodb.Client()),
 		auth.New(mongodb.Client()),
+		coreCommon.New(),
 	)
 
 	watcher, watchErr := stream.NewStream(s.cfg.Mongo.GetMongoConf())

--- a/src/source_controller/coreservice/service/service_initfunc.go
+++ b/src/source_controller/coreservice/service/service_initfunc.go
@@ -395,6 +395,17 @@ func (s *coreService) initAuth(web *restful.WebService) {
 	utility.AddToRestfulWebService(web)
 }
 
+func (s *coreService) initCommon(web *restful.WebService) {
+	utility := rest.NewRestUtility(rest.Config{
+		ErrorIf:  s.engine.CCErr,
+		Language: s.engine.Language,
+	})
+
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/findmany/common/distinct_field", Handler: s.GetDistinctField})
+
+	utility.AddToRestfulWebService(web)
+}
+
 func (s *coreService) initService(web *restful.WebService) {
 	s.initModelClassification(web)
 	s.initModel(web)
@@ -419,4 +430,5 @@ func (s *coreService) initService(web *restful.WebService) {
 	s.initCache(web)
 	s.initCloudSync(web)
 	s.initAuth(web)
+	s.initCommon(web)
 }


### PR DESCRIPTION
### 新加的功能:
- coreservice增加获取mongo任意表字段dintinct值的通用接口
### 优化的功能:
- 优化ListProcessInstancesNameIDsInModule接口

close issue #4746 