### PR TITLE
修复权限中心反向拉取时因为没有设置用户导致查询失败的问题

### DIFF
--- a/src/common/metadata/object.go
+++ b/src/common/metadata/object.go
@@ -141,7 +141,10 @@ func (o *Object) GetObjectID() string {
 
 // IsCommon is common object
 func (o *Object) IsCommon() bool {
-	switch o.ObjectID {
+	return IsCommon(o.ObjectID)
+}
+func IsCommon(objID string) bool {
+	switch objID {
 	case common.BKInnerObjIDApp:
 		return false
 	case common.BKInnerObjIDSet:

--- a/src/scene_server/auth_server/service/service.go
+++ b/src/scene_server/auth_server/service/service.go
@@ -94,6 +94,11 @@ func (s *AuthService) checkRequestFromIamFilter() func(req *restful.Request, res
 		// set supplierID
 		setSupplierID(req.Request)
 
+		user := req.Request.Header.Get(common.BKHTTPHeaderUser)
+		if len(user) == 0 {
+			req.Request.Header.Set(common.BKHTTPHeaderUser, "auth")
+		}
+
 		chain.ProcessFilter(req, resp)
 		return
 	}

--- a/src/scene_server/topo_server/service/inst.go
+++ b/src/scene_server/topo_server/service/inst.go
@@ -477,12 +477,6 @@ func (s *Service) SearchInstAndAssociationDetail(ctx *rest.Contexts) {
 		ctx.RespAutoError(err)
 		return
 	}
-	obj, err := s.Core.ObjectOperation().FindSingleObject(ctx.Kit, objID)
-	if nil != err {
-		blog.Errorf("[api-inst] failed to find the objects(%s), error info is %s, rid: %s", ctx.Request.PathParameter("bk_obj_id"), err.Error(), ctx.Kit.Rid)
-		ctx.RespAutoError(err)
-		return
-	}
 
 	// construct the query inst condition
 	queryCond := data.SearchParams
@@ -498,16 +492,12 @@ func (s *Service) SearchInstAndAssociationDetail(ctx *rest.Contexts) {
 	query.Sort = page.Sort
 	query.Start = page.Start
 
-	cnt, instItems, err := s.Core.InstOperation().FindInst(ctx.Kit, obj, query, true)
+	result, err := s.Core.InstOperation().FindOriginInst(ctx.Kit, objID, query)
 	if nil != err {
 		blog.Errorf("[api-inst] failed to find the objects(%s), error info is %s, rid: %s", ctx.Request.PathParameter("bk_obj_id"), err.Error(), ctx.Kit.Rid)
 		ctx.RespAutoError(err)
 		return
 	}
-
-	result := mapstr.MapStr{}
-	result.Set("count", cnt)
-	result.Set("info", instItems)
 	ctx.RespEntity(result)
 }
 
@@ -565,23 +555,14 @@ func (s *Service) SearchInstByAssociation(ctx *rest.Contexts) {
 	objID := ctx.Request.PathParameter("bk_obj_id")
 
 	ctx.SetReadPreference(common.SecondaryPreferredMode)
-	obj, err := s.Core.ObjectOperation().FindSingleObject(ctx.Kit, objID)
+
+	result, err := s.Core.InstOperation().FindInstByAssociationInst(ctx.Kit, objID, &data.AssociationParams)
 	if nil != err {
 		blog.Errorf("[api-inst] failed to find the objects(%s), error info is %s, rid: %s", ctx.Request.PathParameter("bk_obj_id"), err.Error(), ctx.Kit.Rid)
 		ctx.RespAutoError(err)
 		return
 	}
 
-	cnt, instItems, err := s.Core.InstOperation().FindInstByAssociationInst(ctx.Kit, obj, &data.AssociationParams)
-	if nil != err {
-		blog.Errorf("[api-inst] failed to find the objects(%s), error info is %s, rid: %s", ctx.Request.PathParameter("bk_obj_id"), err.Error(), ctx.Kit.Rid)
-		ctx.RespAutoError(err)
-		return
-	}
-
-	result := mapstr.MapStr{}
-	result.Set("count", cnt)
-	result.Set("info", instItems)
 	ctx.RespEntity(result)
 }
 

--- a/src/scene_server/topo_server/service/inst_business.go
+++ b/src/scene_server/topo_server/service/inst_business.go
@@ -586,19 +586,15 @@ func (s *Service) CreateDefaultBusiness(ctx *rest.Contexts) {
 }
 
 func (s *Service) GetInternalModule(ctx *rest.Contexts) {
-	obj, err := s.Core.ObjectOperation().FindSingleObject(ctx.Kit, common.BKInnerObjIDApp)
-	if nil != err {
-		blog.Errorf("failed to search the business, %s, rid: %s", err.Error(), ctx.Kit.Rid)
-		ctx.RespAutoError(err)
-		return
-	}
 	bizID, err := strconv.ParseInt(ctx.Request.PathParameter("app_id"), 10, 64)
 	if nil != err {
 		ctx.RespAutoError(ctx.Kit.CCError.New(common.CCErrTopoAppSearchFailed, err.Error()))
 		return
 	}
 
-	_, result, err := s.Core.BusinessOperation().GetInternalModule(ctx.Kit, obj, bizID)
+	ctx.SetReadPreference(common.SecondaryPreferredMode)
+
+	_, result, err := s.Core.BusinessOperation().GetInternalModule(ctx.Kit, bizID)
 	if nil != err {
 		ctx.RespAutoError(err)
 		return
@@ -614,13 +610,7 @@ func (s *Service) GetInternalModuleWithStatistics(ctx *rest.Contexts) {
 		return
 	}
 
-	obj, err := s.Core.ObjectOperation().FindSingleObject(ctx.Kit, common.BKInnerObjIDApp)
-	if nil != err {
-		blog.Errorf("failed to search the business, %s, rid: %s", err.Error(), ctx.Kit.Rid)
-		ctx.RespAutoError(err)
-		return
-	}
-	_, innerAppTopo, err := s.Core.BusinessOperation().GetInternalModule(ctx.Kit, obj, bizID)
+	_, innerAppTopo, err := s.Core.BusinessOperation().GetInternalModule(ctx.Kit, bizID)
 	if nil != err {
 		ctx.RespAutoError(err)
 		return


### PR DESCRIPTION
### 优化的功能:
- search_inst_by_object 和 get_biz_internal_module 接口优化，去除查询模型的操作
### 修复的问题：
- auth server 添加默认用户，修复core service 校验用户失败的问题
