### PR TITLE
fix: 修复主机搜索和动态分组主机搜索逻辑中未能正确判定数据是否不存在的bug. issue #4750

### DIFF
--- a/src/scene_server/host_server/logics/dynamic_grouping.go
+++ b/src/scene_server/host_server/logics/dynamic_grouping.go
@@ -353,6 +353,9 @@ func (e *HostDynamicGroupExecutor) searchByHostConds() error {
 	if err != nil {
 		return err
 	}
+	if e.isNotFound {
+		return nil
+	}
 	e.conds.hostCond.Fields = append(e.conds.hostCond.Fields, e.fields...)
 
 	// empty means all fileds.
@@ -487,6 +490,10 @@ func (e *HostDynamicGroupExecutor) appendHostTopoConds() error {
 
 		e.needPaged = true
 	} else {
+		if len(respHostIDInfo.Data.IDArr) == 0 {
+			e.isNotFound = true
+			return nil
+		}
 		hostIDs = respHostIDInfo.Data.IDArr
 	}
 
@@ -554,6 +561,10 @@ func (e *HostDynamicGroupExecutor) appendHostTopoConds() error {
 
 func (e *HostDynamicGroupExecutor) buildSearchResult() ([]mapstr.MapStr, int) {
 	result := make([]mapstr.MapStr, 0)
+
+	if e.isNotFound {
+		return result, 0
+	}
 
 	for _, host := range e.hosts {
 		result = append(result, host.hostInfo)

--- a/src/scene_server/host_server/logics/hostsearch.go
+++ b/src/scene_server/host_server/logics/hostsearch.go
@@ -138,7 +138,7 @@ type searchHostInterface interface {
 func NewSearchHost(kit *rest.Kit, lgc *Logics, hostSearchParam *metadata.HostCommonSearch) searchHostInterface {
 	sh := &searchHost{
 		kit:             kit,
-		lgc:			 lgc,
+		lgc:             lgc,
 		pheader:         kit.Header,
 		hostSearchParam: hostSearchParam,
 		idArr:           searchHostIDArr{},
@@ -660,6 +660,9 @@ func (sh *searchHost) searchByHostConds() errors.CCError {
 	if err != nil {
 		return err
 	}
+	if sh.noData {
+		return nil
+	}
 
 	if 0 != len(sh.conds.hostCond.Fields) {
 		sh.conds.hostCond.Fields = append(sh.conds.hostCond.Fields, common.BKHostIDField, common.BKCloudIDField)
@@ -808,6 +811,10 @@ func (sh *searchHost) appendHostTopoConds() errors.CCError {
 		}
 		sh.paged = true
 	} else {
+		if len(respHostIDInfo.Data.IDArr) == 0 {
+			sh.noData = true
+			return nil
+		}
 		hostIDArr = respHostIDInfo.Data.IDArr
 	}
 


### PR DESCRIPTION
### 修复的问题：
- 修复主机搜索和动态分组主机搜索逻辑中未能正确判定数据是否不存在的bug