### PR TITLE
主机更新创建时对bk_cloud_id做校验，必须为数值型

### DIFF
--- a/src/scene_server/host_server/service/host.go
+++ b/src/scene_server/host_server/service/host.go
@@ -1377,6 +1377,15 @@ func (s *Service) UpdateImportHosts(ctx *rest.Contexts) {
 		hosts[index] = hostInfo
 		indexHostIDMap[index] = intHostID
 	}
+
+	if len(hostIDArr) == 0 {
+		ctx.RespEntity(map[string]interface{}{
+			"error":   errMsg,
+			"success": []string{},
+		})
+		return
+	}
+
 	// auth: check authorization
 	if err := s.AuthManager.AuthorizeByHostsIDs(ctx.Kit.Ctx, ctx.Kit.Header, authmeta.Update, hostIDArr...); err != nil {
 		blog.Errorf("check host authorization failed, hosts: %+v, err: %v, rid: %s", hostIDArr, err, ctx.Kit.Rid)

--- a/src/source_controller/coreservice/core/host/transfer/manager.go
+++ b/src/source_controller/coreservice/core/host/transfer/manager.go
@@ -381,7 +381,7 @@ func (manager *TransferManager) setDefaultPrivateField(kit *rest.Kit, attributes
 func (manager *TransferManager) GetHostModuleRelation(kit *rest.Kit, input *metadata.HostModuleRelationRequest) (*metadata.HostConfigData, error) {
 	if input.Empty() {
 		blog.Errorf("GetHostModuleRelation input empty. input:%#v, rid:%s", input, kit.Rid)
-		return nil, kit.CCError.Errorf(common.CCErrCommParamsNeedSet, common.BKAppIDField)
+		return nil, kit.CCError.Errorf(common.CCErrCommParamsNeedSet, "GetHostModuleRelation input")
 	}
 	moduleHostCond := condition.CreateCondition()
 	if input.ApplicationID > 0 {

--- a/src/source_controller/coreservice/core/instances/instance_validate.go
+++ b/src/source_controller/coreservice/core/instances/instance_validate.go
@@ -118,6 +118,11 @@ func (m *instanceManager) validCreateInstanceData(kit *rest.Kit, objID string, i
 		}
 	}
 	FillLostedFieldValue(kit.Ctx, instanceData, valid.propertySlice)
+
+	if err := m.validCloudID(kit, objID, instanceData); err != nil {
+		return err
+	}
+
 	if err := m.validMainlineInstanceName(kit, objID, instanceData); err != nil {
 		return err
 	}
@@ -252,6 +257,11 @@ func (m *instanceManager) validUpdateInstanceData(kit *rest.Kit, objID string, i
 			return kit.CCError.CCErrorf(common.CCErrCommGetBusinessIDByHostIDFailed)
 		}
 	}
+
+	if err := m.validCloudID(kit, objID, instanceData); err != nil {
+		return err
+	}
+
 	if err := m.validMainlineInstanceName(kit, objID, instanceData); err != nil {
 		return err
 	}
@@ -334,5 +344,19 @@ func (m *instanceManager) validMainlineInstanceName(kit *rest.Kit, objID string,
 			break
 		}
 	}
+	return nil
+}
+
+// validCloudID valid the bk_cloud_id
+func (m *instanceManager) validCloudID(kit *rest.Kit, objID string, BKInnerObjIDHost mapstr.MapStr) error {
+	if objID == common.BKInnerObjIDHost {
+		if BKInnerObjIDHost.Exists(common.BKCloudIDField) {
+			if cloudID, err := BKInnerObjIDHost.Int64(common.BKCloudIDField); err != nil || cloudID < 0 {
+				blog.Errorf("invalid bk_cloud_id value:%#v, err:%v, rid:%s", BKInnerObjIDHost[common.BKCloudIDField], err, kit.Rid)
+				return kit.CCError.CCErrorf(common.CCErrCommParamsInvalid, common.BKCloudIDField)
+			}
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
### 优化的功能:
- 主机更新创建时对bk_cloud_id做校验，必须为数值型
