### PR TITLE
操作审计传入kit，防止header改变导致事务提交失败

### DIFF
--- a/src/scene_server/host_server/logics/host.go
+++ b/src/scene_server/host_server/logics/host.go
@@ -185,8 +185,8 @@ func (lgc *Logics) EnterIP(kit *rest.Kit, appID, moduleID int64, ip string, clou
 
 	}
 
-	hmAudit := auditlog.NewHostModuleLog(lgc.CoreAPI.CoreService(), kit, []int64{hostID})
-	if err := hmAudit.WithPrevious(kit.Ctx); err != nil {
+	hmAudit := auditlog.NewHostModuleLog(lgc.CoreAPI.CoreService(), []int64{hostID})
+	if err := hmAudit.WithPrevious(kit); err != nil {
 		return err
 	}
 
@@ -209,7 +209,7 @@ func (lgc *Logics) EnterIP(kit *rest.Kit, appID, moduleID int64, ip string, clou
 		return kit.CCError.New(hmResult.Code, hmResult.ErrMsg)
 	}
 
-	if err := hmAudit.SaveAudit(kit.Ctx); err != nil {
+	if err := hmAudit.SaveAudit(kit); err != nil {
 		return err
 	}
 	return nil
@@ -381,8 +381,8 @@ func (lgc *Logics) TransferHostAcrossBusiness(kit *rest.Kit, srcBizID, dstAppID 
 		return kit.CCError.Errorf(common.CCErrHostNotINAPP, notExistHostIDs)
 	}
 
-	audit := auditlog.NewHostModuleLog(lgc.CoreAPI.CoreService(), kit, hostID)
-	if err := audit.WithPrevious(kit.Ctx); err != nil {
+	audit := auditlog.NewHostModuleLog(lgc.CoreAPI.CoreService(), hostID)
+	if err := audit.WithPrevious(kit); err != nil {
 		blog.Errorf("TransferHostAcrossBusiness, get prev module host config failed, err: %v,hostID:%d,oldbizID:%d,appID:%d, moduleID:%#v,rid:%s", err, hostID, srcBizID, dstAppID, moduleID, kit.Rid)
 		return kit.CCError.Errorf(common.CCErrCommResourceInitFailed, "audit server")
 	}
@@ -397,7 +397,7 @@ func (lgc *Logics) TransferHostAcrossBusiness(kit *rest.Kit, srcBizID, dstAppID 
 		return kit.CCError.New(delRet.Code, delRet.ErrMsg)
 	}
 
-	if err := audit.SaveAudit(kit.Ctx); err != nil {
+	if err := audit.SaveAudit(kit); err != nil {
 		blog.Errorf("TransferHostAcrossBusiness, get prev module host config failed, err: %v,hostID:%d,oldbizID:%d,appID:%d, moduleID:%#v,rid:%s", err, hostID, srcBizID, dstAppID, moduleID, kit.Rid)
 		return kit.CCError.Errorf(common.CCErrCommResourceInitFailed, "audit server")
 

--- a/src/scene_server/host_server/logics/module.go
+++ b/src/scene_server/host_server/logics/module.go
@@ -224,8 +224,8 @@ func (lgc *Logics) MoveHostToResourcePool(kit *rest.Kit, conf *metadata.DefaultM
 		DstModuleIDArr:   []int64{ownerModuleID},
 	}
 
-	audit := auditlog.NewHostModuleLog(lgc.CoreAPI.CoreService(), kit, conf.HostIDs)
-	if err := audit.WithPrevious(kit.Ctx); err != nil {
+	audit := auditlog.NewHostModuleLog(lgc.CoreAPI.CoreService(), conf.HostIDs)
+	if err := audit.WithPrevious(kit); err != nil {
 		blog.Errorf("move host to resource pool, but get prev module host config failed, err: %v, input:%+v,rid:%s", err, conf, kit.Rid)
 		return nil, kit.CCError.Errorf(common.CCErrCommResourceInitFailed, "audit server")
 	}
@@ -240,7 +240,7 @@ func (lgc *Logics) MoveHostToResourcePool(kit *rest.Kit, conf *metadata.DefaultM
 
 	}
 
-	if err := audit.SaveAudit(kit.Ctx); err != nil {
+	if err := audit.SaveAudit(kit); err != nil {
 		blog.Errorf("move host to resource pool, but save audit log failed, err: %v, input:%+v,rid:%s", err, conf, kit.Rid)
 		return nil, kit.CCError.Errorf(common.CCErrCommResourceInitFailed, "audit server")
 	}
@@ -357,8 +357,8 @@ func (lgc *Logics) AssignHostToApp(kit *rest.Kit, conf *metadata.DefaultModuleHo
 		DstModuleIDArr:   []int64{moduleID},
 	}
 
-	audit := auditlog.NewHostModuleLog(lgc.CoreAPI.CoreService(), kit, conf.HostIDs)
-	if err := audit.WithPrevious(kit.Ctx); err != nil {
+	audit := auditlog.NewHostModuleLog(lgc.CoreAPI.CoreService(), conf.HostIDs)
+	if err := audit.WithPrevious(kit); err != nil {
 		blog.Warnf("WithPrevious failed, err: %+v, rid: %s", err, kit.Rid)
 	}
 
@@ -372,7 +372,7 @@ func (lgc *Logics) AssignHostToApp(kit *rest.Kit, conf *metadata.DefaultModuleHo
 		return result.Data, kit.CCError.New(result.Code, result.ErrMsg)
 	}
 
-	if err := audit.SaveAudit(kit.Ctx); err != nil {
+	if err := audit.SaveAudit(kit); err != nil {
 		blog.Errorf("assign host to app, but save audit failed, err: %v, rid:%s", err, kit.Rid)
 		return nil, kit.CCError.Errorf(common.CCErrCommResourceInitFailed, "audit server")
 	}

--- a/src/scene_server/host_server/service/host.go
+++ b/src/scene_server/host_server/service/host.go
@@ -1135,7 +1135,7 @@ func (s *Service) MoveSetHost2IdleModule(ctx *rest.Contexts) {
 	idleModuleID := moduleIDArr[0]
 	moduleHostConfigParams := make(map[string]interface{})
 	moduleHostConfigParams[common.BKAppIDField] = data.ApplicationID
-	audit := auditlog.NewHostModuleLog(s.CoreAPI.CoreService(), ctx.Kit, hostIDArr)
+	audit := auditlog.NewHostModuleLog(s.CoreAPI.CoreService(), hostIDArr)
 
 	var exceptionArr []meta.ExceptionResult
 	txnErr := s.Engine.CoreAPI.CoreService().Txn().AutoRunTxn(ctx.Kit.Ctx, s.EnableTxn, ctx.Kit.Header, func() error {
@@ -1216,7 +1216,7 @@ func (s *Service) MoveSetHost2IdleModule(ctx *rest.Contexts) {
 			}
 		}
 
-		if err := audit.SaveAudit(ctx.Kit.Ctx); err != nil {
+		if err := audit.SaveAudit(ctx.Kit); err != nil {
 			blog.Errorf("SaveAudit failed, err: %s, rid: %s", err.Error(), ctx.Kit.Rid)
 			return ctx.Kit.CCError.CCError(common.CCErrHostDeleteFail)
 		}

--- a/src/scene_server/host_server/service/module.go
+++ b/src/scene_server/host_server/service/module.go
@@ -44,8 +44,8 @@ func (s *Service) TransferHostModule(ctx *rest.Contexts) {
 		}
 	}
 
-	audit := auditlog.NewHostModuleLog(s.CoreAPI.CoreService(), ctx.Kit, config.HostID)
-	if err := audit.WithPrevious(ctx.Kit.Ctx); err != nil {
+	audit := auditlog.NewHostModuleLog(s.CoreAPI.CoreService(), config.HostID)
+	if err := audit.WithPrevious(ctx.Kit); err != nil {
 		blog.Errorf("host module relation, get prev module host config failed, err: %v,param:%+v,rid:%s", err, config, ctx.Kit.Rid)
 		ctx.RespAutoError(ctx.Kit.CCError.Errorf(common.CCErrCommResourceInitFailed, "audit server"))
 		return
@@ -65,7 +65,7 @@ func (s *Service) TransferHostModule(ctx *rest.Contexts) {
 			return result.CCError()
 		}
 
-		if err := audit.SaveAudit(ctx.Kit.Ctx); err != nil {
+		if err := audit.SaveAudit(ctx.Kit); err != nil {
 			blog.Errorf("host module relation, save audit log failed, err: %v,input:%+v,rid:%s", err, config, ctx.Kit.Rid)
 			return ctx.Kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
 		}
@@ -281,8 +281,8 @@ func (s *Service) moveHostToDefaultModule(ctx *rest.Contexts, defaultModuleFlag 
 		return
 	}
 
-	audit := auditlog.NewHostModuleLog(s.CoreAPI.CoreService(), ctx.Kit, conf.HostIDs)
-	if err := audit.WithPrevious(ctx.Kit.Ctx); err != nil {
+	audit := auditlog.NewHostModuleLog(s.CoreAPI.CoreService(), conf.HostIDs)
+	if err := audit.WithPrevious(ctx.Kit); err != nil {
 		blog.Errorf("move host to default module s failed, get prev module host config failed, hostIDs: %v, err: %s, rid: %s", conf.HostIDs, err.Error(), ctx.Kit.Rid)
 		ctx.RespAutoError(defErr.Errorf(common.CCErrCommResourceInitFailed, "audit server"))
 		return
@@ -307,7 +307,7 @@ func (s *Service) moveHostToDefaultModule(ctx *rest.Contexts, defaultModuleFlag 
 			return defErr.New(result.Code, result.ErrMsg)
 		}
 
-		if err := audit.SaveAudit(ctx.Kit.Ctx); err != nil {
+		if err := audit.SaveAudit(ctx.Kit); err != nil {
 			blog.ErrorJSON("move host to default module failed, save audit log failed, input:%s, err:%s, rid:%s", conf, err, ctx.Kit.Rid)
 			return ctx.Kit.CCError.Errorf(common.CCErrCommResourceInitFailed, "audit server")
 		}
@@ -347,8 +347,8 @@ func (s *Service) TransferHostResourceDirectory(ctx *rest.Contexts) {
 		return
 	}
 
-	audit := auditlog.NewHostModuleLog(s.CoreAPI.CoreService(), ctx.Kit, input.HostID)
-	if err := audit.WithPrevious(ctx.Kit.Ctx); err != nil {
+	audit := auditlog.NewHostModuleLog(s.CoreAPI.CoreService(), input.HostID)
+	if err := audit.WithPrevious(ctx.Kit); err != nil {
 		blog.Errorf("TransferHostResourceDirectory, but get prev module host config failed, err: %v, hostIDs:%#v,rid:%s", err, input.HostID, ctx.Kit.Rid)
 		ctx.RespAutoError(ctx.Kit.CCError.Errorf(common.CCErrCommResourceInitFailed, "audit server"))
 		return
@@ -361,7 +361,7 @@ func (s *Service) TransferHostResourceDirectory(ctx *rest.Contexts) {
 		return
 	}
 
-	if err := audit.SaveAudit(ctx.Kit.Ctx); err != nil {
+	if err := audit.SaveAudit(ctx.Kit); err != nil {
 		blog.Errorf("move host to resource pool, but save audit log failed, err: %v, input:%+v,rid:%s", err, input.HostID, ctx.Kit.Rid)
 		ctx.RespAutoError(ctx.Kit.CCError.Errorf(common.CCErrCommResourceInitFailed, "audit server"))
 		return

--- a/src/scene_server/host_server/service/transfer.go
+++ b/src/scene_server/host_server/service/transfer.go
@@ -121,8 +121,8 @@ func (s *Service) TransferHostWithAutoClearServiceInstance(ctx *rest.Contexts) {
 			moduleMap[mod.ModuleID] = mod.ServiceTemplateID
 		}
 
-		audit := auditlog.NewHostModuleLog(s.CoreAPI.CoreService(), ctx.Kit, option.HostIDs)
-		if err := audit.WithPrevious(ctx.Kit.Ctx); err != nil {
+		audit := auditlog.NewHostModuleLog(s.CoreAPI.CoreService(), option.HostIDs)
+		if err := audit.WithPrevious(ctx.Kit); err != nil {
 			blog.Errorf("TransferHostWithAutoClearServiceInstance failed, get prev module host config for audit failed, err: %s, HostIDs: %+v, rid: %s", err.Error(), option.HostIDs, ctx.Kit.Rid)
 			return err
 		}
@@ -235,7 +235,7 @@ func (s *Service) TransferHostWithAutoClearServiceInstance(ctx *rest.Contexts) {
 		if firstErr != nil {
 			return firstErr
 		}
-		if err := audit.SaveAudit(ctx.Kit.Ctx); err != nil {
+		if err := audit.SaveAudit(ctx.Kit); err != nil {
 			blog.Errorf("TransferHostWithAutoClearServiceInstance failed, save audit log failed, err: %s, HostIDs: %+v, rid: %s", err.Error(), option.HostIDs, ctx.Kit.Rid)
 			return err
 		}


### PR DESCRIPTION
### 修复的问题：
- 修复主机转移操作审计事务提交失败的问题
