### PR TITLE
事件监听接口在异常情况下强制sleep 500ms，防止调用方一直使用错误的参数拉取事件

### DIFF
--- a/src/scene_server/event_server/service/watch.go
+++ b/src/scene_server/event_server/service/watch.go
@@ -28,6 +28,7 @@ func (s *Service) WatchEvent(ctx *rest.Contexts) {
 	options := new(watch.WatchEventOptions)
 	if err := ctx.DecodeInto(&options); err != nil {
 		blog.Errorf("watch event, but decode request body failed, err: %v, rid: %s", err, ctx.Kit.Rid)
+		time.Sleep(500 * time.Millisecond)
 		ctx.RespAutoError(ctx.Kit.CCError.Error(common.CCErrCommJSONUnmarshalFailed))
 		return
 	}
@@ -35,6 +36,7 @@ func (s *Service) WatchEvent(ctx *rest.Contexts) {
 
 	if err := options.Validate(); err != nil {
 		blog.Errorf("watch event, but got invalid request options, err: %v, rid: %s", err, ctx.Kit.Rid)
+		time.Sleep(500 * time.Millisecond)
 		ctx.RespAutoError(ctx.Kit.CCError.Error(common.CCErrCommHTTPInputInvalid))
 		return
 	}
@@ -42,6 +44,7 @@ func (s *Service) WatchEvent(ctx *rest.Contexts) {
 	key, err := event.GetResourceKeyWithCursorType(options.Resource)
 	if err != nil {
 		blog.Errorf("watch event, but get resource key with cursor type failed, err: %v, rid: %s", err, ctx.Kit.Rid)
+		time.Sleep(500 * time.Millisecond)
 		ctx.RespAutoError(ctx.Kit.CCError.Error(common.CCErrCommHTTPInputInvalid))
 		return
 	}
@@ -54,6 +57,7 @@ func (s *Service) WatchEvent(ctx *rest.Contexts) {
 		events, err := watcher.WatchWithCursor(key, options, ctx.Kit.Rid)
 		if err != nil {
 			blog.Errorf("watch event with cursor failed, cursor: %s, err: %v, rid: %s", options.Cursor, err, ctx.Kit.Rid)
+			time.Sleep(500 * time.Millisecond)
 			ctx.RespAutoError(err)
 			return
 		}
@@ -68,6 +72,7 @@ func (s *Service) WatchEvent(ctx *rest.Contexts) {
 		events, err := watcher.WatchWithStartFrom(key, options, ctx.Kit.Rid)
 		if err != nil {
 			blog.Errorf("watch event with start from: %s, err: %v, rid: %s", time.Unix(options.StartFrom, 0).Format(time.RFC3339), err, ctx.Kit.Rid)
+			time.Sleep(500 * time.Millisecond)
 			ctx.RespAutoError(ctx.Kit.CCError.Error(common.CCErrCommHTTPInputInvalid))
 			return
 		}
@@ -80,6 +85,7 @@ func (s *Service) WatchEvent(ctx *rest.Contexts) {
 	events, err := watcher.WatchFromNow(key, options, ctx.Kit.Rid)
 	if err != nil {
 		blog.Errorf("watch event from now, err: %v, rid: %s", err, ctx.Kit.Rid)
+		time.Sleep(500 * time.Millisecond)
 		ctx.RespAutoError(ctx.Kit.CCError.Error(common.CCErrCommHTTPInputInvalid))
 		return
 	}


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
