### PR TITLE
修复查询主机列表接口因集群查询结果为空没提前返回导致查询结果不对的问题

### DIFF
--- a/src/scene_server/host_server/service/findhost.go
+++ b/src/scene_server/host_server/service/findhost.go
@@ -632,6 +632,13 @@ func (s *Service) listBizHosts(header http.Header, bizID int64, parameter meta.L
 			return nil, errors.New(setList.Code, setList.ErrMsg)
 		}
 
+		if len(setList.Data.Info) == 0 {
+			return &meta.ListHostResult{
+				Count: 0,
+				Info:  []map[string]interface{}{},
+			}, nil
+		}
+
 		for _, set := range setList.Data.Info {
 			id, err := util.GetInt64ByInterface(set[common.BKSetIDField])
 			if err != nil {


### PR DESCRIPTION
### 修复的问题：
- 修复查询主机列表接口因集群查询结果为空没提前返回导致查询结果不对的问题
