### PR TITLE
fix: 修复查询主机列表接口因集群查询结果为空没提前返回导致查询结果不对的问题

### DIFF
--- a/src/scene_server/host_server/service/findhost.go
+++ b/src/scene_server/host_server/service/findhost.go
@@ -118,6 +118,12 @@ func (s *Service) listBizHosts(header http.Header, bizID int64, parameter meta.L
 			blog.ErrorJSON("ListBizHosts failed, GetSetIDByCond %s failed, error: %s, rid:%s", parameter.SetCond, err.Error(), srvData.rid)
 			return result, defErr.CCError(common.CCErrCommHTTPDoRequestFailed)
 		}
+		if len(setIDs) == 0 {
+			return &meta.ListHostResult{
+				Count: 0,
+				Info:  []map[string]interface{}{},
+			}, nil
+		}
 	}
 
 	option := &meta.ListHosts{


### PR DESCRIPTION
### 修复的问题：
- 修复查询主机列表接口因集群查询结果为空没提前返回导致查询结果不对的问题
