### PR TITLE
feature: 新增依照关联关系实例id批量删除关联关系的接口

### DIFF
--- a/src/ac/parser/topolatest.go
+++ b/src/ac/parser/topolatest.go
@@ -420,9 +420,10 @@ const (
 )
 
 var (
-	deleteObjectInstanceAssociationLatestRegexp = regexp.MustCompile("^/api/v3/delete/instassociation/[0-9]+/?$")
-	findObjectInstanceTopologyUILatestRegexp    = regexp.MustCompile(`^/api/v3/findmany/inst/association/object/[^\s/]+/inst_id/[0-9]+/offset/[0-9]+/limit/[0-9]+/web$`)
-	findInstAssociationObjInstInfoLatestRegexp  = regexp.MustCompile(`^/api/v3/findmany/inst/association/association_object/inst_base_info$`)
+	deleteObjectInstanceAssociationLatestRegexp      = regexp.MustCompile("^/api/v3/delete/instassociation/[0-9]+/?$")
+	deleteObjectInstanceAssociationBatchLatestRegexp = regexp.MustCompile("^/api/v3/delete/instassociation/batch")
+	findObjectInstanceTopologyUILatestRegexp         = regexp.MustCompile(`^/api/v3/findmany/inst/association/object/[^\s/]+/inst_id/[0-9]+/offset/[0-9]+/limit/[0-9]+/web$`)
+	findInstAssociationObjInstInfoLatestRegexp       = regexp.MustCompile(`^/api/v3/findmany/inst/association/association_object/inst_base_info$`)
 )
 
 func (ps *parseStream) objectInstanceAssociationLatest() *parseStream {
@@ -620,6 +621,20 @@ func (ps *parseStream) objectInstanceAssociationLatest() *parseStream {
 				})
 		}
 
+		return ps
+	}
+
+	// delete object instance's association batch operation.
+	if ps.hitRegexp(deleteObjectInstanceAssociationBatchLatestRegexp, http.MethodDelete) {
+		ps.Attribute.Resources = []meta.ResourceAttribute{
+			{
+				BusinessID: ps.RequestCtx.BizID,
+				Basic: meta.Basic{
+					Type:   meta.ModelInstanceAssociation,
+					Action: meta.DeleteMany,
+				},
+			},
+		}
 		return ps
 	}
 

--- a/src/apimachinery/toposerver/association/apis.go
+++ b/src/apimachinery/toposerver/association/apis.go
@@ -32,6 +32,7 @@ type AssociationInterface interface {
 	SearchAssociationRelatedInst(ctx context.Context, h http.Header, request *metadata.SearchAssociationRelatedInstRequest) (resp *metadata.SearchAssociationInstResult, err error)
 	CreateInst(ctx context.Context, h http.Header, request *metadata.CreateAssociationInstRequest) (resp *metadata.CreateAssociationInstResult, err error)
 	DeleteInst(ctx context.Context, h http.Header, assoID int64) (resp *metadata.DeleteAssociationInstResult, err error)
+	DeleteInstBatch(ctx context.Context, h http.Header, assoIDs *metadata.DeleteAssociationInstBatchRequest) (resp *metadata.DeleteAssociationInstBatchResult, err error)
 	SearchObjectAssoWithAssoKindList(ctx context.Context, h http.Header, assoKindIDs metadata.AssociationKindIDs) (resp *metadata.ListAssociationsWithAssociationKindResult, err error)
 }
 

--- a/src/apimachinery/toposerver/association/association.go
+++ b/src/apimachinery/toposerver/association/association.go
@@ -192,6 +192,21 @@ func (asst *Association) DeleteInst(ctx context.Context, h http.Header, assoID i
 	return
 }
 
+func (asst *Association) DeleteInstBatch(ctx context.Context, h http.Header, assoIDs *metadata.DeleteAssociationInstBatchRequest) (resp *metadata.DeleteAssociationInstBatchResult, err error) {
+	resp = new(metadata.DeleteAssociationInstBatchResult)
+	subPath := "/inst/association/batch/action/delete"
+
+	err = asst.client.Delete().
+		WithContext(ctx).
+		Body(assoIDs).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	return
+}
+
 func (asst *Association) SearchObjectAssoWithAssoKindList(ctx context.Context, h http.Header, assoKindIDs metadata.AssociationKindIDs) (resp *metadata.ListAssociationsWithAssociationKindResult, err error) {
 	resp = new(metadata.ListAssociationsWithAssociationKindResult)
 	subPath := "/topo/association/type/action/search/batch"

--- a/src/common/metadata/association.go
+++ b/src/common/metadata/association.go
@@ -133,9 +133,18 @@ type DeleteAssociationInstRequest struct {
 	Condition mapstr.MapStr `json:"condition"`
 }
 
+type DeleteAssociationInstBatchRequest struct {
+	ID []int64 `json:"id"`
+}
+
 type DeleteAssociationInstResult struct {
 	BaseResp `json:",inline"`
 	Data     string `json:"data"`
+}
+
+type DeleteAssociationInstBatchResult struct {
+	BaseResp `json:",inline"`
+	Data     int `json:"data"`
 }
 
 type AssociationKindIDs struct {

--- a/src/scene_server/topo_server/service/service_business_initfunc.go
+++ b/src/scene_server/topo_server/service/service_business_initfunc.go
@@ -143,6 +143,7 @@ func (s *Service) initBusinessAssociation(web *restful.WebService) {
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/instassociation/related", Handler: s.SearchAssociationRelatedInst})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/create/instassociation", Handler: s.CreateAssociationInst})
 	utility.AddHandler(rest.Action{Verb: http.MethodDelete, Path: "/delete/instassociation/{association_id}", Handler: s.DeleteAssociationInst})
+	utility.AddHandler(rest.Action{Verb: http.MethodDelete, Path: "/delete/instassociation/batch", Handler: s.DeleteAssociationInstBatch})
 
 	// topo search methods
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/instassociation/object/{bk_obj_id}", Handler: s.SearchInstByAssociation})

--- a/src/scene_server/topo_server/service/service_initfunc.go
+++ b/src/scene_server/topo_server/service/service_initfunc.go
@@ -57,6 +57,7 @@ func (s *Service) initAssociation(web *restful.WebService) {
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/inst/association/related/action/search", Handler: s.SearchAssociationRelatedInst})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/inst/association/action/create", Handler: s.CreateAssociationInst})
 	utility.AddHandler(rest.Action{Verb: http.MethodDelete, Path: "/inst/association/{association_id}/action/delete", Handler: s.DeleteAssociationInst})
+	utility.AddHandler(rest.Action{Verb: http.MethodDelete, Path: "/inst/association/batch/action/delete", Handler: s.DeleteAssociationInstBatch})
 
 	// topo search methods
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/inst/association/search/owner/{owner_id}/object/{bk_obj_id}", Handler: s.SearchInstByAssociation})

--- a/src/test/topo_server/asst_test.go
+++ b/src/test/topo_server/asst_test.go
@@ -179,5 +179,27 @@ var _ = Describe("inst test", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rsp.Result).To(Equal(false))
 	})
+	//check "DeleteInstBatch" "the number of IDs should be less than 500." function.
+	It("delete inst association batch", func() {
+		list := make([]int64, 501, 501)
+		input := &metadata.DeleteAssociationInstBatchRequest{
+			ID: list,
+		}
+		rsp, err := asstClient.DeleteInstBatch(context.Background(), header, input)
+		util.RegisterResponse(rsp)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rsp.Result).To(Equal(false))
+	})
+	//check "DeleteInstBatch" features available.
+	It("delete inst association batch", func() {
+		input := &metadata.DeleteAssociationInstBatchRequest{
+			ID: []int64{1, 2},
+		}
+		rsp, err := asstClient.DeleteInstBatch(context.Background(), header, input)
+		util.RegisterResponse(rsp)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rsp.Result).To(Equal(true))
+		Expect(rsp.Data).To(Equal(2))
+	})
 
 })


### PR DESCRIPTION
### 新加的功能:
- 新增依照关联关系实例id批量删除关联关系的接口(无事务,尽量执行,某条执行失败不影响下一条执行)，并为其增加了集成测试。

close #4595 