### PR TITLE
事件监听保留最后一个事件，修复所有事件均超时后使用cursor监听失败的问题

### DIFF
--- a/src/source_controller/coreservice/event/gc.go
+++ b/src/source_controller/coreservice/event/gc.go
@@ -169,6 +169,11 @@ func (f *Flow) cleanExpiredEvents() {
 			// redirect the head key.
 			pipe.HSet(mainKey, headKey, hBytes)
 			for _, expire := range expiredNodes {
+				// do not delete the last node before tail, in case no event occurred after the last event and watch with that cursor failed
+				if expire.NextCursor == tailKey {
+					continue
+				}
+
 				// delete expired chain node
 				pipe.HDel(mainKey, expire.Cursor)
 				// delete expired cursor targeted detail key


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
