### PR TITLE
fix: 修复转移主机到直接新建的模块下时，会新增两个重复服务实例的问题

### DIFF
--- a/src/source_controller/coreservice/core/process/service_instance.go
+++ b/src/source_controller/coreservice/core/process/service_instance.go
@@ -634,6 +634,9 @@ func (p *processOperation) AutoCreateServiceInstanceModuleHost(kit *rest.Kit, ho
 			common.BKDBIN: moduleIDs,
 		},
 		common.BKDefaultField: common.NormalModuleFlag,
+		common.BKServiceTemplateIDField: map[string]interface{}{
+			common.BKDBNE: common.ServiceTemplateIDNotSet,
+		},
 	}
 
 	modules := make([]metadata.ModuleInst, 0)
@@ -657,9 +660,7 @@ func (p *processOperation) AutoCreateServiceInstanceModuleHost(kit *rest.Kit, ho
 
 	serviceTemplateIDs := make([]int64, 0)
 	for _, module := range modules {
-		if module.ServiceTemplateID != common.ServiceTemplateIDNotSet {
-			serviceTemplateIDs = append(serviceTemplateIDs, module.ServiceTemplateID)
-		}
+		serviceTemplateIDs = append(serviceTemplateIDs, module.ServiceTemplateID)
 	}
 
 	serviceProcessTemplateMap := make(map[int64][]metadata.ProcessTemplate)

--- a/src/storage/stream/event/watch.go
+++ b/src/storage/stream/event/watch.go
@@ -71,7 +71,10 @@ func (e *Event) loopWatch(ctx context.Context,
 			blog.Warnf("received stopped loop watch signal, stop watch db: %s, collection: %s, err: %v", e.database,
 				opts.Collection, ctx.Err())
 
-			stream.Close(context.Background())
+			if stream != nil {
+				stream.Close(context.Background())
+			}
+
 			return
 		default:
 

--- a/src/test/host_server/host_abnormal_test.go
+++ b/src/test/host_server/host_abnormal_test.go
@@ -160,9 +160,16 @@ var _ = Describe("host abnormal test", func() {
 			Expect(rsp.Result).To(Equal(true))
 			Expect(rsp.Data.SetName).To(Equal("空闲机池"))
 			Expect(len(rsp.Data.Module)).To(Equal(3))
-			idleModuleId = rsp.Data.Module[0].ModuleID
-			faultModuleId = rsp.Data.Module[1].ModuleID
-			recycleModuleId = rsp.Data.Module[1].ModuleID
+			for _, module := range rsp.Data.Module {
+				switch module.ModuleName {
+				case "空闲机":
+					idleModuleId = module.ModuleID
+				case "故障机":
+					faultModuleId = module.ModuleID
+				case "待回收":
+					recycleModuleId = module.ModuleID
+				}
+			}
 		})
 
 		// 云区域ID不存在新加主机报错
@@ -638,7 +645,7 @@ var _ = Describe("host abnormal test", func() {
 					Sort: "bk_host_id",
 				},
 				Condition: []params.SearchCondition{
-					params.SearchCondition{
+					{
 						ObjectID: "biz",
 						Condition: []interface{}{
 							map[string]interface{}{
@@ -926,7 +933,7 @@ var _ = Describe("host abnormal test", func() {
 			input1 := &params.HostCommonSearch{
 				AppID: int(bizId1),
 				Condition: []params.SearchCondition{
-					params.SearchCondition{
+					{
 						ObjectID: "module",
 						Condition: []interface{}{
 							map[string]interface{}{
@@ -971,7 +978,7 @@ var _ = Describe("host abnormal test", func() {
 			input1 := &params.HostCommonSearch{
 				AppID: int(bizId1),
 				Condition: []params.SearchCondition{
-					params.SearchCondition{
+					{
 						ObjectID: "module",
 						Condition: []interface{}{
 							map[string]interface{}{
@@ -1014,7 +1021,7 @@ var _ = Describe("host abnormal test", func() {
 			input1 := &params.HostCommonSearch{
 				AppID: int(bizId1),
 				Condition: []params.SearchCondition{
-					params.SearchCondition{
+					{
 						ObjectID: "module",
 						Condition: []interface{}{
 							map[string]interface{}{
@@ -1202,7 +1209,7 @@ var _ = Describe("host abnormal test", func() {
 			input1 := &params.HostCommonSearch{
 				AppID: int(bizId1),
 				Condition: []params.SearchCondition{
-					params.SearchCondition{
+					{
 						ObjectID: "module",
 						Condition: []interface{}{
 							map[string]interface{}{
@@ -1260,7 +1267,7 @@ var _ = Describe("host abnormal test", func() {
 			input1 := &params.HostCommonSearch{
 				AppID: int(bizId1),
 				Condition: []params.SearchCondition{
-					params.SearchCondition{
+					{
 						ObjectID: "module",
 						Condition: []interface{}{
 							map[string]interface{}{
@@ -1372,7 +1379,7 @@ var _ = Describe("host abnormal test", func() {
 			input1 := &params.HostCommonSearch{
 				AppID: int(bizId1),
 				Condition: []params.SearchCondition{
-					params.SearchCondition{
+					{
 						ObjectID: "module",
 						Condition: []interface{}{
 							map[string]interface{}{
@@ -1408,7 +1415,7 @@ var _ = Describe("host abnormal test", func() {
 			input1 := &params.HostCommonSearch{
 				AppID: -1,
 				Condition: []params.SearchCondition{
-					params.SearchCondition{
+					{
 						ObjectID: "biz",
 						Condition: []interface{}{
 							map[string]interface{}{
@@ -1655,7 +1662,7 @@ var _ = Describe("host abnormal test", func() {
 			input := &params.HostCommonSearch{
 				AppID: int(bizId1),
 				Condition: []params.SearchCondition{
-					params.SearchCondition{
+					{
 						ObjectID: "module",
 						Condition: []interface{}{
 							map[string]interface{}{
@@ -1701,7 +1708,7 @@ var _ = Describe("host abnormal test", func() {
 			input1 := &params.HostCommonSearch{
 				AppID: int(bizId),
 				Condition: []params.SearchCondition{
-					params.SearchCondition{
+					{
 						ObjectID: "module",
 						Condition: []interface{}{
 							map[string]interface{}{
@@ -2068,7 +2075,7 @@ func prepareData() {
 	input5 := &params.HostCommonSearch{
 		AppID: -1,
 		Condition: []params.SearchCondition{
-			params.SearchCondition{
+			{
 				ObjectID: "biz",
 				Condition: []interface{}{
 					map[string]interface{}{

--- a/src/test/host_server/host_test.go
+++ b/src/test/host_server/host_test.go
@@ -523,8 +523,14 @@ var _ = Describe("host test", func() {
 			Expect(rsp.Result).To(Equal(true))
 			Expect(rsp.Data.SetName).To(Equal("空闲机池"))
 			Expect(len(rsp.Data.Module)).To(Equal(3))
-			idleModuleId = rsp.Data.Module[0].ModuleID
-			faultModuleId = rsp.Data.Module[1].ModuleID
+			for _, module := range rsp.Data.Module {
+				switch module.ModuleName {
+				case "空闲机":
+					idleModuleId = module.ModuleID
+				case "故障机":
+					faultModuleId = module.ModuleID
+				}
+			}
 		})
 
 		It("search fault host", func() {

--- a/src/test/host_server/host_test.go
+++ b/src/test/host_server/host_test.go
@@ -1371,17 +1371,14 @@ var _ = Describe("multiple ip host validation test", func() {
 	It("multiple ip host validation", func() {
 		test.ClearDatabase()
 
-		By("add hosts with one same ip using api")
+		By("add hosts with different ip using api")
 		hostInput := map[string]interface{}{
 			"host_info": map[string]interface{}{
 				"1": map[string]interface{}{
 					"bk_host_innerip": "1.0.0.1,1.0.0.2",
 				},
 				"2": map[string]interface{}{
-					"bk_host_innerip": "1.0.0.1",
-				},
-				"3": map[string]interface{}{
-					"bk_host_innerip": "1.0.0.1,1.0.0.2,1.0.0.3",
+					"bk_host_innerip": "1.0.0.3",
 				},
 			},
 		}
@@ -1400,7 +1397,7 @@ var _ = Describe("multiple ip host validation test", func() {
 		util.RegisterResponse(searchRsp)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(searchRsp.Result).To(Equal(true))
-		Expect(searchRsp.Data.Count).To(Equal(3))
+		Expect(searchRsp.Data.Count).To(Equal(2))
 
 		By("add same multiple ip host using api")
 		input := &metadata.CreateModelInstance{
@@ -1410,6 +1407,18 @@ var _ = Describe("multiple ip host validation test", func() {
 			},
 		}
 		addHostResult, err := test.GetClientSet().CoreService().Instance().CreateInstance(context.Background(), header, common.BKInnerObjIDHost, input)
+		util.RegisterResponse(addHostResult)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addHostResult.Result).To(Equal(false), addHostResult.ToString())
+
+		By("add hosts with one same ip using api")
+		input = &metadata.CreateModelInstance{
+			Data: map[string]interface{}{
+				"bk_host_innerip": "1.0.0.1",
+				"bk_cloud_id":     0,
+			},
+		}
+		addHostResult, err = test.GetClientSet().CoreService().Instance().CreateInstance(context.Background(), header, common.BKInnerObjIDHost, input)
 		util.RegisterResponse(addHostResult)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(addHostResult.Result).To(Equal(false), addHostResult.ToString())


### PR DESCRIPTION
### 修复的问题：
-修复转移主机到直接新建的模块下时，会新增两个重复服务实例的问题
