### PR TITLE
feature: frame support log output issue #4849

### DIFF
--- a/src/common/blog/glog/glog_method.go
+++ b/src/common/blog/glog/glog_method.go
@@ -14,10 +14,11 @@ package glog
 
 import (
 	"strconv"
+	"sync/atomic"
 )
 
 func GetV() Level {
-	return logging.verbosity
+	return Level(atomic.LoadInt32((*int32)(&logging.verbosity)))
 }
 
 func SetV(level Level) {

--- a/src/common/http/rest/contexts.go
+++ b/src/common/http/rest/contexts.go
@@ -14,7 +14,6 @@ package rest
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -30,15 +29,6 @@ import (
 
 	"github.com/emicklei/go-restful"
 )
-
-type Kit struct {
-	Rid             string
-	Header          http.Header
-	Ctx             context.Context
-	CCError         errors.DefaultCCErrorIf
-	User            string
-	SupplierAccount string
-}
 
 type Contexts struct {
 	Kit            *Kit
@@ -239,7 +229,7 @@ func (c *Contexts) RespWithError(err error, errCode int, format string, args ...
 	if c.respStatusCode != 0 {
 		c.resp.WriteHeader(c.respStatusCode)
 	}
-	blog.ErrorfDepthf(1, "rid: %s, %s, err: %v", c.Kit.Rid, fmt.Sprintf(format, args), err)
+	blog.ErrorfDepthf(1, "rid: %s, %s, err: %v", c.Kit.Rid, fmt.Sprintf(format, args...), err)
 
 	var code int
 	var errMsg string
@@ -337,7 +327,7 @@ func (c *Contexts) RespErrorCodeOnly(errCode int, format string, args ...interfa
 	if c.respStatusCode != 0 {
 		c.resp.WriteHeader(c.respStatusCode)
 	}
-	blog.ErrorfDepthf(1, "%s, rid: %s", fmt.Sprintf(format, args), c.Kit.Rid)
+	blog.ErrorfDepthf(1, "%s, rid: %s", fmt.Sprintf(format, args...), c.Kit.Rid)
 
 	c.resp.Header().Set("Content-Type", "application/json")
 	c.resp.Header().Add(common.BKHTTPCCRequestID, c.Kit.Rid)
@@ -419,17 +409,4 @@ func (c *Contexts) NewHeader() http.Header {
 
 func (c *Contexts) SetReadPreference(mode common.ReadPreferenceMode) {
 	c.Kit.Ctx, c.Kit.Header = util.SetReadPreference(c.Kit.Ctx, c.Kit.Header, mode)
-}
-
-// NewKit 产生一个新的kit， 一般用于在创建新的协程的时候，这个时候会对header 做处理，删除不必要的http header。
-func (kit *Kit) NewKit() *Kit {
-	newHeader := util.CCHeader(kit.Header)
-	newKit := *kit
-	newKit.Header = newHeader
-	return &newKit
-}
-
-// NewHeader 产生一个新的header， 一般用于在创建新的协程的时候，这个时候会对header 做处理，删除不必要的http header。
-func (kit *Kit) NewHeader() http.Header {
-	return util.CCHeader(kit.Header)
 }

--- a/src/common/http/rest/kit.go
+++ b/src/common/http/rest/kit.go
@@ -1,0 +1,217 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rest
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"configcenter/src/common/blog"
+	"configcenter/src/common/blog/glog"
+	"configcenter/src/common/errors"
+	"configcenter/src/common/json"
+	"configcenter/src/common/util"
+)
+
+/*
+
+FILE: kit 座位request 的接入函数
+
+功能：
+
+
+log： 功能描述
+
+fatal: 致命性错误， 需要报警或者影响任务执行
+error: 业务逻辑错误， 用表示处理任务中逻辑错误或者数据错误
+warn: 警告信息，用来提示处理任务中非预期的情况的信息，但是该情况可以忽略的
+
+
+info:  提示信息，默认情况下该信息不输出， 用来标志处理任务中重要节点任务开始，结束或者提示性信息，启动flag中v>=3 输出内容
+
+debug: 调试信息， 默认情况下该信息输出，主要用于线上出现问题的时候获取更多的日志， 启动flag中v>=5 输出内容
+trace: 调用洗洗，默认情况下该信息输出，主要用于线上出现问题的时候获取更多的日志， 启动flag中v>10输出内容
+
+*/
+
+const (
+	fatalFlag  = "[fatal: cc panic] "
+	infoLevel  = 3
+	debugLevel = 5
+	traceLevel = 10
+)
+
+type Kit struct {
+	Rid             string
+	Header          http.Header
+	Ctx             context.Context
+	CCError         errors.DefaultCCErrorIf
+	User            string
+	SupplierAccount string
+}
+
+// NewKit 产生一个新的kit， 一般用于在创建新的协程的时候，这个时候会对header 做处理，删除不必要的http header。
+func (kit *Kit) NewKit() *Kit {
+	newHeader := util.CCHeader(kit.Header)
+	newKit := *kit
+	newKit.Header = newHeader
+	return &newKit
+}
+
+// NewHeader 产生一个新的header， 一般用于在创建新的协程的时候，这个时候会对header 做处理，删除不必要的http header。
+func (kit *Kit) NewHeader() http.Header {
+	return util.CCHeader(kit.Header)
+}
+
+func (kit *Kit) LogFatalJSON(format string, args ...interface{}) {
+	kit.logJSON(true, format, args)
+}
+
+func (kit *Kit) LogFatalf(format string, args ...interface{}) {
+	format = fatalFlag + kit.logprefix() + format + kit.logSuffix()
+	glog.ErrorfDepthf(1, format, args...)
+}
+
+func (kit *Kit) LogFatal(msg string) {
+	msg = fatalFlag + kit.logprefix() + msg + kit.logSuffix()
+	glog.ErrorDepth(1, msg)
+}
+
+func (kit *Kit) LogErrorJSON(format string, args ...interface{}) {
+	kit.logJSON(true, format, args)
+}
+
+func (kit *Kit) LogErrorf(format string, args ...interface{}) {
+	format = kit.logprefix() + format + kit.logSuffix()
+	glog.ErrorfDepthf(1, format, args...)
+}
+
+func (kit *Kit) LogError(msg string) {
+	msg = kit.logprefix() + msg + kit.logSuffix()
+	glog.ErrorDepth(1, msg)
+}
+
+func (kit *Kit) LogWarnJSON(format string, args ...interface{}) {
+	kit.logJSON(true, format, args)
+}
+
+func (kit *Kit) LogWarnf(format string, args ...interface{}) {
+	format = kit.logprefix() + format + kit.logSuffix()
+	glog.InfoDepthf(1, format, args...)
+}
+
+func (kit *Kit) LogWarn(msg string) {
+	msg = kit.logprefix() + msg + kit.logSuffix()
+	glog.InfoDepth(1, msg)
+}
+
+func (kit *Kit) LogInfoJSON(format string, args ...interface{}) {
+	if blog.GetV() >= infoLevel {
+		kit.logJSON(true, format, args)
+	}
+}
+
+func (kit *Kit) LogInfof(format string, args ...interface{}) {
+	if blog.GetV() >= infoLevel {
+		format = kit.logprefix() + format + kit.logSuffix()
+		glog.InfoDepthf(1, format, args...)
+	}
+}
+
+func (kit *Kit) LogInfo(msg string) {
+	if blog.GetV() >= infoLevel {
+		msg = kit.logprefix() + msg + kit.logSuffix()
+		glog.InfoDepth(1, msg)
+	}
+}
+
+func (kit *Kit) LogDebugJSON(format string, args ...interface{}) {
+	if blog.GetV() >= debugLevel {
+		kit.logJSON(true, format, args)
+	}
+}
+
+func (kit *Kit) LogDebugf(format string, args ...interface{}) {
+	if blog.GetV() >= debugLevel {
+		format = kit.logprefix() + format + kit.logSuffix()
+		glog.InfoDepthf(1, format, args...)
+	}
+}
+
+func (kit *Kit) LogDebug(msg string) {
+	if blog.GetV() >= debugLevel {
+		msg = kit.logprefix() + msg + kit.logSuffix()
+		glog.InfoDepth(1, msg)
+	}
+}
+
+func (kit *Kit) LogTraceJSON(format string, args ...interface{}) {
+	if blog.GetV() >= traceLevel {
+		kit.logJSON(true, format, args)
+	}
+}
+
+func (kit *Kit) LogTracef(format string, args ...interface{}) {
+	if blog.GetV() >= traceLevel {
+		format = kit.logprefix() + format + kit.logSuffix()
+		glog.InfoDepthf(1, format, args...)
+	}
+}
+
+func (kit *Kit) LogTrace(msg string) {
+	if blog.GetV() >= traceLevel {
+		msg = kit.logprefix() + msg + kit.logSuffix()
+		glog.InfoDepth(1, msg)
+	}
+}
+
+func (kit *Kit) logJSON(isInfo bool, format string, args ...interface{}) {
+	params := []interface{}{}
+	for _, arg := range args {
+		if f, ok := arg.(errorFunc); ok {
+			params = append(params, f.Error())
+			continue
+		}
+		if f, ok := arg.(stringFunc); ok {
+			params = append(params, f.String())
+			continue
+		}
+		out, err := json.Marshal(arg)
+		if err != nil {
+			params = append(params, err.Error())
+		}
+		params = append(params, out)
+	}
+	format = kit.logprefix() + format + kit.logSuffix()
+	if isInfo {
+		glog.InfoDepth(2, fmt.Sprintf(format, params...))
+	} else {
+		glog.ErrorDepth(2, fmt.Sprintf(format, params...))
+	}
+}
+
+func (kit *Kit) logSuffix() string {
+	return " rid: " + kit.Rid
+}
+
+func (kit *Kit) logprefix() string {
+	return ""
+}
+
+type errorFunc interface {
+	Error() string
+}
+type stringFunc interface {
+	String() string
+}

--- a/src/common/http/rest/kit_log_test.go
+++ b/src/common/http/rest/kit_log_test.go
@@ -1,0 +1,110 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rest
+
+import (
+	"configcenter/src/common/blog"
+	"fmt"
+	"testing"
+)
+
+var (
+	kvMap = map[string]string{"key": "value"}
+)
+
+func getKit() Kit {
+	return Kit{
+		Rid: "cc000rid1212",
+	}
+}
+func TestFatalLog(t *testing.T) {
+	kit := getKit()
+
+	kit.LogFatalJSON("map: %s", kvMap)
+	kit.LogFatalf("msg: %s", "fatalf")
+	kit.LogFatal("msg: fatal")
+	fmt.Println("set v=3")
+
+}
+
+func TestErrorLog(t *testing.T) {
+	kit := getKit()
+
+	kit.LogErrorJSON("map: %s", kvMap)
+	kit.LogErrorf("msg: %s", "error")
+	kit.LogError("msg: error")
+
+}
+
+func TestWarnLog(t *testing.T) {
+	kit := getKit()
+
+	kit.LogWarnJSON("map: %s", kvMap)
+	kit.LogWarnf("msg: %s", "warn")
+	kit.LogWarn("msg: warn")
+
+}
+
+func TestInfoLog(t *testing.T) {
+	kit := getKit()
+
+	kit.LogInfoJSON("map: %s", kvMap)
+	kit.LogInfof("msg: %s", "Info")
+	kit.LogInfo("msg: Info")
+	blog.SetV(3)
+	fmt.Println("set log level= 3")
+	kit.LogInfoJSON("map: %s", kvMap)
+	kit.LogInfof("msg: %s", "Info")
+	kit.LogInfo("msg: Info")
+}
+
+func TestDebugLog(t *testing.T) {
+	kit := getKit()
+
+	kit.LogDebugJSON("map: %s", kvMap)
+	kit.LogDebugf("msg: %s", "Debug")
+	kit.LogDebug("msg: Debug")
+	blog.SetV(3)
+	fmt.Println("set log level= 3")
+	kit.LogDebugJSON("map: %s", kvMap)
+	kit.LogDebugf("msg: %s", "Debug")
+	kit.LogDebug("msg: Debug")
+	blog.SetV(5)
+	fmt.Println("set log level= 5")
+	kit.LogDebugJSON("map: %s", kvMap)
+	kit.LogDebugf("msg: %s", "Debug")
+	kit.LogDebug("msg: Debug")
+}
+
+func TestTraceLog(t *testing.T) {
+	kit := getKit()
+
+	kit.LogTraceJSON("map: %s", kvMap)
+	kit.LogTracef("msg: %s", "Trace")
+	kit.LogTrace("msg: Trace")
+	blog.SetV(3)
+	fmt.Println("set log level= 3")
+	kit.LogTraceJSON("map: %s", kvMap)
+	kit.LogTracef("msg: %s", "Trace")
+	kit.LogTrace("msg: Trace")
+	blog.SetV(5)
+	fmt.Println("set log level= 5")
+	kit.LogTraceJSON("map: %s", kvMap)
+	kit.LogTracef("msg: %s", "Trace")
+	kit.LogTrace("msg: Trace")
+	blog.SetV(10)
+	fmt.Println("set log level= 10")
+	kit.LogTraceJSON("map: %s", kvMap)
+	kit.LogTracef("msg: %s", "Trace")
+	kit.LogTrace("msg: Trace")
+}


### PR DESCRIPTION
### 新加的功能:
-  cc框架新加日志输出能力
  ```

log： 功能描述
fatal: 致命性错误， 需要报警或者影响任务执行
error: 业务逻辑错误， 用表示处理任务中逻辑错误或者数据错误
warn: 警告信息，用来提示处理任务中非预期的情况的信息，但是该情况可以忽略的
info:  提示信息，默认情况下该信息不输出， 用来标志处理任务中重要节点任务开始，接触或者提示性信息； v>=3
debug: 调试信息， 默认情况下该信息输出，主要用于线上出现问题的时候获取更多的日志 v>=5
trace: 调用洗洗，默认情况下该信息输出，主要用于线上出现问题的时候获取更多的日志  v>10
   ```
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
