### PR TITLE
将升级程序里的删除实例关系的updatgeflag字段改成分页删除，防止实例数据过多时DB io timeout

### DIFF
--- a/src/scene_server/admin_server/upgrader/x18.10.30.01/association.go
+++ b/src/scene_server/admin_server/upgrader/x18.10.30.01/association.go
@@ -50,8 +50,8 @@ func createInstanceAssociationIndex(ctx context.Context, db dal.RDB, conf *upgra
 	}
 
 	createIdxArr := []dal.Index{
-		dal.Index{Name: "idx_id", Keys: map[string]int32{"id": -1}, Background: true, Unique: true},
-		dal.Index{Name: "idx_objID_asstObjID_asstID", Keys: map[string]int32{"bk_obj_id": -1, "bk_asst_obj_id": -1, "bk_asst_id": -1}},
+		{Name: "idx_id", Keys: map[string]int32{"id": -1}, Background: true, Unique: true},
+		{Name: "idx_objID_asstObjID_asstID", Keys: map[string]int32{"bk_obj_id": -1, "bk_asst_obj_id": -1, "bk_asst_id": -1}},
 	}
 	for _, idx := range createIdxArr {
 		exist := false
@@ -278,7 +278,7 @@ func reconcilAsstData(ctx context.Context, db dal.RDB, conf *upgrader.Config) er
 		}
 	}
 	blog.InfoJSON("start drop column cond:%s", flag)
-	if err = db.Table(common.BKTableNameInstAsst).DropColumn(ctx, flag); err != nil {
+	if err = dropFlagColumn(ctx, db, conf); err != nil {
 		return err
 	}
 
@@ -325,6 +325,50 @@ func reconcilAsstData(ctx context.Context, db dal.RDB, conf *upgrader.Config) er
 	if err = db.Table(common.BKTableNameObjAsst).Delete(ctx, delCond.ToMapStr()); err != nil {
 		return err
 	}
+	return nil
+}
+
+func dropFlagColumn(ctx context.Context, db dal.RDB, conf *upgrader.Config) error {
+	flag := "updateflag"
+	flagFilter := map[string]interface{}{
+		flag: map[string]interface{}{
+			"$exists": true,
+		},
+	}
+	cnt, err := db.Table(common.BKTableNameInstAsst).Find(flagFilter).Count(ctx)
+	if err != nil {
+		blog.ErrorJSON("dropFlagColumn failed, Find err: %s, filter: %#v, ", err, flagFilter)
+		return err
+	}
+
+	if cnt == 0 {
+		return nil
+	}
+
+	pageSize := uint64(2000)
+	for startIdx := uint64(0); startIdx < cnt; startIdx += pageSize {
+		insts := make([]map[string]int64, 0)
+		if err := db.Table(common.BKTableNameInstAsst).Find(flagFilter).Fields(common.BKFieldID).Start(startIdx).Limit(pageSize).All(ctx, &insts); err != nil {
+			blog.Errorf("find insts failed, Find err: %s", err.Error())
+			return err
+		}
+		instIDs := make([]int64, len(insts))
+		for i, inst := range insts {
+			instIDs[i] = inst[common.BKFieldID]
+		}
+
+		filter := map[string]interface{}{
+			common.BKFieldID: map[string]interface{}{
+				"$in": instIDs,
+			},
+		}
+		if err := db.Table(common.BKTableNameInstAsst).DropDocsColumn(ctx, flag, filter); err != nil {
+			blog.Errorf("dropFlagColumn failed, filter:%#v, DropDocsColumn err:%v", filter, err)
+			return err
+		}
+	}
+	blog.Infof("drop flag count:%d successfully", cnt)
+
 	return nil
 }
 

--- a/src/storage/dal/interface.go
+++ b/src/storage/dal/interface.go
@@ -110,6 +110,8 @@ type Table interface {
 	RenameColumn(ctx context.Context, oldName, newColumn string) error
 	// DropColumn 移除字段
 	DropColumn(ctx context.Context, field string) error
+	// DropDocsColumn 根据条件移除字段
+	DropDocsColumn(ctx context.Context, field string, filter Filter) error
 
 	// Distinct Finds the distinct values for a specified field across a single collection or view and returns the results in an
 	// field the field for which to return distinct values.

--- a/src/storage/dal/mongo/local/mock_mongo.go
+++ b/src/storage/dal/mongo/local/mock_mongo.go
@@ -456,6 +456,18 @@ func (c *MockCollection) DropColumn(ctx context.Context, field string) error {
 	return nil
 }
 
+// DropDocsColumn 根据条件移除字段
+func (c *MockCollection) DropDocsColumn(ctx context.Context, field string, filter dal.Filter) error {
+	key := "DROP_DOCS_COLUMN:" + c.collName + ":" + field
+	if retval, ok := c.cache[key]; ok {
+		return retval.Err
+	}
+	c.cache[key] = c.retval
+	c.retval = nil
+
+	return nil
+}
+
 func (c *MockCollection) AggregateAll(ctx context.Context, pipeline interface{}, result interface{}) error {
 	out, err := json.Marshal(pipeline)
 	if err != nil {


### PR DESCRIPTION
### 修复的问题：
- 将升级程序里的删除实例关系的updatgeflag字段改成分页删除，防止实例数据过多时DB io timeout
