### PR TITLE
全文检索新增对cc_SetBase和cc_ModuleBase的检索支持

### DIFF
--- a/scripts/init.py
+++ b/scripts/init.py
@@ -341,7 +341,9 @@ appSecret = $auth_app_secret
 
 [es]
 full_text_search = $full_text_search
-url=$es_url
+url = $es_url
+set = off
+module = off
 '''
 
     template = FileTemplate(topo_file_template_str)

--- a/src/common/find_common.go
+++ b/src/common/find_common.go
@@ -8,6 +8,8 @@ const (
 	TypeModel       = "model"
 	TypeProcess     = "process"
 	TypeApplication = "biz"
+	TypeSet         = "set"
+	TypeModule      = "module"
 
 	TypeAggName  = "type_agg"
 	TypeAggField = "_type"
@@ -20,6 +22,7 @@ const (
 
 var (
 	CmdbFindTypes = []string{BKTableNameBaseInst, BKTableNameBaseHost, BKTableNameObjDes}
+	EsBucketKeys  = []string{BKTableNameBaseHost, BKTableNameBaseApp}
 	SpecialChar   = []string{"`", "~", "!", "@", "#", "$", "%", "^", "&", "*",
 		"(", ")", "-", "_", "=", "+", "[", "{", "]", "}",
 		"\\", "|", ";", ":", "'", "\"", ",", "<", ".", ">", "/", "?"}

--- a/src/scene_server/topo_server/app/options/options.go
+++ b/src/scene_server/topo_server/app/options/options.go
@@ -30,8 +30,7 @@ type Config struct {
 	Mongo                mongo.Config
 	ConfigMap            map[string]string
 	Auth                 authcenter.AuthConfig
-	FullTextSearch       string `json:"es.full_text_search"`
-	EsUrl                string `json:"es.url"`
+	FullTextSearchCfg
 }
 
 func NewServerOption() *ServerOption {
@@ -47,4 +46,11 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ServConf.RegDiscover, "regdiscv", "", "hosts of register and discover server. e.g: 127.0.0.1:2181")
 	fs.StringVar(&s.ServConf.ExConfig, "config", "", "The config path. e.g conf/api.conf")
 	fs.Var(auth.EnableAuthFlag, "enable-auth", "The auth center enable status, true for enabled, false for disabled")
+}
+
+type FullTextSearchCfg struct {
+	FullTextSearch string `json:"es.full_text_search"`
+	EsUrl          string `json:"es.url"`
+	Set            string `json:"es.set"`
+	Module         string `json:"es.module"`
 }

--- a/src/scene_server/topo_server/app/server.go
+++ b/src/scene_server/topo_server/app/server.go
@@ -61,6 +61,8 @@ func (t *TopoServer) onTopoConfigUpdate(previous, current cc.ProcessConfig) {
 	t.Config.Mongo = mongo.ParseConfigFromKV("mongodb", current.ConfigMap)
 	t.Config.FullTextSearch = current.ConfigMap["es.full_text_search"]
 	t.Config.EsUrl = current.ConfigMap["es.url"]
+	t.Config.Set = current.ConfigMap["es.set"]
+	t.Config.Module = current.ConfigMap["es.module"]
 	t.Config.ConfigMap = current.ConfigMap
 	blog.Infof("the new cfg:%#v the origin cfg:%#v", t.Config, current.ConfigMap)
 
@@ -126,6 +128,14 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 			return fmt.Errorf("new es client failed, err: %v", err)
 		}
 		essrv.Client = esclient
+		if server.Config.Set == "on" {
+			common.CmdbFindTypes = append(common.CmdbFindTypes, common.BKTableNameBaseSet)
+			common.EsBucketKeys = append(common.EsBucketKeys, common.BKTableNameBaseSet)
+		}
+		if server.Config.Module == "on" {
+			common.CmdbFindTypes = append(common.CmdbFindTypes, common.BKTableNameBaseModule)
+			common.EsBucketKeys = append(common.EsBucketKeys, common.BKTableNameBaseModule)
+		}
 	}
 
 	authManager := extensions.NewAuthManager(engine.CoreAPI, authorize)

--- a/src/ui/src/views/index/children/search-input.vue
+++ b/src/ui/src/views/index/children/search-input.vue
@@ -38,6 +38,18 @@
                                     <span class="lenovo-name">{{item.source.bk_biz_name}}</span>
                                     <span>({{$t('业务')}})</span>
                                 </li>
+                                <li :key="index" v-else-if="item.type === 'set'"
+                                    :title="item.source.bk_inst_name"
+                                    @click="handleGoInstace(item.source)">
+                                    <span class="lenovo-name">{{item.source.bk_set_name}}</span>
+                                    <span>({{ $t('集群') }})</span>
+                                </li>
+                                <li :key="index" v-else-if="item.type === 'module'"
+                                    :title="item.source.bk_inst_name"
+                                    @click="handleGoInstace(item.source)">
+                                    <span class="lenovo-name">{{item.source.bk_module_name}}</span>
+                                    <span>({{ $t('模块') }})</span>
+                                </li>
                             </template>
                         </ul>
                     </div>


### PR DESCRIPTION
### 优化的功能:
- 全文检索增加cc_SetBase和cc_ModuleBase的检索支持。

todo，todo，todo：
1.后端：已实现从topo.conf进行配置。权限相关校验逻辑未实现。
2.前端：搜索到集群和模块后，需要支持跳转到相应业务拓扑界面。
