### PR TITLE
去掉gin自带的recovery中间件，不打印panic关键字

### DIFF
--- a/src/web_server/service/service.go
+++ b/src/web_server/service/service.go
@@ -44,7 +44,8 @@ type Service struct {
 
 func (s *Service) WebService() *gin.Engine {
 	setGinMode()
-	ws := gin.Default()
+	ws := gin.New()
+	ws.Use(gin.Logger())
 
 	ws.Use(middleware.RequestIDMiddleware)
 	ws.Use(sessions.Sessions(s.Config.Session.Name, s.Session))


### PR DESCRIPTION
### 优化的功能:
- 去掉gin自带的recovery中间件，不打印panic关键字
