### PR TITLE
修复excel导入数据里用户类型值为中英文时的正则校验失败和登陆版本获取错误的问题

### DIFF
--- a/src/web_server/service/host.go
+++ b/src/web_server/service/host.go
@@ -129,6 +129,7 @@ func (s *Service) ExportHost(c *gin.Context) {
 		blog.Errorf("ExportHost failed, get username map and property list failed, err: %+v, rid: %s", err, rid)
 		reply := getReturnStr(common.CCErrWebGetUsernameMapFail, defErr.Errorf(common.CCErrWebGetUsernameMapFail, objID).Error(), nil)
 		_, _ = c.Writer.Write([]byte(reply))
+		return
 	}
 
 	err = s.Logics.BuildHostExcelFromData(context.Background(), objID, fields, nil, hostInfo, file, header, &metadata.Metadata{}, usernameMap, propertyList)

--- a/src/web_server/service/util.go
+++ b/src/web_server/service/util.go
@@ -100,7 +100,7 @@ func (s *Service) getUsernameFromEsb(c *gin.Context, userList []string) (map[str
 		params := make(map[string]string)
 		params["exact_lookups"] = userListStr
 		params["fields"] = "username,display_name"
-		user := plugins.CurrentPlugin(c, s.Config.Version)
+		user := plugins.CurrentPlugin(c, s.Config.LoginVersion)
 
 		userListEsb, err := user.GetUserList(c, s.Config.ConfigMap)
 		if err != nil {


### PR DESCRIPTION
### 修复的问题：
- 修复excel导入数据里用户类型值为中英文时的正则校验失败
- 修复登陆版本获取错误的问题