### PR TITLE
excel导入主机问题修复

### DIFF
--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -845,6 +845,9 @@ const (
 
 	ExcelFirstColumnAssociationAttribute = "excel_association_attribute"
 	ExcelFirstColumnFieldDescription     = "excel_field_description"
+
+	// the value of ignored excel cell
+	ExcelCellIgnoreValue = "--"
 )
 
 const (

--- a/src/web_server/logics/excel_util.go
+++ b/src/web_server/logics/excel_util.go
@@ -79,6 +79,10 @@ func checkExcelHeader(ctx context.Context, sheet *xlsx.Sheet, fields map[string]
 	}
 	for index, name := range sheet.Rows[headerRow-1].Cells {
 		strName := name.Value
+		// skip the ignored cell field
+		if strName == common.ExcelCellIgnoreValue {
+			continue
+		}
 		field, ok := fields[strName]
 		if true == ok {
 			field.ExcelColIndex = index
@@ -92,8 +96,7 @@ func checkExcelHeader(ctx context.Context, sheet *xlsx.Sheet, fields map[string]
 	// excel three row  values  exceeding 1/2 does not appear in the field array,
 	// indicating that the third line of the excel template was deleted
 	if len(errCells) > len(sheet.Rows[headerRow-1].Cells)/2 && true == isCheckHeader {
-		// web_import_field_not_found
-		blog.Errorf(defLang.Languagef("web_import_field_not_found, rid: %s", strings.Join(errCells, ",")), rid)
+		blog.Errorf("err:%s, no found fields %s, rid:%s", defLang.Language("web_import_field_not_found"), strings.Join(errCells, ","), rid)
 		return ret, errors.New(defLang.Language("web_import_field_not_found"))
 	}
 	return ret, nil

--- a/src/web_server/logics/host.go
+++ b/src/web_server/logics/host.go
@@ -571,14 +571,17 @@ func (lgc *Logics) getExistHostsByInnerIPs(ctx context.Context, header http.Head
 	}
 
 	// step2. query host info by innerIPs
-	rules := make([]querybuilder.Rule, len(ipArr))
-	for index, innerIP := range ipArr {
+	innerIPs := make([]string, 0)
+	for _, innerIP := range ipArr {
 		innerIPArr := strings.Split(innerIP, ",")
-		rules[index] = querybuilder.AtomRule{
+		innerIPs = append(innerIPs, innerIPArr...)
+	}
+	rules := []querybuilder.Rule{
+		querybuilder.AtomRule{
 			Field:    common.BKHostInnerIPField,
 			Operator: querybuilder.OperatorIn,
-			Value:    innerIPArr,
-		}
+			Value:    innerIPs,
+		},
 	}
 
 	option := metadata.ListHostsWithNoBizParameter{

--- a/src/web_server/logics/util.go
+++ b/src/web_server/logics/util.go
@@ -200,6 +200,6 @@ func replaceEnName(rowMap mapstr.MapStr, usernameMap map[string]string, property
 // setExcelCellIgnore set the excel cell to be ignored
 func setExcelCellIgnored(sheet *xlsx.Sheet, style *xlsx.Style, row int, col int) {
 	cell := sheet.Cell(row, col)
-	cell.Value = "--"
+	cell.Value = common.ExcelCellIgnoreValue
 	cell.SetStyle(style)
 }


### PR DESCRIPTION
### 修复的问题：
- 修复在excel导入编辑少量主机字段时，没有忽略业务拓扑、业务名、云区域等字段值为'--'而导致报错的问题
- 修复因db查询超时导致导入1000台主机失败的问题