### PR TITLE
优化统计业务总数、主机总数和根据模型字段分组计数的接口

### DIFF
--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -199,6 +199,12 @@ const (
 
 	// BKDBAll matches arrays that contain all elements specified in the query.
 	BKDBAll = "$all"
+
+	// BKDBProject passes along the documents with the requested fields to the next stage in the pipeline
+	BKDBProject = "$project"
+
+	// BKDBSize counts and returns the total number of items in an array
+	BKDBSize = "$size"
 )
 
 const (

--- a/src/scene_server/admin_server/imports.go
+++ b/src/scene_server/admin_server/imports.go
@@ -117,4 +117,5 @@ import (
 	_ "configcenter/src/scene_server/admin_server/upgrader/y3.9.202011301723"
 	_ "configcenter/src/scene_server/admin_server/upgrader/y3.9.202012011450"
 	_ "configcenter/src/scene_server/admin_server/upgrader/y3.9.202101061721"
+	_ "configcenter/src/scene_server/admin_server/upgrader/y3.9.202102011055"
 )

--- a/src/scene_server/admin_server/upgrader/y3.9.202102011055/add_os_type_index.go
+++ b/src/scene_server/admin_server/upgrader/y3.9.202102011055/add_os_type_index.go
@@ -1,0 +1,40 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package y3_9_202102011055
+
+import (
+	"context"
+
+	"configcenter/src/common"
+	"configcenter/src/common/blog"
+	"configcenter/src/scene_server/admin_server/upgrader"
+	"configcenter/src/storage/dal"
+	"configcenter/src/storage/dal/types"
+)
+
+func addOsTypeIndex(ctx context.Context, db dal.RDB, conf *upgrader.Config) error {
+	index := types.Index{
+		Keys:       map[string]int32{"bk_os_type": 1},
+		Name:       "bk_os_type_1",
+		Unique:     false,
+		Background: true,
+	}
+
+	err := db.Table(common.BKTableNameBaseHost).CreateIndex(ctx, index)
+	if err != nil {
+		blog.ErrorJSON("add index %s for table %s failed, err:%s", index, common.BKTableNameBaseHost, err)
+		return err
+	}
+
+	return nil
+}

--- a/src/scene_server/admin_server/upgrader/y3.9.202102011055/pkg.go
+++ b/src/scene_server/admin_server/upgrader/y3.9.202102011055/pkg.go
@@ -29,7 +29,7 @@ func upgrade(ctx context.Context, db dal.RDB, conf *upgrader.Config) (err error)
 
 	err = addOsTypeIndex(ctx, db, conf)
 	if err != nil {
-		blog.Errorf("[upgrade y3.9.202102011055] addCloudIDIndex failed, error  %s", err.Error())
+		blog.Errorf("[upgrade y3.9.202102011055] addOsTypeIndex failed, error  %s", err.Error())
 		return err
 	}
 

--- a/src/scene_server/admin_server/upgrader/y3.9.202102011055/pkg.go
+++ b/src/scene_server/admin_server/upgrader/y3.9.202102011055/pkg.go
@@ -1,0 +1,37 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package y3_9_202102011055
+
+import (
+	"context"
+
+	"configcenter/src/common/blog"
+	"configcenter/src/scene_server/admin_server/upgrader"
+	"configcenter/src/storage/dal"
+)
+
+func init() {
+	upgrader.RegistUpgrader("y3.9.202102011055", upgrade)
+}
+
+func upgrade(ctx context.Context, db dal.RDB, conf *upgrader.Config) (err error) {
+	blog.Infof("start execute y3.9.202102011055")
+
+	err = addOsTypeIndex(ctx, db, conf)
+	if err != nil {
+		blog.Errorf("[upgrade y3.9.202102011055] addCloudIDIndex failed, error  %s", err.Error())
+		return err
+	}
+
+	return nil
+}

--- a/src/source_controller/coreservice/core/operation/operation.go
+++ b/src/source_controller/coreservice/core/operation/operation.go
@@ -74,13 +74,26 @@ func (m *operationManager) CommonModelStatistic(kit *rest.Kit, inputParam metada
 	filterCondition := fmt.Sprintf("$%s", inputParam.Field)
 
 	if inputParam.ObjID == common.BKInnerObjIDHost {
-		pipeline := []M{{common.BKDBGroup: M{"_id": filterCondition, "count": M{common.BKDBSum: 1}}}}
+		pipeline := []M{
+			{common.BKDBMatch: M{common.BKDBAND: []M{
+				{inputParam.Field: M{common.BKDBExists: true}},
+				{inputParam.Field: M{common.BKDBNE: nil}},
+			}}},
+			{common.BKDBGroup: M{"_id": filterCondition, "count": M{common.BKDBSum: 1}}},
+		}
 		if err := mongodb.Client().Table(common.BKTableNameBaseHost).AggregateAll(kit.Ctx, pipeline, &commonCount); err != nil {
 			blog.Errorf("host os type count aggregate fail, chartName: %v, err: %v, rid: %v", inputParam.Name, err, kit.Rid)
 			return nil, err
 		}
 	} else {
-		pipeline := []M{{common.BKDBMatch: M{common.BKObjIDField: inputParam.ObjID}}, {common.BKDBGroup: M{"_id": filterCondition, "count": M{common.BKDBSum: 1}}}}
+		pipeline := []M{
+			{common.BKDBMatch: M{common.BKDBAND: []M{
+				{inputParam.Field: M{common.BKDBExists: true}},
+				{inputParam.Field: M{common.BKDBNE: nil}},
+				{common.BKDBMatch: M{common.BKObjIDField: inputParam.ObjID}},
+			}}},
+			{common.BKDBGroup: M{"_id": filterCondition, "count": M{common.BKDBSum: 1}}},
+		}
 		if err := mongodb.Client().Table(common.BKTableNameBaseInst).AggregateAll(kit.Ctx, pipeline, &commonCount); err != nil {
 			blog.Errorf("model's instance count aggregate fail, chartName: %v, ObjID: %v, err: %v, rid: %v", inputParam.Name, inputParam.ObjID, err, kit.Rid)
 			return nil, err

--- a/src/source_controller/coreservice/core/operation/operation.go
+++ b/src/source_controller/coreservice/core/operation/operation.go
@@ -70,58 +70,45 @@ func (m *operationManager) SearchChartData(kit *rest.Kit, inputParam metadata.Ch
 }
 
 func (m *operationManager) CommonModelStatistic(kit *rest.Kit, inputParam metadata.ChartConfig) (interface{}, error) {
-	commonCount := make([]metadata.StringIDCount, 0)
-	filterCondition := fmt.Sprintf("$%s", inputParam.Field)
-
-	if inputParam.ObjID == common.BKInnerObjIDHost {
-		pipeline := []M{
-			{common.BKDBMatch: M{common.BKDBAND: []M{
-				{inputParam.Field: M{common.BKDBExists: true}},
-				{inputParam.Field: M{common.BKDBNE: nil}},
-			}}},
-			{common.BKDBGroup: M{"_id": filterCondition, "count": M{common.BKDBSum: 1}}},
-		}
-		if err := mongodb.Client().Table(common.BKTableNameBaseHost).AggregateAll(kit.Ctx, pipeline, &commonCount); err != nil {
-			blog.Errorf("host os type count aggregate fail, chartName: %v, err: %v, rid: %v", inputParam.Name, err, kit.Rid)
-			return nil, err
-		}
-	} else {
-		pipeline := []M{
-			{common.BKDBMatch: M{common.BKDBAND: []M{
-				{inputParam.Field: M{common.BKDBExists: true}},
-				{inputParam.Field: M{common.BKDBNE: nil}},
-				{common.BKDBMatch: M{common.BKObjIDField: inputParam.ObjID}},
-			}}},
-			{common.BKDBGroup: M{"_id": filterCondition, "count": M{common.BKDBSum: 1}}},
-		}
-		if err := mongodb.Client().Table(common.BKTableNameBaseInst).AggregateAll(kit.Ctx, pipeline, &commonCount); err != nil {
-			blog.Errorf("model's instance count aggregate fail, chartName: %v, ObjID: %v, err: %v, rid: %v", inputParam.Name, inputParam.ObjID, err, kit.Rid)
-			return nil, err
-		}
-	}
-
+	// get enum options by model's field
 	attribute := metadata.Attribute{}
 	opt := map[string]interface{}{}
 	opt[common.BKObjIDField] = inputParam.ObjID
 	opt[common.BKPropertyIDField] = inputParam.Field
 	if err := mongodb.Client().Table(common.BKTableNameObjAttDes).Find(opt).One(kit.Ctx, &attribute); err != nil {
-		blog.Errorf("model's instance count aggregate fail, chartName: %v, objID: %v, err: %v, rid: %v", inputParam.Name, inputParam.ObjID, err, kit.Rid)
+		blog.Errorf("model's instance count aggregate failed, chartName: %v, objID: %v, err: %v, rid: %v", inputParam.Name, inputParam.ObjID, err, kit.Rid)
 		return nil, err
 	}
 
+	option, err := metadata.ParseEnumOption(kit.Ctx, attribute.Option)
+	if err != nil {
+		blog.Errorf("count model's instance, parse enum option fail, ObjID: %v, err:%v, rid: %v", inputParam.ObjID, err, kit.Rid)
+		return nil, err
+	}
+
+	// get model instances' count group by its field
+	// eg: get host count group by bk_os_type
+	groupCountArr := make([]metadata.StringIDCount, 0)
+	filterCondition := fmt.Sprintf("$%s", inputParam.Field)
 	instCount := uint64(0)
 	cond := M{}
 	var countErr error
 	if inputParam.ObjID == common.BKInnerObjIDHost {
 		instCount, countErr = mongodb.Client().Table(common.BKTableNameBaseHost).Find(cond).Count(kit.Ctx)
 		if countErr != nil {
-			blog.Errorf("host os type count aggregate fail, chartName: %v, err: %v, rid: %v", inputParam.Name, countErr, kit.Rid)
+			blog.Errorf("model's instance count aggregate failed, chartName: %v, err: %v, rid: %v", inputParam.Name, countErr, kit.Rid)
 			return nil, countErr
 		}
 		if instCount > 0 {
-			pipeline := []M{{"$group": M{"_id": filterCondition, "count": M{"$sum": 1}}}}
-			if err := mongodb.Client().Table(common.BKTableNameBaseHost).AggregateAll(kit.Ctx, pipeline, &commonCount); err != nil {
-				blog.Errorf("host os type count aggregate fail, chartName: %v, err: %v, rid: %v", inputParam.Name, err, kit.Rid)
+			pipeline := []M{
+				{common.BKDBMatch: M{common.BKDBAND: []M{
+					{inputParam.Field: M{common.BKDBExists: true}},
+					{inputParam.Field: M{common.BKDBNE: nil}},
+				}}},
+				{common.BKDBGroup: M{"_id": filterCondition, "count": M{common.BKDBSum: 1}}},
+			}
+			if err := mongodb.Client().Table(common.BKTableNameBaseHost).AggregateAll(kit.Ctx, pipeline, &groupCountArr); err != nil {
+				blog.Errorf("model's instance count aggregate failed, chartName: %v, err: %v, rid: %v", inputParam.Name, err, kit.Rid)
 				return nil, err
 			}
 		}
@@ -132,35 +119,43 @@ func (m *operationManager) CommonModelStatistic(kit *rest.Kit, inputParam metada
 			return nil, countErr
 		}
 		if instCount > 0 {
-			pipeline := []M{{"$match": M{"bk_obj_id": inputParam.ObjID}}, {"$group": M{"_id": filterCondition, "count": M{"$sum": 1}}}}
-			if err := mongodb.Client().Table(common.BKTableNameBaseInst).AggregateAll(kit.Ctx, pipeline, &commonCount); err != nil {
-				blog.Errorf("model's instance count aggregate fail, chartName: %v, ObjID: %v, err: %v, rid: %v", inputParam.Name, inputParam.ObjID, err, kit.Rid)
+			pipeline := []M{
+				{common.BKDBMatch: M{common.BKDBAND: []M{
+					{inputParam.Field: M{common.BKDBExists: true}},
+					{inputParam.Field: M{common.BKDBNE: nil}},
+					{common.BKDBMatch: M{common.BKObjIDField: inputParam.ObjID}},
+				}}},
+				{common.BKDBGroup: M{"_id": filterCondition, "count": M{common.BKDBSum: 1}}},
+			}
+			if err := mongodb.Client().Table(common.BKTableNameBaseInst).AggregateAll(kit.Ctx, pipeline, &groupCountArr); err != nil {
+				blog.Errorf("model's instance count aggregate failed, chartName: %v, ObjID: %v, err: %v, rid: %v", inputParam.Name, inputParam.ObjID, err, kit.Rid)
 				return nil, err
 			}
 		}
 	}
 
-	option, err := metadata.ParseEnumOption(kit.Ctx, attribute.Option)
-	if err != nil {
-		blog.Errorf("count model's instance, parse enum option fail, ObjID: %v, err:%v, rid: %v", inputParam.ObjID, err, kit.Rid)
-		return nil, err
+	if len(groupCountArr) == 0 {
+		return []metadata.StringIDCount{}, nil
+	}
+
+	groupCountMap := make(map[string]int64)
+	for _, groupCount := range groupCountArr {
+		groupCountMap[groupCount.ID] = groupCount.Count
 	}
 
 	respData := make([]metadata.StringIDCount, 0)
 	for _, opt := range option {
-		info := metadata.StringIDCount{
+		if opt.Name == common.OptionOther {
+			respData = append(respData, metadata.StringIDCount{
+				ID:    opt.Name,
+				Count: groupCountMap[""],
+			})
+			continue
+		}
+		respData = append(respData, metadata.StringIDCount{
 			ID:    opt.Name,
-			Count: 0,
-		}
-		for _, count := range commonCount {
-			if count.ID == opt.ID {
-				info.Count = count.Count
-			}
-			if opt.Name == common.OptionOther && count.ID == "" {
-				info.Count = count.Count
-			}
-		}
-		respData = append(respData, info)
+			Count: groupCountMap[opt.ID],
+		})
 	}
 
 	return respData, nil

--- a/src/source_controller/coreservice/core/operation/operation.go
+++ b/src/source_controller/coreservice/core/operation/operation.go
@@ -89,7 +89,7 @@ func (m *operationManager) CommonModelStatistic(kit *rest.Kit, inputParam metada
 	// get model instances' count group by its field
 	// eg: get host count group by bk_os_type
 	groupCountArr := make([]metadata.StringIDCount, 0)
-	filterCondition := fmt.Sprintf("$%s", inputParam.Field)
+	groupField := fmt.Sprintf("$%s", inputParam.Field)
 	instCount := uint64(0)
 	cond := M{}
 	var countErr error
@@ -105,7 +105,7 @@ func (m *operationManager) CommonModelStatistic(kit *rest.Kit, inputParam metada
 					{inputParam.Field: M{common.BKDBExists: true}},
 					{inputParam.Field: M{common.BKDBNE: nil}},
 				}}},
-				{common.BKDBGroup: M{"_id": filterCondition, "count": M{common.BKDBSum: 1}}},
+				{common.BKDBGroup: M{"_id": groupField, "count": M{common.BKDBSum: 1}}},
 			}
 			if err := mongodb.Client().Table(common.BKTableNameBaseHost).AggregateAll(kit.Ctx, pipeline, &groupCountArr); err != nil {
 				blog.Errorf("model's instance count aggregate failed, chartName: %v, err: %v, rid: %v", inputParam.Name, err, kit.Rid)
@@ -125,7 +125,7 @@ func (m *operationManager) CommonModelStatistic(kit *rest.Kit, inputParam metada
 					{inputParam.Field: M{common.BKDBNE: nil}},
 					{common.BKDBMatch: M{common.BKObjIDField: inputParam.ObjID}},
 				}}},
-				{common.BKDBGroup: M{"_id": filterCondition, "count": M{common.BKDBSum: 1}}},
+				{common.BKDBGroup: M{"_id": groupField, "count": M{common.BKDBSum: 1}}},
 			}
 			if err := mongodb.Client().Table(common.BKTableNameBaseInst).AggregateAll(kit.Ctx, pipeline, &groupCountArr); err != nil {
 				blog.Errorf("model's instance count aggregate failed, chartName: %v, ObjID: %v, err: %v, rid: %v", inputParam.Name, inputParam.ObjID, err, kit.Rid)


### PR DESCRIPTION
### 优化的功能:
- 优化统计业务总数、主机总数的接口
- 优化根据模型字段分组计数的接口

### 修复的问题:
- 修复统计各业务下主机数量不对的问题

close #issue 5047

### 接口优化情况

#### 测试场景
数据库里有业务数1966，主机数569694，在6核16G的mac下测试

#### 统计业务总数和主机总数接口
原耗时324秒；优化后耗时1秒

#### 统计各个业务下的主机数量接口
原耗时5秒；优化后耗时1秒

#### 统计不同操作系统下的主机数量接口
原耗时3秒；优化后耗时0.3秒