### PR TITLE
添加根据实例名模糊查询模型实例名称列表的接口

### DIFF
--- a/src/ac/parser/topolatest.go
+++ b/src/ac/parser/topolatest.go
@@ -810,6 +810,7 @@ var (
 	findObjectInstanceSubTopologyLatestRegexp = regexp.MustCompile(`^/api/v3/find/insttopo/object/[^\s/]+/inst/[0-9]+/?$`)
 	findObjectInstanceTopologyLatestRegexp    = regexp.MustCompile(`^/api/v3/find/instassttopo/object/[^\s/]+/inst/[0-9]+/?$`)
 	findObjectInstancesLatestRegexp           = regexp.MustCompile(`^/api/v3/find/instance/object/[^\s/]+/?$`)
+	findObjectInstancesNamesRegexp            = regexp.MustCompile(`^/api/v3/findmany/object/instances/names/?$`)
 )
 
 func (ps *parseStream) objectInstanceLatest() *parseStream {
@@ -1097,6 +1098,24 @@ func (ps *parseStream) objectInstanceLatest() *parseStream {
 	if ps.hitRegexp(findObjectInstancesLatestRegexp, http.MethodPost) {
 		if len(ps.RequestCtx.Elements) != 6 {
 			ps.err = errors.New("find object's instance list, but got invalid url")
+			return ps
+		}
+
+		ps.Attribute.Resources = []meta.ResourceAttribute{
+			{
+				Basic: meta.Basic{
+					Type:   meta.ModelInstance,
+					Action: meta.SkipAction,
+				},
+			},
+		}
+		return ps
+	}
+
+	// find object instances' brief info
+	if ps.hitRegexp(findObjectInstancesNamesRegexp, http.MethodPost) {
+		if len(ps.RequestCtx.Elements) != 6 {
+			ps.err = errors.New("find object instances' brief info, but got invalid url")
 			return ps
 		}
 

--- a/src/apimachinery/toposerver/inst/api.go
+++ b/src/apimachinery/toposerver/inst/api.go
@@ -59,6 +59,7 @@ type InstanceInterface interface {
 	UpdateSet(ctx context.Context, appID string, setID string, h http.Header, dat map[string]interface{}) (resp *metadata.Response, err error)
 	SearchSet(ctx context.Context, ownerID string, appID string, h http.Header, s *params.SearchParams) (resp *metadata.SearchInstResult, err error)
 	SearchSetBatch(ctx context.Context, appID string, h http.Header, s *metadata.SearchInstBatchOption) (resp *metadata.MapArrayResponse, err error)
+	SearchInstsNames(ctx context.Context, h http.Header, s *metadata.SearchInstsNamesOption) (resp *metadata.ArrayResponse, err error)
 }
 
 type instanceClient struct {

--- a/src/apimachinery/toposerver/inst/inst.go
+++ b/src/apimachinery/toposerver/inst/inst.go
@@ -159,3 +159,17 @@ func (t *instanceClient) SelectAssociationTopo(ctx context.Context, ownerID stri
 		Into(resp)
 	return
 }
+
+func (t *instanceClient) SearchInstsNames(ctx context.Context, h http.Header, s *metadata.SearchInstsNamesOption) (resp *metadata.ArrayResponse, err error) {
+	resp = new(metadata.ArrayResponse)
+	subPath := "/findmany/object/instances/names"
+
+	err = t.client.Post().
+		WithContext(ctx).
+		Body(s).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+	return
+}

--- a/src/common/metadata/inst.go
+++ b/src/common/metadata/inst.go
@@ -16,6 +16,8 @@ import (
 	"encoding/json"
 	"sort"
 
+	"configcenter/src/common"
+	"configcenter/src/common/errors"
 	"configcenter/src/common/util"
 )
 
@@ -178,4 +180,42 @@ type SearchHostIdentifierResult struct {
 type SearchHostIdentifierData struct {
 	Count int              `json:"count"`
 	Info  []HostIdentifier `json:"info"`
+}
+
+// SearchInstsNamesOption search instances names option
+type SearchInstsNamesOption struct {
+	ObjID string `json:"bk_obj_id"`
+	BizID int64  `json:"bk_biz_id"`
+	Name  string `json:"name"`
+}
+
+var ObjsForSearchName = map[string]bool{
+	common.BKInnerObjIDSet:    true,
+	common.BKInnerObjIDModule: true,
+}
+
+// Validate verify the SearchInstsNamesOption
+func (o *SearchInstsNamesOption) Validate() (rawError errors.RawErrorInfo) {
+	if _, ok := ObjsForSearchName[o.ObjID]; !ok {
+		return errors.RawErrorInfo{
+			ErrCode: common.CCErrCommParamsInvalid,
+			Args:    []interface{}{"bk_obj_id"},
+		}
+	}
+
+	if o.BizID <= 0 {
+		return errors.RawErrorInfo{
+			ErrCode: common.CCErrCommParamsInvalid,
+			Args:    []interface{}{"bk_biz_id"},
+		}
+	}
+
+	if o.Name == "" {
+		return errors.RawErrorInfo{
+			ErrCode: common.CCErrCommParamsInvalid,
+			Args:    []interface{}{"name"},
+		}
+	}
+
+	return errors.RawErrorInfo{}
 }

--- a/src/scene_server/topo_server/service/service_business_initfunc.go
+++ b/src/scene_server/topo_server/service/service_business_initfunc.go
@@ -169,6 +169,7 @@ func (s *Service) initBusinessInst(web *restful.WebService) {
 	utility.AddHandler(rest.Action{Verb: http.MethodPut, Path: "/updatemany/instance/object/{bk_obj_id}", Handler: s.UpdateInsts})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/instance/object/{bk_obj_id}", Handler: s.SearchInstAndAssociationDetail})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/instdetail/object/{bk_obj_id}/inst/{inst_id}", Handler: s.SearchInstByInstID})
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/findmany/object/instances/names", Handler: s.SearchInstsNames})
 
 	utility.AddToRestfulWebService(web)
 }

--- a/src/test/topo_server/object_test.go
+++ b/src/test/topo_server/object_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"configcenter/src/common"
 	"configcenter/src/common/mapstr"
 	"configcenter/src/common/metadata"
 	params "configcenter/src/common/paraparse"
@@ -1344,6 +1345,24 @@ var _ = Describe("object test", func() {
 			bizIdRes, err := commonutil.GetInt64ByInterface(rsp.Data.Info[rsp.Data.Count-1]["bk_biz_id"])
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bizIdRes).To(Equal(bizIdInt))
+		})
+
+		It("search object instances names info", func() {
+			bizIDInt, _ := strconv.ParseInt(bizId, 10, 64)
+			input := &metadata.SearchInstsNamesOption{
+				ObjID: common.BKInnerObjIDSet,
+				BizID: bizIDInt,
+				Name:  "test",
+			}
+			rsp, err := instClient.SearchInstsNames(context.Background(), header, input)
+			util.RegisterResponse(rsp)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rsp.Result).To(Equal(true))
+			nameMap := make(map[string]bool)
+			for _, name := range rsp.Data {
+				nameMap[commonutil.GetStrByInterface(name)] = true
+			}
+			Expect(nameMap["new_test"]).To(Equal(true))
 		})
 
 		It("search set batch", func() {


### PR DESCRIPTION
### 新加的功能:
- 添加根据实例名模糊查询模型实例名称列表的接口

close issue #5050
