### PR TITLE
修复添加模型的业务ID查询条件直接覆盖or条件的问题

### DIFF
--- a/src/common/util/model.go
+++ b/src/common/util/model.go
@@ -19,18 +19,35 @@ import (
 
 // AddModelBizIDConditon add model bizID condition according to bizID value
 func AddModelBizIDConditon(cond mapstr.MapStr, modelBizID int64) {
+	var modelBizIDOrCondArr []mapstr.MapStr
 	if modelBizID > 0 {
 		// special business model and global shared model
-		cond[common.BKDBOR] = []mapstr.MapStr{
+		modelBizIDOrCondArr = []mapstr.MapStr{
 			{common.BKAppIDField: modelBizID},
 			{common.BKAppIDField: 0},
 			{common.BKAppIDField: mapstr.MapStr{common.BKDBExists: false}},
 		}
 	} else {
 		// global shared model
-		cond[common.BKDBOR] = []mapstr.MapStr{
+		modelBizIDOrCondArr = []mapstr.MapStr{
 			{common.BKAppIDField: 0},
 			{common.BKAppIDField: mapstr.MapStr{common.BKDBExists: false}},
+		}
+	}
+
+	if orCond, exists := cond[common.BKDBOR]; !exists {
+		cond[common.BKDBOR] = modelBizIDOrCondArr
+	} else {
+		andCondArr := []map[string]interface{}{
+			{common.BKDBOR: orCond},
+			{common.BKDBOR: modelBizIDOrCondArr},
+		}
+
+		andCond, exists := cond[common.BKDBAND]
+		if !exists {
+			cond[common.BKDBAND] = andCondArr
+		} else {
+			cond[common.BKDBAND] = append(andCondArr, map[string]interface{}{common.BKDBAND: andCond})
 		}
 	}
 	delete(cond, common.BKAppIDField)


### PR DESCRIPTION
### 修复的问题
- 修复查询模型属性接口在查询属性相关的分组时使用了or条件，被后续推荐业务ID查询条件覆盖的问题
