### PR TITLE
修复当主机有关联主线模型实例时，导出主机失败的问题

### DIFF
--- a/src/ac/parser/topolatest.go
+++ b/src/ac/parser/topolatest.go
@@ -810,6 +810,7 @@ var (
 	findObjectInstanceSubTopologyLatestRegexp = regexp.MustCompile(`^/api/v3/find/insttopo/object/[^\s/]+/inst/[0-9]+/?$`)
 	findObjectInstanceTopologyLatestRegexp    = regexp.MustCompile(`^/api/v3/find/instassttopo/object/[^\s/]+/inst/[0-9]+/?$`)
 	findObjectInstancesLatestRegexp           = regexp.MustCompile(`^/api/v3/find/instance/object/[^\s/]+/?$`)
+	findObjectInstancesUniqueFieldsRegexp     = regexp.MustCompile(`^/api/v3/find/instance/object/[^\s/]+/unique_fields/?$`)
 	findObjectInstancesNamesRegexp            = regexp.MustCompile(`^/api/v3/findmany/object/instances/names/?$`)
 )
 
@@ -1098,6 +1099,24 @@ func (ps *parseStream) objectInstanceLatest() *parseStream {
 	if ps.hitRegexp(findObjectInstancesLatestRegexp, http.MethodPost) {
 		if len(ps.RequestCtx.Elements) != 6 {
 			ps.err = errors.New("find object's instance list, but got invalid url")
+			return ps
+		}
+
+		ps.Attribute.Resources = []meta.ResourceAttribute{
+			{
+				Basic: meta.Basic{
+					Type:   meta.ModelInstance,
+					Action: meta.SkipAction,
+				},
+			},
+		}
+		return ps
+	}
+
+	// find object's instances' unique fields operation
+	if ps.hitRegexp(findObjectInstancesUniqueFieldsRegexp, http.MethodPost) {
+		if len(ps.RequestCtx.Elements) != 7 {
+			ps.err = errors.New("find object's instances' unique fields, but got invalid url")
 			return ps
 		}
 

--- a/src/apimachinery/apiserver/api.go
+++ b/src/apimachinery/apiserver/api.go
@@ -84,6 +84,20 @@ func (a *apiServer) GetInstDetail(ctx context.Context, h http.Header, objID stri
 	return
 }
 
+func (a *apiServer) GetInstUniqueFields(ctx context.Context, h http.Header, objID string, params mapstr.MapStr) (resp *metadata.QueryInstResult, err error) {
+
+	resp = new(metadata.QueryInstResult)
+	subPath := "/find/instance/object/%s/unique_fields"
+	err = a.client.Post().
+		WithContext(ctx).
+		Body(params).
+		SubResourcef(subPath, objID).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+	return
+}
+
 func (a *apiServer) CreateObjectAtt(ctx context.Context, h http.Header, obj *metadata.ObjAttDes) (resp *metadata.Response, err error) {
 	resp = new(metadata.Response)
 	subPath := "/create/objectattr"

--- a/src/apimachinery/apiserver/apiserver.go
+++ b/src/apimachinery/apiserver/apiserver.go
@@ -33,6 +33,7 @@ type ApiServerClientInterface interface {
 	SearchDefaultApp(ctx context.Context, h http.Header, ownerID string) (resp *metadata.QueryInstResult, err error)
 	GetObjectData(ctx context.Context, h http.Header, params mapstr.MapStr) (resp *metadata.ObjectAttrBatchResult, err error)
 	GetInstDetail(ctx context.Context, h http.Header, objID string, params mapstr.MapStr) (resp *metadata.QueryInstResult, err error)
+	GetInstUniqueFields(ctx context.Context, h http.Header, objID string, params mapstr.MapStr) (resp *metadata.QueryInstResult, err error)
 	CreateObjectAtt(ctx context.Context, h http.Header, obj *metadata.ObjAttDes) (resp *metadata.Response, err error)
 	UpdateObjectAtt(ctx context.Context, objID string, h http.Header, data map[string]interface{}) (resp *metadata.Response, err error)
 	DeleteObjectAtt(ctx context.Context, objID string, h http.Header) (resp *metadata.Response, err error)

--- a/src/scene_server/topo_server/service/inst.go
+++ b/src/scene_server/topo_server/service/inst.go
@@ -530,12 +530,12 @@ func (s *Service) SearchInstUniqueFields(ctx *rest.Contexts) {
 	}
 	uniqueResp, err := s.Engine.CoreAPI.CoreService().Model().ReadModelAttrUnique(ctx.Kit.Ctx, ctx.Kit.Header, metadata.QueryCondition{Condition: cond})
 	if err != nil {
-		blog.Errorf("search model unique failed, cond: %s, error: %s, rid: %s", cond, err.Error(), ctx.Kit.Rid)
+		blog.ErrorJSON("search model unique failed, cond: %s, error: %s, rid: %s", cond, err.Error(), ctx.Kit.Rid)
 		ctx.RespAutoError(ctx.Kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed))
 		return
 	}
 	if !uniqueResp.Result {
-		blog.Errorf("search model unique failed, cond: %s, error message: %s, rid: %s", cond, uniqueResp.ErrMsg, ctx.Kit.Rid)
+		blog.ErrorJSON("search model unique failed, cond: %s, error message: %s, rid: %s", cond, uniqueResp.ErrMsg, ctx.Kit.Rid)
 		ctx.RespAutoError(uniqueResp.Error())
 		return
 	}
@@ -558,17 +558,17 @@ func (s *Service) SearchInstUniqueFields(ctx *rest.Contexts) {
 	}
 	attrResp, err := s.Engine.CoreAPI.CoreService().Model().ReadModelAttr(ctx.Kit.Ctx, ctx.Kit.Header, objID, &metadata.QueryCondition{Condition: cond})
 	if err != nil {
-		blog.Errorf("search model attribute failed, cond: %s, error: %s, rid: %s", cond, err.Error(), ctx.Kit.Rid)
+		blog.ErrorJSON("search model attribute failed, cond: %s, error: %s, rid: %s", cond, err.Error(), ctx.Kit.Rid)
 		ctx.RespAutoError(ctx.Kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed))
 		return
 	}
 	if !attrResp.Result {
-		blog.Errorf("search model attribute failed, cond: %s, error message: %s, rid: %s", cond, attrResp.ErrMsg, ctx.Kit.Rid)
+		blog.ErrorJSON("search model attribute failed, cond: %s, error message: %s, rid: %s", cond, attrResp.ErrMsg, ctx.Kit.Rid)
 		ctx.RespAutoError(attrResp.Error())
 		return
 	}
 	if attrResp.Data.Count <= 0 {
-		blog.Errorf("unique model attribute count illegal, cond: %s, rid: %s", cond, ctx.Kit.Rid)
+		blog.ErrorJSON("unique model attribute count illegal, cond: %s, rid: %s", cond, ctx.Kit.Rid)
 		ctx.RespAutoError(ctx.Kit.CCError.Error(common.CCErrTopoObjectUniqueSearchFailed))
 		return
 	}
@@ -579,22 +579,18 @@ func (s *Service) SearchInstUniqueFields(ctx *rest.Contexts) {
 		keys = append(keys, attr.PropertyID)
 	}
 
-	data := struct {
-		paraparse.SearchParams `json:",inline"`
-	}{}
-	if err := ctx.DecodeInto(&data); nil != err {
+	// construct the query inst condition
+	queryCond := new(paraparse.SearchParams)
+	if err := ctx.DecodeInto(queryCond); nil != err {
 		ctx.RespAutoError(err)
 		return
 	}
-
-	// construct the query inst condition
-	queryCond := data.SearchParams
 	if queryCond.Condition == nil {
 		queryCond.Condition = mapstr.New()
 	}
 	page := metadata.ParsePage(queryCond.Page)
 
-	query := &metadata.QueryInput{}
+	query := new(metadata.QueryInput)
 	query.Condition = queryCond.Condition
 	// just get the unique fields
 	query.Fields = strings.Join(keys, ",")

--- a/src/scene_server/topo_server/service/service_business_initfunc.go
+++ b/src/scene_server/topo_server/service/service_business_initfunc.go
@@ -168,6 +168,7 @@ func (s *Service) initBusinessInst(web *restful.WebService) {
 	utility.AddHandler(rest.Action{Verb: http.MethodPut, Path: "/update/instance/object/{bk_obj_id}/inst/{inst_id}", Handler: s.UpdateInst})
 	utility.AddHandler(rest.Action{Verb: http.MethodPut, Path: "/updatemany/instance/object/{bk_obj_id}", Handler: s.UpdateInsts})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/instance/object/{bk_obj_id}", Handler: s.SearchInstAndAssociationDetail})
+	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/instance/object/{bk_obj_id}/unique_fields", Handler: s.SearchInstUniqueFields})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/instdetail/object/{bk_obj_id}/inst/{inst_id}", Handler: s.SearchInstByInstID})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/findmany/object/instances/names", Handler: s.SearchInstsNames})
 

--- a/src/web_server/logics/association.go
+++ b/src/web_server/logics/association.go
@@ -21,7 +21,6 @@ import (
 	"configcenter/src/common/condition"
 	"configcenter/src/common/mapstr"
 	"configcenter/src/common/metadata"
-	"configcenter/src/common/querybuilder"
 	"configcenter/src/common/util"
 )
 
@@ -114,58 +113,25 @@ func (lgc *Logics) fetchInstAssocationData(ctx context.Context, header http.Head
 	dbFields = append(dbFields, instIDKey)
 
 	insts := make([]mapstr.MapStr, 0)
-	switch objID {
-	case common.BKInnerObjIDHost:
-		option := metadata.ListHostsWithNoBizParameter{
-			HostPropertyFilter: &querybuilder.QueryFilter{
-				Rule: querybuilder.CombinedRule{
-					Condition: querybuilder.ConditionOr,
-					Rules: []querybuilder.Rule{
-						querybuilder.AtomRule{
-							Field:    common.BKHostIDField,
-							Operator: querybuilder.OperatorIn,
-							Value:    instIDArr,
-						},
-					},
-				},
+	option := mapstr.MapStr{
+		"condition": mapstr.MapStr{
+			instIDKey: mapstr.MapStr{
+				common.BKDBIN: instIDArr,
 			},
-			Fields: dbFields,
-		}
-
-		resp, err := lgc.CoreAPI.ApiServer().ListHostWithoutApp(ctx, header, option)
-		if err != nil {
-			blog.ErrorJSON(" fetchInstAssocationData failed, ListHostWithoutApp err:%s, option: %s, rid: %s", err, option, rid)
-			return nil, ccErr.CCError(common.CCErrCommHTTPDoRequestFailed)
-		}
-		if !resp.Result {
-			blog.ErrorJSON(" fetchInstAssocationData failed, ListHostWithoutApp resp:%s, option: %s, rid: %s", resp, option, rid)
-			return nil, resp.CCError()
-		}
-
-		for _, inst := range resp.Data.Info {
-			insts = append(insts, mapstr.NewFromMap(inst))
-		}
-	default:
-		option := mapstr.MapStr{
-			"condition": mapstr.MapStr{
-				instIDKey: mapstr.MapStr{
-					common.BKDBIN: instIDArr,
-				},
-			},
-			"fields": dbFields,
-		}
-
-		resp, err := lgc.CoreAPI.ApiServer().GetInstDetail(ctx, header, objID, option)
-		if err != nil {
-			blog.ErrorJSON(" fetchInstAssocationData failed, GetInstDetail err:%v, option: %s, rid: %s", err, option, rid)
-			return nil, ccErr.Error(common.CCErrCommHTTPDoRequestFailed)
-		}
-		if !resp.Result {
-			blog.ErrorJSON(" fetchInstAssocationData failed, GetInstDetail resp:%s, option: %s, rid: %s", resp, option, rid)
-			return nil, resp.CCError()
-		}
-		insts = resp.Data.Info
+		},
+		"fields": dbFields,
 	}
+
+	resp, err := lgc.CoreAPI.ApiServer().GetInstUniqueFields(ctx, header, objID, option)
+	if err != nil {
+		blog.ErrorJSON(" fetchInstAssocationData failed, GetInstUniqueFields err:%v, option: %s, rid: %s", err, option, rid)
+		return nil, ccErr.Error(common.CCErrCommHTTPDoRequestFailed)
+	}
+	if !resp.Result {
+		blog.ErrorJSON(" fetchInstAssocationData failed, GetInstUniqueFields resp:%s, option: %s, rid: %s", resp, option, rid)
+		return nil, resp.CCError()
+	}
+	insts = resp.Data.Info
 
 	retAsstInstInfo := make(map[int64][]PropertyPrimaryVal, 0)
 	for _, inst := range insts {

--- a/src/web_server/logics/excel.go
+++ b/src/web_server/logics/excel.go
@@ -181,7 +181,7 @@ func (lgc *Logics) BuildAssociationExcelFromData(ctx context.Context, objID stri
 	for instID := range instPrimaryInfo {
 		instIDArr = append(instIDArr, instID)
 	}
-	instAsst, err := lgc.fetchAssocationData(ctx, header, objID, instIDArr, modelBizID)
+	instAsst, err := lgc.fetchAssociationData(ctx, header, objID, instIDArr, modelBizID)
 	if err != nil {
 		return err
 	}

--- a/src/web_server/service/host.go
+++ b/src/web_server/service/host.go
@@ -13,7 +13,6 @@
 package service
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -164,7 +163,7 @@ func (s *Service) ExportHost(c *gin.Context) {
 		return
 	}
 
-	err = s.Logics.BuildHostExcelFromData(context.Background(), objID, fields, nil, hostInfo, file, header, 0, usernameMap, propertyList)
+	err = s.Logics.BuildHostExcelFromData(ctx, objID, fields, nil, hostInfo, file, header, 0, usernameMap, propertyList)
 	if nil != err {
 		blog.Errorf("ExportHost failed, BuildHostExcelFromData failed, object:%s, err:%+v, rid:%s", objID, err, rid)
 		reply := getReturnStr(common.CCErrCommExcelTemplateFailed, defErr.Errorf(common.CCErrCommExcelTemplateFailed, objID).Error(), nil)


### PR DESCRIPTION
### 修复的问题：
- 修复当主机有关联主线模型实例时，导出主机失败的问题

### 解决方式
因主机关联关系实例的导出只需要实例唯一校验字段，所以在toposerver增加查询所有模型实例唯一校验字段的接口
该接口只会返回唯一校验字段，即使主机关联了用户没权限的业务，也能正常导出关联关系excel表里的业务唯一字段
