### PR TITLE
修正新建动态分组时条件是大于或者小于时返回不支持条件的错误

### DIFF
--- a/src/common/metadata/dynamic_grouping.go
+++ b/src/common/metadata/dynamic_grouping.go
@@ -44,6 +44,12 @@ const (
 	// DynamicGroupOperatorGTE gte operator.
 	DynamicGroupOperatorGTE = "$gte"
 
++       // DynamicGroupOperatorGT gt operator.
++       DynamicGroupOperatorGT = "$gt"
++
++       // DynamicGroupOperatorLT lt operator.
++       DynamicGroupOperatorLT = "$lt"
+	
 	// DynamicGroupOperatorLIKE like operator.
 	DynamicGroupOperatorLIKE = "$regex"
 )
@@ -58,6 +64,8 @@ var (
 		DynamicGroupOperatorLTE:  DynamicGroupOperatorLTE,
 		DynamicGroupOperatorGTE:  DynamicGroupOperatorGTE,
 		DynamicGroupOperatorLIKE: DynamicGroupOperatorLIKE,
++               DynamicGroupOperatorGT:   DynamicGroupOperatorGT,
++               DynamicGroupOperatorLT:   DynamicGroupOperatorLT,
 	}
 
 	// DynamicGroupConditionTypes all condition object types of dynamic group.


### PR DESCRIPTION
增加动态分组大于小于的条件


### 修复的问题：
- 当大于或者小于是会返回不支持参数的错误

### 修复方法
- 增加对应的参数
