### PR TITLE
添加权限中心内置的常用操作

### DIFF
--- a/src/ac/iam/client.go
+++ b/src/ac/iam/client.go
@@ -65,7 +65,8 @@ func (c *iamClient) GetSystemInfo(ctx context.Context) (*SystemResp, error) {
 		SubResourcef("/api/v1/model/systems/%s/query", c.Config.SystemID).
 		WithContext(ctx).
 		WithHeaders(c.basicHeader).
-		WithParam("fields", "base_info,resource_types,actions,action_groups,instance_selections,resource_creator_actions").
+		WithParam("fields", "base_info,resource_types,actions,action_groups,instance_selections,"+
+			"resource_creator_actions,common_actions").
 		Body(nil).Do()
 	err := result.Into(resp)
 	if err != nil {
@@ -422,6 +423,54 @@ func (c *iamClient) UpdateResourceCreatorActions(ctx context.Context, resourceCr
 		return &AuthError{
 			RequestID: result.Header.Get(IamRequestHeader),
 			Reason:    fmt.Errorf("update resource creator actions %v failed, code: %d, msg:%s", resourceCreatorActions, resp.Code, resp.Message),
+		}
+	}
+
+	return nil
+}
+
+func (c *iamClient) RegisterCommonActions(ctx context.Context, commonActions []CommonAction) error {
+	resp := new(BaseResponse)
+	result := c.client.Post().
+		SubResourcef("/api/v1/model/systems/%s/configs/common_actions", c.Config.SystemID).
+		WithContext(ctx).
+		WithHeaders(c.basicHeader).
+		Body(commonActions).Do()
+
+	err := result.Into(resp)
+	if err != nil {
+		return err
+	}
+
+	if resp.Code != 0 {
+		return &AuthError{
+			RequestID: result.Header.Get(IamRequestHeader),
+			Reason: fmt.Errorf("register common actions %v failed, code: %d, msg: %s", commonActions, resp.Code,
+				resp.Message),
+		}
+	}
+
+	return nil
+}
+
+func (c *iamClient) UpdateCommonActions(ctx context.Context, commonActions []CommonAction) error {
+	resp := new(BaseResponse)
+	result := c.client.Put().
+		SubResourcef("/api/v1/model/systems/%s/configs/common_actions", c.Config.SystemID).
+		WithContext(ctx).
+		WithHeaders(c.basicHeader).
+		Body(commonActions).Do()
+
+	err := result.Into(resp)
+	if err != nil {
+		return err
+	}
+
+	if resp.Code != 0 {
+		return &AuthError{
+			RequestID: result.Header.Get(IamRequestHeader),
+			Reason: fmt.Errorf("update common actions %v failed, code: %d, msg: %s", commonActions, resp.Code,
+				resp.Message),
 		}
 	}
 

--- a/src/ac/iam/iam.go
+++ b/src/ac/iam/iam.go
@@ -255,6 +255,20 @@ func (i Iam) RegisterSystem(ctx context.Context, host string) error {
 		}
 	}
 
+	// register or update common actions
+	commonActions := GenerateCommonActions()
+	if len(systemResp.Data.CommonActions) == 0 {
+		if err = i.client.RegisterCommonActions(ctx, commonActions); err != nil {
+			blog.ErrorJSON("register common actions failed, error: %s, common actions: %s", err.Error(), commonActions)
+			return err
+		}
+	} else {
+		if err = i.client.UpdateCommonActions(ctx, commonActions); err != nil {
+			blog.ErrorJSON("update common actions failed, error: %s, common actions: %s", err.Error(), commonActions)
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/src/ac/iam/initial_common_actions.go
+++ b/src/ac/iam/initial_common_actions.go
@@ -1,0 +1,113 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package iam
+
+// GenerateCommonActions generate all the common actions registered to IAM.
+func GenerateCommonActions() []CommonAction {
+	return []CommonAction{
+		{
+			Name:        "业务运维",
+			EnglishName: "operator",
+			Actions: []ActionWithID{
+				{ID: ViewBusinessResource},
+				{ID: EditBusinessHost},
+				{ID: BusinessHostTransferToResourcePool},
+				{ID: CreateBusinessTopology},
+				{ID: EditBusinessTopology},
+				{ID: DeleteBusinessTopology},
+				{ID: CreateBusinessServiceInstance},
+				{ID: EditBusinessServiceInstance},
+				{ID: DeleteBusinessServiceInstance},
+				{ID: CreateBusinessServiceTemplate},
+				{ID: EditBusinessServiceTemplate},
+				{ID: DeleteBusinessServiceTemplate},
+				{ID: CreateBusinessSetTemplate},
+				{ID: EditBusinessSetTemplate},
+				{ID: DeleteBusinessSetTemplate},
+				{ID: CreateBusinessServiceCategory},
+				{ID: EditBusinessServiceCategory},
+				{ID: DeleteBusinessServiceCategory},
+				{ID: CreateBusinessCustomQuery},
+				{ID: EditBusinessCustomQuery},
+				{ID: DeleteBusinessCustomQuery},
+				{ID: EditBusinessCustomField},
+				{ID: EditBusinessHostApply},
+				{ID: FindBusiness},
+			},
+		},
+		{
+			Name:        "主机资源管理员",
+			EnglishName: "Host Maintainer",
+			Actions: []ActionWithID{
+				{ID: CreateResourcePoolHost},
+				{ID: EditResourcePoolHost},
+				{ID: DeleteResourcePoolHost},
+				{ID: ResourcePoolHostTransferToBusiness},
+				{ID: ResourcePoolHostTransferToDirectory},
+				{ID: CreateResourcePoolDirectory},
+				{ID: EditResourcePoolDirectory},
+				{ID: DeleteResourcePoolDirectory},
+				{ID: CreateCloudAccount},
+				{ID: EditCloudAccount},
+				{ID: DeleteCloudAccount},
+				{ID: FindCloudAccount},
+				{ID: CreateCloudResourceTask},
+				{ID: EditCloudResourceTask},
+				{ID: DeleteCloudResourceTask},
+				{ID: FindCloudResourceTask},
+			},
+		},
+		{
+			Name:        "开发者",
+			EnglishName: "Developer",
+			Actions: []ActionWithID{
+				{ID: CreateEventPushing},
+				{ID: EditEventPushing},
+				{ID: DeleteEventPushing},
+				{ID: FindEventPushing},
+				{ID: WatchHostEvent},
+				{ID: WatchHostRelationEvent},
+				{ID: WatchBizEvent},
+				{ID: WatchSetEvent},
+				{ID: WatchModuleEvent},
+				{ID: WatchSetTemplateEvent},
+			},
+		},
+		{
+			Name:        "模型关系维护人",
+			EnglishName: "Model Maintainer",
+			Actions: []ActionWithID{
+				{ID: CreateModelGroup},
+				{ID: EditModelGroup},
+				{ID: DeleteModelGroup},
+				{ID: EditBusinessLayer},
+				{ID: EditModelTopologyView},
+				{ID: CreateSysModel},
+				{ID: EditSysModel},
+				{ID: DeleteSysModel},
+				{ID: CreateAssociationType},
+				{ID: EditAssociationType},
+				{ID: DeleteAssociationType},
+			},
+		},
+		{
+			Name:        "审计员",
+			EnglishName: "Auditor",
+			Actions: []ActionWithID{
+				{ID: FindOperationStatistic},
+				{ID: EditOperationStatistic},
+				{ID: FindAuditLog},
+			},
+		},
+	}
+}

--- a/src/ac/iam/types.go
+++ b/src/ac/iam/types.go
@@ -116,6 +116,7 @@ type RegisteredSystemInfo struct {
 	ActionGroups           []ActionGroup          `json:"action_groups"`
 	InstanceSelections     []InstanceSelection    `json:"instance_selections"`
 	ResourceCreatorActions ResourceCreatorActions `json:"resource_creator_actions"`
+	CommonActions          []CommonAction         `json:"common_actions"`
 }
 
 type BaseResponse struct {
@@ -465,4 +466,11 @@ type ResourceCreatorAction struct {
 type CreatorRelatedAction struct {
 	ID         ActionID `json:"id"`
 	IsRequired bool     `json:"required"`
+}
+
+// CommonAction specifies a common operation's related iam actions
+type CommonAction struct {
+	Name        string         `json:"name"`
+	EnglishName string         `json:"name_en"`
+	Actions     []ActionWithID `json:"actions"`
 }


### PR DESCRIPTION
### 新加的功能:
- 新增支持权限中心常用分组：业务运维，主机资源管理员，开发者，模型关系维护人，审计员。

