### PR TITLE
实例关联数据写入相应分表

### DIFF
--- a/src/ac/parser/topolatest.go
+++ b/src/ac/parser/topolatest.go
@@ -483,7 +483,7 @@ const (
 )
 
 var (
-	deleteObjectInstanceAssociationLatestRegexp      = regexp.MustCompile("^/api/v3/delete/instassociation/[0-9]+/?$")
+	deleteObjectInstanceAssociationLatestRegexp      = regexp.MustCompile(`^/api/v3/delete/instassociation/[^\s/]+/[0-9]+/?$`)
 	deleteObjectInstanceAssociationBatchLatestRegexp = regexp.MustCompile("^/api/v3/delete/instassociation/batch")
 	findObjectInstanceTopologyUILatestRegexp         = regexp.MustCompile(`^/api/v3/findmany/inst/association/object/[^\s/]+/inst_id/[0-9]+/offset/[0-9]+/limit/[0-9]+/web$`)
 	findInstAssociationObjInstInfoLatestRegexp       = regexp.MustCompile(`^/api/v3/findmany/inst/association/association_object/inst_base_info$`)
@@ -652,13 +652,19 @@ func (ps *parseStream) objectInstanceAssociationLatest() *parseStream {
 
 	// delete object's instance association operation. for web
 	if ps.hitRegexp(deleteObjectInstanceAssociationLatestRegexp, http.MethodDelete) {
-		assoID, err := strconv.ParseInt(ps.RequestCtx.Elements[4], 10, 64)
-		if err != nil {
-			ps.err = fmt.Errorf("delete object instance association, but got invalid association id %s", ps.RequestCtx.Elements[4])
+		objID := ps.RequestCtx.Elements[4]
+		if len(objID) == 0 {
+			ps.err = fmt.Errorf("delete object instance association, but got empty object id")
 			return ps
 		}
 
-		asst, err := ps.getInstAssociation(mapstr.MapStr{common.BKFieldID: assoID})
+		assoID, err := strconv.ParseInt(ps.RequestCtx.Elements[5], 10, 64)
+		if err != nil {
+			ps.err = fmt.Errorf("delete object instance association, but got invalid association id %s", ps.RequestCtx.Elements[5])
+			return ps
+		}
+
+		asst, err := ps.getInstAssociation(objID, mapstr.MapStr{common.BKFieldID: assoID})
 		if err != nil {
 			ps.err = err
 			return ps

--- a/src/ac/parser/util.go
+++ b/src/ac/parser/util.go
@@ -180,9 +180,9 @@ func (ps *parseStream) getModelAssociation(cond mapstr.MapStr) ([]metadata.Assoc
 	return asst.Data.Info, nil
 }
 
-func (ps *parseStream) getInstAssociation(cond mapstr.MapStr) (metadata.InstAsst, error) {
+func (ps *parseStream) getInstAssociation(objID string, cond mapstr.MapStr) (metadata.InstAsst, error) {
 	asst, err := ps.engine.CoreAPI.CoreService().Association().ReadInstAssociation(context.Background(), ps.RequestCtx.Header,
-		&metadata.QueryCondition{Condition: cond})
+		&metadata.InstAsstQueryCondition{Cond: metadata.QueryCondition{Condition: cond}, ObjID: objID})
 	if err != nil {
 		return metadata.InstAsst{}, err
 	}

--- a/src/apimachinery/coreservice/association/api.go
+++ b/src/apimachinery/coreservice/association/api.go
@@ -271,7 +271,9 @@ func (asst *association) UpdateInstAssociation(ctx context.Context, h http.Heade
 	return
 }
 
-func (asst *association) ReadInstAssociation(ctx context.Context, h http.Header, input *metadata.QueryCondition) (resp *metadata.ReadInstAssociationResult, err error) {
+func (asst *association) ReadInstAssociation(ctx context.Context, h http.Header, input *metadata.InstAsstQueryCondition) (
+	resp *metadata.ReadInstAssociationResult, err error) {
+
 	resp = new(metadata.ReadInstAssociationResult)
 	subPath := "/read/instanceassociation"
 
@@ -285,7 +287,9 @@ func (asst *association) ReadInstAssociation(ctx context.Context, h http.Header,
 	return
 }
 
-func (asst *association) DeleteInstAssociation(ctx context.Context, h http.Header, input *metadata.DeleteOption) (resp *metadata.DeletedOptionResult, err error) {
+func (asst *association) DeleteInstAssociation(ctx context.Context, h http.Header, input *metadata.InstAsstDeleteOption) (
+	resp *metadata.DeletedOptionResult, err error) {
+
 	resp = new(metadata.DeletedOptionResult)
 	subPath := "/delete/instanceassociation"
 

--- a/src/apimachinery/coreservice/association/association.go
+++ b/src/apimachinery/coreservice/association/association.go
@@ -40,8 +40,10 @@ type AssociationClientInterface interface {
 	CreateInstAssociation(ctx context.Context, h http.Header, input *metadata.CreateOneInstanceAssociation) (resp *metadata.CreatedOneOptionResult, err error)
 	SetInstAssociation(ctx context.Context, h http.Header, input *metadata.SetOneInstanceAssociation) (resp *metadata.SetOptionResult, err error)
 	UpdateInstAssociation(ctx context.Context, h http.Header, input *metadata.UpdateOption) (resp *metadata.UpdatedOptionResult, err error)
-	ReadInstAssociation(ctx context.Context, h http.Header, input *metadata.QueryCondition) (resp *metadata.ReadInstAssociationResult, err error)
-	DeleteInstAssociation(ctx context.Context, h http.Header, input *metadata.DeleteOption) (resp *metadata.DeletedOptionResult, err error)
+	ReadInstAssociation(ctx context.Context, h http.Header, input *metadata.InstAsstQueryCondition) (
+		resp *metadata.ReadInstAssociationResult, err error)
+	DeleteInstAssociation(ctx context.Context, h http.Header, input *metadata.InstAsstDeleteOption) (
+		resp *metadata.DeletedOptionResult, err error)
 }
 
 func NewAssociationClientInterface(client rest.ClientInterface) AssociationClientInterface {

--- a/src/apimachinery/toposerver/association/apis.go
+++ b/src/apimachinery/toposerver/association/apis.go
@@ -31,7 +31,7 @@ type AssociationInterface interface {
 	SearchInst(ctx context.Context, h http.Header, request *metadata.SearchAssociationInstRequest) (resp *metadata.SearchAssociationInstResult, err error)
 	SearchAssociationRelatedInst(ctx context.Context, h http.Header, request *metadata.SearchAssociationRelatedInstRequest) (resp *metadata.SearchAssociationInstResult, err error)
 	CreateInst(ctx context.Context, h http.Header, request *metadata.CreateAssociationInstRequest) (resp *metadata.CreateAssociationInstResult, err error)
-	DeleteInst(ctx context.Context, h http.Header, assoID int64) (resp *metadata.DeleteAssociationInstResult, err error)
+	DeleteInst(ctx context.Context, h http.Header, objID string, assoID int64) (resp *metadata.DeleteAssociationInstResult, err error)
 	DeleteInstBatch(ctx context.Context, h http.Header, assoIDs *metadata.DeleteAssociationInstBatchRequest) (resp *metadata.DeleteAssociationInstBatchResult, err error)
 	SearchObjectAssoWithAssoKindList(ctx context.Context, h http.Header, assoKindIDs metadata.AssociationKindIDs) (resp *metadata.ListAssociationsWithAssociationKindResult, err error)
 }

--- a/src/apimachinery/toposerver/association/association.go
+++ b/src/apimachinery/toposerver/association/association.go
@@ -179,14 +179,14 @@ func (asst *Association) CreateInst(ctx context.Context, h http.Header, request 
 
 	return
 }
-func (asst *Association) DeleteInst(ctx context.Context, h http.Header, assoID int64) (resp *metadata.DeleteAssociationInstResult, err error) {
+func (asst *Association) DeleteInst(ctx context.Context, h http.Header, objID string, assoID int64) (resp *metadata.DeleteAssociationInstResult, err error) {
 	resp = new(metadata.DeleteAssociationInstResult)
-	subPath := "/delete/instassociation/%d"
+	subPath := "/delete/instassociation/%s/%d"
 
 	err = asst.client.Delete().
 		WithContext(ctx).
 		Body(nil).
-		SubResourcef(subPath, assoID).
+		SubResourcef(subPath, objID, assoID).
 		WithHeaders(h).
 		Do().
 		Into(resp)

--- a/src/common/auditlog/association.go
+++ b/src/common/auditlog/association.go
@@ -25,12 +25,18 @@ type instanceAssociationAuditLog struct {
 }
 
 // GenerateAuditLog generate audit log of instance association, if data is nil, will auto get data by id and instance association.
-func (a *instanceAssociationAuditLog) GenerateAuditLog(parameter *generateAuditCommonParameter, id int64, data *metadata.InstAsst) (
-	*metadata.AuditLog, error) {
+func (a *instanceAssociationAuditLog) GenerateAuditLog(parameter *generateAuditCommonParameter, id int64, objID string,
+	data *metadata.InstAsst) (*metadata.AuditLog, error) {
 	kit := parameter.kit
 
 	if data == nil {
-		cond := metadata.QueryCondition{Condition: map[string]interface{}{metadata.AssociationFieldAssociationId: id}}
+		cond := metadata.InstAsstQueryCondition{
+			Cond: metadata.QueryCondition{
+				Condition: map[string]interface{}{metadata.AssociationFieldAssociationId: id},
+			},
+			ObjID: objID,
+		}
+
 		result, err := a.clientSet.Association().ReadInstAssociation(kit.Ctx, kit.Header, &cond)
 		if err != nil {
 			blog.Errorf("generate inst asst audit log failed, get instance association failed, err: %v, rid: %s", err, kit.Rid)

--- a/src/common/metadata/association.go
+++ b/src/common/metadata/association.go
@@ -106,6 +106,7 @@ type SearchAssociationRelatedInstRequestCond struct {
 
 type SearchAssociationInstRequest struct {
 	Condition mapstr.MapStr `json:"condition"` // construct condition mapstr by condition.Condition
+	ObjID     string        `json:"bk_obj_id"`
 }
 
 type SearchAssociationRelatedInstRequest struct {
@@ -134,7 +135,8 @@ type DeleteAssociationInstRequest struct {
 }
 
 type DeleteAssociationInstBatchRequest struct {
-	ID []int64 `json:"id"`
+	ID    []int64 `json:"id"`
+	ObjID string  `json:"bk_obj_id"`
 }
 
 type DeleteAssociationInstResult struct {
@@ -498,4 +500,14 @@ type NodeTopoPath struct {
 	BizID int64                       `json:"bk_biz_id" mapstructure:"bk_biz_id"`
 	Node  TopoNode                    `json:"topo_node" mapstructure:"topo_node"`
 	Path  []*TopoInstanceNodeSimplify `json:"topo_path" mapstructure:"topo_path"`
+}
+
+type InstAsstQueryCondition struct {
+	Cond  QueryCondition `json:"cond"`
+	ObjID string         `json:"bk_obj_id"`
+}
+
+type InstAsstDeleteOption struct {
+	Opt   DeleteOption `json:"opt"`
+	ObjID string       `json:"bk_obj_id"`
 }

--- a/src/scene_server/datacollection/logics/report.go
+++ b/src/scene_server/datacollection/logics/report.go
@@ -340,6 +340,7 @@ func (lgc *Logics) findInstAssociation(header http.Header, objectID string, inst
 
 	option := &metadata.SearchAssociationInstRequest{
 		Condition: cond.ToMapStr(),
+		ObjID:     objectID,
 	}
 	resp, err := lgc.CoreAPI.ApiServer().SearchAssociationInst(context.Background(), header, option)
 	if err != nil {

--- a/src/scene_server/host_server/logics/object.go
+++ b/src/scene_server/host_server/logics/object.go
@@ -291,8 +291,9 @@ func (lgc *Logics) GetHostIDByInstID(kit *rest.Kit, asstObjId string, instIDArr 
 	cond := hutil.NewOperation().WithObjID(common.BKInnerObjIDHost).
 		WithAssoObjID(asstObjId).WithAssoInstID(map[string]interface{}{common.BKDBIN: instIDArr}).Data()
 
-	query := &meta.QueryCondition{
-		Condition: cond,
+	query := &meta.InstAsstQueryCondition{
+		Cond:  meta.QueryCondition{Condition: cond},
+		ObjID: common.BKInnerObjIDHost,
 	}
 	result, err := lgc.CoreAPI.CoreService().Association().ReadInstAssociation(kit.Ctx, kit.Header, query)
 	if err != nil {

--- a/src/scene_server/host_server/service/host.go
+++ b/src/scene_server/host_server/service/host.go
@@ -96,7 +96,13 @@ func (s *Service) DeleteHostBatchFromResourcePool(ctx *rest.Contexts) {
 				},
 			},
 		}
-		rsp, err := s.CoreAPI.CoreService().Association().ReadInstAssociation(ctx.Kit.Ctx, ctx.Kit.Header, &meta.QueryCondition{Condition: asstCond})
+
+		queryCond := &meta.InstAsstQueryCondition{
+			Cond:  meta.QueryCondition{Condition: asstCond},
+			ObjID: common.BKInnerObjIDHost,
+		}
+
+		rsp, err := s.CoreAPI.CoreService().Association().ReadInstAssociation(ctx.Kit.Ctx, ctx.Kit.Header, queryCond)
 		if nil != err {
 			blog.ErrorJSON("DeleteHostBatch read host association do request failed , err: %s, rid: %s", err.Error(), ctx.Kit.Rid)
 			ctx.RespAutoError(ctx.Kit.CCError.CCError(common.CCErrCommHTTPDoRequestFailed))
@@ -167,8 +173,11 @@ func (s *Service) DeleteHostBatchFromResourcePool(ctx *rest.Contexts) {
 
 	txnErr := s.Engine.CoreAPI.CoreService().Txn().AutoRunTxn(ctx.Kit.Ctx, ctx.Kit.Header, func() error {
 		for _, delConds := range delCondsArr {
-			delRsp, err := s.CoreAPI.CoreService().Association().DeleteInstAssociation(ctx.Kit.Ctx, ctx.Kit.Header,
-				&meta.DeleteOption{Condition: map[string]interface{}{common.BKDBOR: delConds}})
+			opt := &meta.InstAsstDeleteOption{
+				Opt:   meta.DeleteOption{Condition: map[string]interface{}{common.BKDBOR: delConds}},
+				ObjID: common.BKInnerObjIDHost,
+			}
+			delRsp, err := s.CoreAPI.CoreService().Association().DeleteInstAssociation(ctx.Kit.Ctx, ctx.Kit.Header, opt)
 			if err != nil {
 				blog.ErrorJSON("DeleteHostBatch delete host redundant association do request failed , err: %s, rid: %s", err.Error(), ctx.Kit.Rid)
 				return ctx.Kit.CCError.CCError(common.CCErrCommHTTPDoRequestFailed)

--- a/src/scene_server/topo_server/core/operation/inst.go
+++ b/src/scene_server/topo_server/core/operation/inst.go
@@ -1100,7 +1100,7 @@ func (c *commonInst) FindInstByAssociationInst(kit *rest.Kit, objID string, asst
 			"bk_obj_id":      objID,
 		}
 
-		asstInst, err := c.asst.SearchInstAssociation(kit, query)
+		asstInst, err := c.asst.SearchInstAssociation(kit, objID, query)
 		if nil != err {
 			blog.Errorf("[operation-inst] failed to search the association inst, err: %s, rid: %s", err.Error(), kit.Rid)
 			return nil, err

--- a/src/scene_server/topo_server/service/inst.go
+++ b/src/scene_server/topo_server/service/inst.go
@@ -881,7 +881,7 @@ func (s *Service) SearchInstAssociation(ctx *rest.Contexts) {
 	}
 
 	blog.V(5).Infof("input:%#v, rid:%s", input, ctx.Kit.Rid)
-	infos, cnt, err := s.Core.AssociationOperation().SearchInstAssociationList(ctx.Kit, input)
+	infos, cnt, err := s.Core.AssociationOperation().SearchInstAssociationList(ctx.Kit, objID, input)
 	if err != nil {
 		blog.ErrorJSON("parse page illegal, input:%s, err:%s, rid:%s", input, err.Error(), ctx.Kit.Rid)
 		ctx.RespAutoError(err)

--- a/src/scene_server/topo_server/service/service_business_initfunc.go
+++ b/src/scene_server/topo_server/service/service_business_initfunc.go
@@ -142,7 +142,7 @@ func (s *Service) initBusinessAssociation(web *restful.WebService) {
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/instassociation", Handler: s.SearchAssociationInst})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/find/instassociation/related", Handler: s.SearchAssociationRelatedInst})
 	utility.AddHandler(rest.Action{Verb: http.MethodPost, Path: "/create/instassociation", Handler: s.CreateAssociationInst})
-	utility.AddHandler(rest.Action{Verb: http.MethodDelete, Path: "/delete/instassociation/{association_id}", Handler: s.DeleteAssociationInst})
+	utility.AddHandler(rest.Action{Verb: http.MethodDelete, Path: "/delete/instassociation/{bk_obj_id}/{association_id}", Handler: s.DeleteAssociationInst})
 	utility.AddHandler(rest.Action{Verb: http.MethodDelete, Path: "/delete/instassociation/batch", Handler: s.DeleteAssociationInstBatch})
 
 	// topo search methods

--- a/src/source_controller/coreservice/core/association/instance.go
+++ b/src/source_controller/coreservice/core/association/instance.go
@@ -30,44 +30,44 @@ type associationInstance struct {
 	dependent OperationDependencies
 }
 
-func (m *associationInstance) isExists(kit *rest.Kit, instID, asstInstID int64, objAsstID string, bizID int64) (origin *metadata.InstAsst, exists bool, err error) {
-	cond := mongo.NewCondition()
-	origin = &metadata.InstAsst{}
-	cond.Element(
-		&mongo.Eq{Key: common.BKInstIDField, Val: instID},
-		&mongo.Eq{Key: common.BKAsstInstIDField, Val: asstInstID},
-		&mongo.Eq{Key: common.AssociationObjAsstIDField, Val: objAsstID})
+func (m *associationInstance) isExists(kit *rest.Kit, instID, asstInstID int64, objAsstID, objID string, bizID int64) (
+	bool, error) {
+
+	cond := map[string]interface{}{
+		common.BKInstIDField:             instID,
+		common.BKAsstInstIDField:         asstInstID,
+		common.AssociationObjAsstIDField: objAsstID,
+	}
+
 	if bizID > 0 {
-		cond.Element(&mongo.Eq{Key: common.BKAppIDField, Val: bizID})
+		cond[common.BKAppIDField] = bizID
 	}
 
-	err = mongodb.Client().Table(common.BKTableNameInstAsst).Find(cond.ToMapStr()).One(kit.Ctx, origin)
-	if mongodb.Client().IsNotFoundError(err) {
-		return origin, !mongodb.Client().IsNotFoundError(err), nil
+	count, err := m.countInstanceAssociation(kit, objID, cond)
+	if err != nil {
+		return false, err
 	}
-	return origin, !mongodb.Client().IsNotFoundError(err), err
+
+	return count > 0, nil
 }
 
-func (m *associationInstance) instCount(kit *rest.Kit, cond mapstr.MapStr) (cnt uint64, err error) {
-	innerCnt, err := mongodb.Client().Table(common.BKTableNameInstAsst).Find(cond).Count(kit.Ctx)
-	return innerCnt, err
-}
+func (m *associationInstance) searchInstanceAssociation(kit *rest.Kit, objID string, param metadata.QueryCondition) (
+	[]metadata.InstAsst, error) {
 
-func (m *associationInstance) searchInstanceAssociation(kit *rest.Kit, inputParam metadata.QueryCondition) (results []metadata.InstAsst, err error) {
-	results = []metadata.InstAsst{}
-	instHandler := mongodb.Client().Table(common.BKTableNameInstAsst).Find(inputParam.Condition).Fields(inputParam.Fields...)
-	err = instHandler.Start(uint64(inputParam.Page.Start)).Limit(uint64(inputParam.Page.Limit)).Sort(inputParam.Page.Sort).All(kit.Ctx, &results)
+	results := make([]metadata.InstAsst, 0)
+	asstTableName := common.GetObjectInstAsstTableName(objID)
+	instHandler := mongodb.Client().Table(asstTableName).Find(param.Condition).Fields(param.Fields...)
+	err := instHandler.Start(uint64(param.Page.Start)).Limit(uint64(param.Page.Limit)).
+		Sort(param.Page.Sort).All(kit.Ctx, &results)
 	return results, err
 }
 
-func (m *associationInstance) countInstanceAssociation(kit *rest.Kit, cond mapstr.MapStr) (count uint64, err error) {
-	count, err = mongodb.Client().Table(common.BKTableNameInstAsst).Find(cond).Count(kit.Ctx)
-
-	return count, err
+func (m *associationInstance) countInstanceAssociation(kit *rest.Kit, objID string, cond mapstr.MapStr) (uint64, error) {
+	asstTableName := common.GetObjectInstAsstTableName(objID)
+	return mongodb.Client().Table(asstTableName).Find(cond).Count(kit.Ctx)
 }
 
 func (m *associationInstance) save(kit *rest.Kit, asstInst metadata.InstAsst) (id uint64, err error) {
-
 	id, err = mongodb.Client().NextSequence(kit.Ctx, common.BKTableNameInstAsst)
 	if err != nil {
 		return id, kit.CCError.New(common.CCErrObjectDBOpErrno, err.Error())
@@ -76,13 +76,58 @@ func (m *associationInstance) save(kit *rest.Kit, asstInst metadata.InstAsst) (i
 	asstInst.ID = int64(id)
 	asstInst.OwnerID = kit.SupplierAccount
 
-	err = mongodb.Client().Table(common.BKTableNameInstAsst).Insert(kit.Ctx, asstInst)
+	objInstAsstTableName := common.GetObjectInstAsstTableName(asstInst.ObjectID)
+	err = mongodb.Client().Table(objInstAsstTableName).Insert(kit.Ctx, asstInst)
+	if err != nil {
+		return id, err
+	}
+
+	// do not insert twice for self related association
+	if asstInst.ObjectID == asstInst.AsstObjectID {
+		return id, nil
+	}
+
+	asstObjInstAsstTableName := common.GetObjectInstAsstTableName(asstInst.AsstObjectID)
+	err = mongodb.Client().Table(asstObjInstAsstTableName).Insert(kit.Ctx, asstInst)
 	return id, err
+}
+
+func (m *associationInstance) deleteInstanceAssociation(kit *rest.Kit, objID string, cond mapstr.MapStr) error {
+	asstInstTableName := common.GetObjectInstAsstTableName(objID)
+	associations := make([]metadata.InstAsst, 0)
+	if err := mongodb.Client().Table(asstInstTableName).Find(cond).Fields(common.BKObjIDField, common.BKAsstObjIDField).
+		All(kit.Ctx, &associations); err != nil {
+		return err
+	}
+
+	objIDMap := make(map[string]struct{})
+	for _, asst := range associations {
+		var objID string
+		if asst.ObjectID != objID {
+			objID = asst.ObjectID
+		} else if asst.AsstObjectID != objID {
+			objID = asst.AsstObjectID
+		}
+
+		if _, exists := objIDMap[objID]; exists {
+			continue
+		}
+		objIDMap[objID] = struct{}{}
+
+		asstTableName := common.GetObjectInstAsstTableName(objID)
+		err := mongodb.Client().Table(asstTableName).Delete(kit.Ctx, cond)
+		if err != nil {
+			return err
+		}
+	}
+
+	return mongodb.Client().Table(asstInstTableName).Delete(kit.Ctx, cond)
 }
 
 func (m *associationInstance) CreateOneInstanceAssociation(kit *rest.Kit, inputParam metadata.CreateOneInstanceAssociation) (*metadata.CreateOneDataResult, error) {
 	inputParam.Data.OwnerID = kit.SupplierAccount
-	_, exists, err := m.isExists(kit, inputParam.Data.InstID, inputParam.Data.AsstInstID, inputParam.Data.ObjectAsstID, inputParam.Data.BizID)
+	exists, err := m.isExists(kit, inputParam.Data.InstID, inputParam.Data.AsstInstID, inputParam.Data.ObjectAsstID,
+		inputParam.Data.ObjectID, inputParam.Data.BizID)
 	if nil != err {
 		blog.Errorf("check instance (%#v)is duplicated error, rid: %s", inputParam.Data, kit.Rid)
 		return nil, err
@@ -132,7 +177,7 @@ func (m *associationInstance) CreateManyInstanceAssociation(kit *rest.Kit, input
 	for itemIdx, item := range inputParam.Datas {
 		item.OwnerID = kit.SupplierAccount
 		//check is exist
-		_, exists, err := m.isExists(kit, item.InstID, item.AsstInstID, item.ObjectAsstID, item.BizID)
+		exists, err := m.isExists(kit, item.InstID, item.AsstInstID, item.ObjectAsstID, item.ObjectID, item.BizID)
 		if nil != err {
 			dataResult.Exceptions = append(dataResult.Exceptions, metadata.ExceptionResult{
 				Message:     err.Error(),
@@ -231,19 +276,25 @@ func (m *associationInstance) CreateManyInstanceAssociation(kit *rest.Kit, input
 	return dataResult, nil
 }
 
-func (m *associationInstance) SearchInstanceAssociation(kit *rest.Kit, inputParam metadata.QueryCondition) (*metadata.QueryResult, error) {
-	inputParam.Condition = util.SetQueryOwner(inputParam.Condition, kit.SupplierAccount)
-	instAsstItems, err := m.searchInstanceAssociation(kit, inputParam)
+func (m *associationInstance) SearchInstanceAssociation(kit *rest.Kit, objID string, param metadata.QueryCondition) (
+	*metadata.QueryResult, error) {
+
+	if len(objID) == 0 {
+		return &metadata.QueryResult{}, kit.CCError.CCErrorf(common.CCErrCommParamsNeedSet, common.BKObjIDField)
+	}
+
+	param.Condition = util.SetQueryOwner(param.Condition, kit.SupplierAccount)
+	instAsstItems, err := m.searchInstanceAssociation(kit, objID, param)
 	if nil != err {
-		blog.Errorf("search inst association array err [%#v], rid: %s", err, kit.Rid)
+		blog.ErrorJSON("search inst association err: %s, objID: %s, param: %s, rid: %s", err, objID, param, kit.Rid)
 		return &metadata.QueryResult{}, err
 	}
 
 	dataResult := &metadata.QueryResult{}
-	dataResult.Count, err = m.countInstanceAssociation(kit, inputParam.Condition)
+	dataResult.Count, err = m.countInstanceAssociation(kit, objID, param.Condition)
 	dataResult.Info = make([]mapstr.MapStr, 0)
 	if nil != err {
-		blog.Errorf("search inst association count err [%#v], rid: %s", err, kit.Rid)
+		blog.ErrorJSON("count inst association err: %s, objID: %s, param: %s, rid: %s", err, objID, param, kit.Rid)
 		return &metadata.QueryResult{}, err
 	}
 	for _, item := range instAsstItems {
@@ -253,15 +304,21 @@ func (m *associationInstance) SearchInstanceAssociation(kit *rest.Kit, inputPara
 	return dataResult, nil
 }
 
-func (m *associationInstance) DeleteInstanceAssociation(kit *rest.Kit, inputParam metadata.DeleteOption) (*metadata.DeletedCount, error) {
+func (m *associationInstance) DeleteInstanceAssociation(kit *rest.Kit, objID string, inputParam metadata.DeleteOption) (
+	*metadata.DeletedCount, error) {
+
+	if len(objID) == 0 {
+		return &metadata.DeletedCount{}, kit.CCError.CCErrorf(common.CCErrCommParamsNeedSet, common.BKObjIDField)
+	}
+
 	inputParam.Condition = util.SetModOwner(inputParam.Condition, kit.SupplierAccount)
-	cnt, err := m.instCount(kit, inputParam.Condition)
+	cnt, err := m.countInstanceAssociation(kit, objID, inputParam.Condition)
 	if nil != err {
 		blog.Errorf("delete inst association get inst [%#v] count err [%#v], rid: %s", inputParam.Condition, err, kit.Rid)
 		return &metadata.DeletedCount{}, err
 	}
 
-	err = mongodb.Client().Table(common.BKTableNameInstAsst).Delete(kit.Ctx, inputParam.Condition)
+	err = m.deleteInstanceAssociation(kit, objID, inputParam.Condition)
 	if nil != err {
 		blog.Errorf("delete inst association [%#v] err [%#v], rid: %s", inputParam.Condition, err, kit.Rid)
 		return &metadata.DeletedCount{}, err

--- a/src/source_controller/coreservice/core/association/instance_test.go
+++ b/src/source_controller/coreservice/core/association/instance_test.go
@@ -169,7 +169,7 @@ func TestAssociationInstance(t *testing.T) {
 	//search association instance
 	searchCond := metadata.QueryCondition{}
 	searchCond.Condition = mapstr.MapStr{common.BKObjIDField: objID}
-	asstSearchResult, err := asstMgr.SearchInstanceAssociation(defaultCtx, searchCond)
+	asstSearchResult, err := asstMgr.SearchInstanceAssociation(defaultCtx, objID, searchCond)
 	require.Nil(t, err)
 	require.NotNil(t, asstSearchResult)
 	require.NotEqual(t, 0, asstSearchResult.Count)
@@ -177,7 +177,7 @@ func TestAssociationInstance(t *testing.T) {
 	//delete association instance
 	deleteCond := metadata.DeleteOption{}
 	deleteCond.Condition = mapstr.MapStr{common.BKObjIDField: objID}
-	deleteResult, err := asstMgr.DeleteInstanceAssociation(defaultCtx, deleteCond)
+	deleteResult, err := asstMgr.DeleteInstanceAssociation(defaultCtx, objID, deleteCond)
 	require.Nil(t, err)
 	require.NotNil(t, deleteResult)
 	require.NotEqual(t, 0, deleteResult.Count)

--- a/src/source_controller/coreservice/core/cloud/synctask.go
+++ b/src/source_controller/coreservice/core/cloud/synctask.go
@@ -306,7 +306,39 @@ func (c *cloudOperation) DeleteDestroyedHostRelated(kit *rest.Kit, option *metad
 			},
 		},
 	}
-	err = c.dbProxy.Table(common.BKTableNameInstAsst).Delete(kit.Ctx, asstFilter)
+
+	hostAsstTableName := common.GetObjectInstAsstTableName(common.BKInnerObjIDHost)
+	hostAssociations := make([]metadata.InstAsst, 0)
+	if err := c.dbProxy.Table(hostAsstTableName).Find(asstFilter).Fields(common.BKObjIDField, common.BKAsstObjIDField).
+		All(kit.Ctx, &hostAssociations); err != nil {
+		blog.ErrorJSON("find host associations failed, err: %s, filter: %s, rid: %s", err, asstFilter, kit.Rid)
+		return kit.CCError.CCErrorf(common.CCErrCommDBSelectFailed)
+	}
+
+	objIDMap := make(map[string]struct{})
+	for _, asst := range hostAssociations {
+		var objID string
+		if asst.ObjectID != common.BKHostIDField {
+			objID = asst.ObjectID
+		} else if asst.AsstObjectID != common.BKHostIDField {
+			objID = asst.AsstObjectID
+		}
+
+		if _, exists := objIDMap[objID]; exists {
+			continue
+		}
+		objIDMap[objID] = struct{}{}
+
+		asstTableName := common.GetObjectInstAsstTableName(objID)
+		err = c.dbProxy.Table(asstTableName).Delete(kit.Ctx, asstFilter)
+		if err != nil {
+			blog.ErrorJSON("delete host association failed, err: %s, table: %s, filter: %s, rid: %s", err,
+				asstTableName, asstFilter, kit.Rid)
+			return kit.CCError.CCErrorf(common.CCErrCommDBDeleteFailed)
+		}
+	}
+
+	err = c.dbProxy.Table(hostAsstTableName).Delete(kit.Ctx, asstFilter)
 	if nil != err {
 		blog.Errorf("DeleteDestroyedHostRelated failed, delete inst association err:%s, filter:%s, rid: %s", err, asstFilter, kit.Rid)
 		return kit.CCError.CCErrorf(common.CCErrCommDBDeleteFailed)

--- a/src/source_controller/coreservice/core/core.go
+++ b/src/source_controller/coreservice/core/core.go
@@ -119,8 +119,8 @@ type ModelAssociation interface {
 type InstanceAssociation interface {
 	CreateOneInstanceAssociation(kit *rest.Kit, inputParam metadata.CreateOneInstanceAssociation) (*metadata.CreateOneDataResult, error)
 	CreateManyInstanceAssociation(kit *rest.Kit, inputParam metadata.CreateManyInstanceAssociation) (*metadata.CreateManyDataResult, error)
-	SearchInstanceAssociation(kit *rest.Kit, inputParam metadata.QueryCondition) (*metadata.QueryResult, error)
-	DeleteInstanceAssociation(kit *rest.Kit, inputParam metadata.DeleteOption) (*metadata.DeletedCount, error)
+	SearchInstanceAssociation(kit *rest.Kit, objID string, param metadata.QueryCondition) (*metadata.QueryResult, error)
+	DeleteInstanceAssociation(kit *rest.Kit, objID string, param metadata.DeleteOption) (*metadata.DeletedCount, error)
 }
 
 // DataSynchronizeOperation manager data synchronize interface

--- a/src/source_controller/coreservice/service/association.go
+++ b/src/source_controller/coreservice/service/association.go
@@ -264,12 +264,12 @@ func (s *coreService) CreateManyInstanceAssociation(ctx *rest.Contexts) {
 }
 
 func (s *coreService) SearchInstanceAssociation(ctx *rest.Contexts) {
-	inputData := metadata.QueryCondition{}
+	inputData := metadata.InstAsstQueryCondition{}
 	if err := ctx.DecodeInto(&inputData); nil != err {
 		ctx.RespAutoError(err)
 		return
 	}
-	result, err := s.core.AssociationOperation().SearchInstanceAssociation(ctx.Kit, inputData)
+	result, err := s.core.AssociationOperation().SearchInstanceAssociation(ctx.Kit, inputData.ObjID, inputData.Cond)
 	if err != nil {
 		ctx.RespAutoError(err)
 		return
@@ -278,12 +278,12 @@ func (s *coreService) SearchInstanceAssociation(ctx *rest.Contexts) {
 }
 
 func (s *coreService) DeleteInstanceAssociation(ctx *rest.Contexts) {
-	inputData := metadata.DeleteOption{}
+	inputData := metadata.InstAsstDeleteOption{}
 	if err := ctx.DecodeInto(&inputData); nil != err {
 		ctx.RespAutoError(err)
 		return
 	}
-	result, err := s.core.AssociationOperation().DeleteInstanceAssociation(ctx.Kit, inputData)
+	result, err := s.core.AssociationOperation().DeleteInstanceAssociation(ctx.Kit, inputData.ObjID, inputData.Opt)
 	if err != nil {
 		ctx.RespAutoError(err)
 		return

--- a/src/source_controller/coreservice/service/instances_dependence.go
+++ b/src/source_controller/coreservice/service/instances_dependence.go
@@ -29,7 +29,7 @@ func (s *coreService) IsInstAsstExist(kit *rest.Kit, objID string, instID uint64
 	cond := mongo.NewCondition()
 	cond.Element(&mongo.Eq{Key: common.BKObjIDField, Val: objID}, &mongo.Eq{Key: common.BKInstIDField, Val: instID})
 	queryCond := metadata.QueryCondition{Condition: cond.ToMapStr()}
-	objInsts, err := s.core.AssociationOperation().SearchInstanceAssociation(kit, queryCond)
+	objInsts, err := s.core.AssociationOperation().SearchInstanceAssociation(kit, objID, queryCond)
 	if nil != err {
 		blog.Errorf("search instance association error %v, rid: %s", err, kit.Rid)
 		return false, err
@@ -37,7 +37,7 @@ func (s *coreService) IsInstAsstExist(kit *rest.Kit, objID string, instID uint64
 	cond = mongo.NewCondition()
 	cond.Element(&mongo.Eq{Key: common.BKAsstObjIDField, Val: objID}, &mongo.Eq{Key: common.BKAsstInstIDField, Val: instID})
 	queryCond = metadata.QueryCondition{Condition: cond.ToMapStr()}
-	objAsstInsts, err := s.core.AssociationOperation().SearchInstanceAssociation(kit, queryCond)
+	objAsstInsts, err := s.core.AssociationOperation().SearchInstanceAssociation(kit, objID, queryCond)
 	if nil != err {
 		blog.Errorf("search instance to association error %v, rid: %s", err, kit.Rid)
 		return false, err
@@ -54,7 +54,7 @@ func (s *coreService) DeleteInstAsst(kit *rest.Kit, objID string, instID uint64)
 	cond := mongo.NewCondition()
 	cond.Element(&mongo.Eq{Key: common.BKObjIDField, Val: objID}, &mongo.Eq{Key: common.BKInstIDField, Val: instID})
 	deleteCond := metadata.DeleteOption{Condition: cond.ToMapStr()}
-	_, err := s.core.AssociationOperation().DeleteInstanceAssociation(kit, deleteCond)
+	_, err := s.core.AssociationOperation().DeleteInstanceAssociation(kit, objID, deleteCond)
 	if nil != err {
 		blog.Errorf("delete instance association error %v, rid: %s", err, kit.Rid)
 		return err
@@ -62,7 +62,7 @@ func (s *coreService) DeleteInstAsst(kit *rest.Kit, objID string, instID uint64)
 	cond = mongo.NewCondition()
 	cond.Element(&mongo.Eq{Key: common.BKAsstObjIDField, Val: objID}, &mongo.Eq{Key: common.BKAsstInstIDField, Val: instID})
 	deleteCond = metadata.DeleteOption{Condition: cond.ToMapStr()}
-	_, err = s.core.AssociationOperation().DeleteInstanceAssociation(kit, deleteCond)
+	_, err = s.core.AssociationOperation().DeleteInstanceAssociation(kit, objID, deleteCond)
 	if nil != err {
 		blog.Errorf("delete instance to association error %v, rid: %s", err, kit.Rid)
 		return err

--- a/src/storage/driver/mongodb/table.go
+++ b/src/storage/driver/mongodb/table.go
@@ -88,13 +88,13 @@ func TBObjClassification() types.Table {
 }
 
 // 实例关系数据， TBInstAsst别名函数
-func TBInstnceAsst(objID string) types.Table {
+func TBInstanceAsst(objID string) types.Table {
 	return Table(common.GetObjectInstAsstTableName(objID))
 }
 
-// 实例关系数据， TBInstnceAsst别名函数
+// 实例关系数据， TBInstanceAsst别名函数
 func TBInstAsst(objID string) types.Table {
-	return TBInstnceAsst(objID)
+	return TBInstanceAsst(objID)
 }
 
 func TBModuleHostConfig() types.Table {

--- a/src/test/topo_server/asst_test.go
+++ b/src/test/topo_server/asst_test.go
@@ -182,7 +182,8 @@ var _ = Describe("inst test", func() {
 	It("delete inst association batch", func() {
 		list := make([]int64, 501, 501)
 		input := &metadata.DeleteAssociationInstBatchRequest{
-			ID: list,
+			ID:    list,
+			ObjID: "bk_router",
 		}
 		rsp, err := asstClient.DeleteInstBatch(context.Background(), header, input)
 		util.RegisterResponse(rsp)
@@ -192,7 +193,8 @@ var _ = Describe("inst test", func() {
 	//check "DeleteInstBatch" features available.
 	It("delete inst association batch", func() {
 		input := &metadata.DeleteAssociationInstBatchRequest{
-			ID: []int64{instAsst1, instAsst2},
+			ID:    []int64{instAsst1, instAsst2},
+			ObjID: "bk_router",
 		}
 		rsp, err := asstClient.DeleteInstBatch(context.Background(), header, input)
 		util.RegisterResponse(rsp)

--- a/src/web_server/logics/association.go
+++ b/src/web_server/logics/association.go
@@ -57,7 +57,7 @@ func (lgc *Logics) fetchAssociationData(ctx context.Context, header http.Header,
 	rid := util.ExtractRequestIDFromContext(ctx)
 
 	ccErr := lgc.CCErr.CreateDefaultCCErrorIf(util.GetLanguage(header))
-	input := &metadata.SearchAssociationInstRequest{}
+	input := &metadata.SearchAssociationInstRequest{ObjID: objID}
 
 	//实例作为关联关系源模型
 	cond := condition.CreateCondition()


### PR DESCRIPTION
### 优化的功能:
- 实例关联数据写入相应分表

**注意：因为需要知道模型ID才能知道实例关联所在的表，因此对所有相关接口增加了必填objID的参数校验，会导致部分原有接口不可用**
