### PR TITLE
3.2升级到3.9进程有空bind_ip时使用默认值127.0.0.1

### DIFF
--- a/src/scene_server/admin_server/upgrader/x19.05.16.01/upgrade_service_template.go
+++ b/src/scene_server/admin_server/upgrader/x19.05.16.01/upgrade_service_template.go
@@ -353,12 +353,16 @@ func upgradeServiceTemplate(ctx context.Context, db dal.RDB, conf *upgrader.Conf
 								}
 							}
 
-							bindIP, err := tplBindIP.IP(hostMap[moduleHost.HostID])
-							if err != nil {
-								return err
-							}
+							if tplBindIP == "" {
+								*inst.BindIP = "127.0.0.1"
+							} else {
+								bindIP, err := tplBindIP.IP(hostMap[moduleHost.HostID])
+								if err != nil {
+									return err
+								}
 
-							*inst.BindIP = bindIP
+								*inst.BindIP = bindIP
+							}
 						} else {
 							inst.BindIP = new(string)
 						}

--- a/src/scene_server/host_server/service/cloudarea.go
+++ b/src/scene_server/host_server/service/cloudarea.go
@@ -223,13 +223,6 @@ func (s *Service) CreatePlat(ctx *rest.Contexts) {
 	input[common.BKCreator] = user
 	input[common.BKLastEditor] = user
 
-	// auth: check authorization
-	if err := s.AuthManager.AuthorizeResourceCreate(ctx.Kit.Ctx, ctx.Kit.Header, 0, authmeta.Model); err != nil {
-		blog.Errorf("check create plat authorization failed, err: %v, rid: %s", err, ctx.Kit.Rid)
-		ctx.RespAutoError(ctx.Kit.CCError.CCError(common.CCErrCommAuthorizeFailed))
-		return
-	}
-
 	instInfo := &meta.CreateModelInstance{
 		Data: mapstr.NewFromMap(input),
 	}


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
