### PR TITLE
权限中心回调接口支持动态模型实例

### DIFF
--- a/src/scene_server/auth_server/service/gen_method.go
+++ b/src/scene_server/auth_server/service/gen_method.go
@@ -81,12 +81,10 @@ func (s *AuthService) genResourcePullMethod(kit *rest.Kit, resourceType iam.Type
 
 	case iam.SysInstance:
 		return types.ResourcePullMethod{
-			ListAttr:      s.lgc.ListAttr,
-			ListAttrValue: s.lgc.ListAttrValue,
-			ListInstance:  s.lgc.ListModelInstance,
-			FetchInstanceInfo: func(kit *rest.Kit, resourceType iam.TypeID, filter *types.FetchInstanceInfoFilter) ([]map[string]interface{}, error) {
-				return s.lgc.FetchInstanceInfo(kit, resourceType, filter, nil)
-			},
+			ListAttr:          s.lgc.ListAttr,
+			ListAttrValue:     s.lgc.ListAttrValue,
+			ListInstance:      s.lgc.ListModelInstance,
+			FetchInstanceInfo: s.lgc.FetchObjInstInfo,
 			ListInstanceByPolicy: func(kit *rest.Kit, resourceType iam.TypeID, filter *types.ListInstanceByPolicyFilter, page types.Page) (result *types.ListInstanceResult, e error) {
 				return s.lgc.ListInstanceByPolicy(kit, resourceType, filter, page, nil)
 			},


### PR DESCRIPTION
仅支持了按ID查询模型实例的回调接口，如何对其它直接按名称查询的接口进行分页需要再看一下怎么实现