### PR TITLE
添加注册主机静态快照采集的dataid的接口

### DIFF
--- a/scripts/init.py
+++ b/scripts/init.py
@@ -371,37 +371,6 @@ registerServer:
   addrs: $rd_server
   usr:
   pwd:
-# mongodb配置
-mongodb:
-  host: $mongo_host
-  port: $mongo_port
-  usr: $mongo_user
-  pwd: "$mongo_pass"
-  database: $db
-  maxOpenConns: 5
-  maxIdleConns: 1
-  mechanism: SCRAM-SHA-1
-  rsName: $rs_name
-  # mongodb事件监听存储事件链的mongodb配置
-watch:
-  host: $mongo_host
-  port: $mongo_port
-  usr: $mongo_user
-  pwd: "$mongo_pass"
-  database: $db
-  maxOpenConns: 10
-  maxIdleConns: 5
-  mechanism: SCRAM-SHA-1
-  rsName: $rs_name
-  socketTimeoutSeconds: 10
-# redis配置
-redis:
-  host: $redis_host:$redis_port
-  pwd: "$redis_pass"
-  sentinelPwd: "$sentinel_pass"
-  database: "0"
-  maxOpenConns: 5
-  maxIDleConns: 1
 # 指定configures的路径，通过这个路径找到其他的配置文件
 confs:
   dir: $configures_dir
@@ -411,14 +380,6 @@ errors:
 # 指定language的路径
 language:
   res: conf/language
-# 权限相关配置
-auth:
-  #蓝鲸权限中心地址,可配置多个,用,(逗号)分割
-  address: $auth_address
-  #cmdb项目在蓝鲸权限中心的应用编码
-  appCode: $auth_app_code
-  #cmdb项目在蓝鲸权限中心的应用密钥
-  appSecret: $auth_app_secret
     '''
 
     template = FileTemplate(migrate_file_template_str)

--- a/src/common/backbone/configcenter/viper.go
+++ b/src/common/backbone/configcenter/viper.go
@@ -451,16 +451,10 @@ func IsExist(key string) bool {
 }
 
 func getRedisParser() *viperParser {
-	if migrateParser != nil {
-		return migrateParser
-	}
 	return redisParser
 }
 
 func getMongodbParser() *viperParser {
-	if migrateParser != nil {
-		return migrateParser
-	}
 	return mongodbParser
 }
 

--- a/src/common/metadata/dataid.go
+++ b/src/common/metadata/dataid.go
@@ -1,0 +1,248 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metadata
+
+type GseConfigAddStreamToParams struct {
+	Metadata  GseConfigAddStreamToMetadata `json:"metadata"`
+	Operation GseConfigOperation           `json:"operation"`
+	StreamTo  GseConfigStreamTo            `json:"stream_to"`
+}
+
+type GseConfigAddStreamToMetadata struct {
+	PlatName GseConfigPlatName       `json:"plat_name"`
+	Label    *GseConfigStreamToLabel `json:"label,omitempty"`
+}
+
+type GseConfigPlatName string
+
+const (
+	GseConfigPlatTglog     GseConfigPlatName = "tglog"
+	GseConfigPlatTdm       GseConfigPlatName = "tdm"
+	GseConfigPlatBkmonitor GseConfigPlatName = "bkmonitor"
+	GseConfigPlatTgdp      GseConfigPlatName = "tgdp"
+)
+
+type GseConfigStreamToLabel struct {
+	BizID   int64  `json:"bk_biz_id,omitempty"`
+	BizName string `json:"bk_biz_name,omitempty"`
+}
+
+type GseConfigOperation struct {
+	OperatorName string `json:"operator_name"`
+}
+
+type GseConfigStreamTo struct {
+	Name        string                   `json:"name"`
+	ReportMode  GseConfigReportMode      `json:"report_mode"`
+	DataLogPath string                   `json:"data_log_path,omitempty"`
+	Kafka       *GseConfigStreamToKafka  `json:"kafka,omitempty"`
+	Redis       *GseConfigStreamToRedis  `json:"redis,omitempty"`
+	Pulsar      *GseConfigStreamToPulsar `json:"pulsar,omitempty"`
+}
+
+type GseConfigReportMode string
+
+const (
+	GseConfigReportModeKafka  GseConfigReportMode = "kafka"
+	GseConfigReportModeRedis  GseConfigReportMode = "redis"
+	GseConfigReportModeFile   GseConfigReportMode = "file"
+	GseConfigReportModePulsar GseConfigReportMode = "pulsar"
+)
+
+type GseConfigStreamToKafka struct {
+	StorageAddresses []GseConfigStorageAddress `json:"storage_address"`
+	SaslUsername     string                    `json:"sasl_usename,omitempty"`
+	SaslPassword     string                    `json:"sasl_passwd,omitempty"`
+	SaslMechanisms   string                    `json:"sasl_mechanisms,omitempty"`
+	SecurityProtocol string                    `json:"security_protocol,omitempty"`
+}
+
+type GseConfigStorageAddress struct {
+	IP   string `json:"ip"`
+	Port int64  `json:"port"`
+}
+
+type GseConfigStreamToRedis struct {
+	StorageAddresses []GseConfigStorageAddress `json:"storage_address"`
+	Password         string                    `json:"passwd,omitempty"`
+	MasterName       string                    `json:"master_name,omitempty"`
+}
+
+type GseConfigStreamToPulsar struct {
+	StorageAddresses []GseConfigStorageAddress `json:"storage_address"`
+	Token            string                    `json:"token,omitempty"`
+}
+
+type GseConfigAddStreamToResp struct {
+	EsbBaseResponse `json:",inline"`
+	Data            *GseConfigAddStreamToResult `json:"data"`
+}
+
+type GseConfigAddStreamToResult struct {
+	StreamToID int64  `json:"stream_to_id"`
+	Name       string `json:"name"`
+}
+
+type GseConfigUpdateStreamToParams struct {
+	Condition     GseConfigStreamToCondition           `json:"condition"`
+	Operation     GseConfigOperation                   `json:"operation"`
+	Specification GseConfigUpdateStreamToSpecification `json:"specification"`
+}
+
+type GseConfigStreamToCondition struct {
+	StreamToID int64             `json:"stream_to_id"`
+	PlatName   GseConfigPlatName `json:"plat_name"`
+}
+
+type GseConfigUpdateStreamToSpecification struct {
+	StreamTo GseConfigStreamTo `json:"stream_to"`
+}
+
+type GseConfigDeleteStreamToParams struct {
+	Condition GseConfigStreamToCondition `json:"condition"`
+	Operation GseConfigOperation         `json:"operation"`
+}
+
+type GseConfigQueryStreamToParams struct {
+	Condition GseConfigQueryStreamToCondition `json:"condition"`
+	Operation GseConfigOperation              `json:"operation"`
+}
+
+type GseConfigQueryStreamToCondition struct {
+	GseConfigStreamToCondition `json:",inline"`
+	Label                      *GseConfigStreamToLabel `json:"label,omitempty"`
+}
+
+type GseConfigQueryStreamToResp struct {
+	EsbBaseResponse `json:",inline"`
+	Data            []GseConfigAddStreamToParams `json:"data"`
+}
+
+type GseConfigAddRouteParams struct {
+	GseConfigChannel `json:",inline"`
+	Operation        GseConfigOperation `json:"operation"`
+}
+
+type GseConfigChannel struct {
+	Metadata      GseConfigAddRouteMetadata    `json:"metadata"`
+	Route         []GseConfigRoute             `json:"route,omitempty"`
+	StreamFilters []GseConfigRouteStreamFilter `json:"stream_filters,omitempty"`
+}
+
+type GseConfigAddRouteMetadata struct {
+	PlatName  GseConfigPlatName    `json:"plat_name"`
+	Label     *GseConfigRouteLabel `json:"label,omitempty"`
+	ChannelID int64                `json:"channel_id,omitempty"`
+}
+
+type GseConfigRouteLabel struct {
+	Odm       string `json:"odm,omitempty"`
+	BkBizID   int64  `json:"bk_biz_id,omitempty"`
+	BkBizName string `json:"bk_biz_name,omitempty"`
+}
+
+type GseConfigRoute struct {
+	Name          string                 `json:"name"`
+	StreamTo      GseConfigRouteStreamTo `json:"stream_to"`
+	FilterNameAnd []string               `json:"filter_name_and,omitempty"`
+	FilterNameOr  []string               `json:"filter_name_or,omitempty"`
+}
+
+type GseConfigRouteStreamTo struct {
+	StreamToID int64                 `json:"stream_to_id"`
+	Kafka      *GseConfigRouteKafka  `json:"kafka,omitempty"`
+	Redis      *GseConfigRouteRedis  `json:"redis,omitempty"`
+	Pulsar     *GseConfigRoutePulsar `json:"pulsar,omitempty"`
+}
+
+type GseConfigRouteKafka struct {
+	TopicName string `json:"topic_name"`
+	DataSet   string `json:"data_set,omitempty"`
+	BizID     int64  `json:"biz_id,omitempty"`
+	Partition int64  `json:"partition,omitempty"`
+}
+
+type GseConfigRouteRedis struct {
+	ChannelName string `json:"channel_name"`
+	DataSet     string `json:"data_set,omitempty"`
+	BizID       int64  `json:"biz_id,omitempty"`
+}
+
+type GseConfigRoutePulsar struct {
+	Name      string `json:"name"`
+	Tenant    string `json:"tenant,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+type GseConfigRouteStreamFilter struct {
+	Name           string `json:"name"`
+	FieldIndex     int64  `json:"field_index"`
+	FieldDataType  string `json:"field_data_type"`
+	FieldDataValue string `json:"field_data_value"`
+	FieldSeparator string `json:"field_separator,omitempty"`
+	FieldIn        string `json:"field_in,omitempty"`
+}
+
+type GseConfigAddRouteResp struct {
+	EsbBaseResponse `json:",inline"`
+	Data            *GseConfigAddRouteResult `json:"data"`
+}
+
+type GseConfigAddRouteResult struct {
+	ChannelID  int64 `json:"channel_id"`
+	ProofingID int64 `json:"proofing_id"`
+}
+
+type GseConfigUpdateRouteParams struct {
+	Condition     GseConfigRouteCondition           `json:"condition"`
+	Operation     GseConfigOperation                `json:"operation"`
+	Specification GseConfigUpdateRouteSpecification `json:"specification"`
+}
+
+type GseConfigRouteCondition struct {
+	ChannelID int64                `json:"channel_id"`
+	PlatName  GseConfigPlatName    `json:"plat_name"`
+	Label     *GseConfigRouteLabel `json:"label,omitempty"`
+}
+
+type GseConfigUpdateRouteSpecification struct {
+	Route         []GseConfigRoute             `json:"route,omitempty"`
+	StreamFilters []GseConfigRouteStreamFilter `json:"stream_filters,omitempty"`
+}
+
+type GseConfigDeleteRouteParams struct {
+	Condition GseConfigRouteCondition `json:"condition"`
+	Operation GseConfigOperation      `json:"operation"`
+}
+
+type GseConfigDeleteRouteOperation struct {
+	GseConfigOperation `json:",inline"`
+	Method             GseConfigDeleteRouteMethod `json:"method"`
+}
+
+type GseConfigDeleteRouteMethod string
+
+const (
+	All           GseConfigDeleteRouteMethod = "all"
+	Specification GseConfigDeleteRouteMethod = "specification"
+)
+
+type GseConfigQueryRouteParams struct {
+	Condition GseConfigRouteCondition `json:"condition"`
+	Operation GseConfigOperation      `json:"operation"`
+}
+
+type GseConfigQueryRouteResp struct {
+	EsbBaseResponse `json:",inline"`
+	Data            []GseConfigChannel `json:"data"`
+}

--- a/src/common/resource/esb/esb.go
+++ b/src/common/resource/esb/esb.go
@@ -36,22 +36,26 @@ func EsbClient() esbserver.EsbClientInterface {
 }
 
 func ParseEsbConfig(prefix string) (*esbutil.EsbConfig, errors.CCErrorCoder) {
+	if len(prefix) > 0 {
+		prefix = prefix + "."
+	}
+
 	var err error
-	esbAddr, err := cc.String(prefix + ".esb.addr")
+	esbAddr, err := cc.String(prefix + "esb.addr")
 	if err != nil {
 		blog.Infof("esb addr not found, unable to call esb service")
 		lastConfigErr = errors.NewCCError(common.CCErrCommConfMissItem, "Configuration file missing [esb.addr] configuration item")
 		return nil, lastConfigErr
 	}
 
-	esbAppCode, err := cc.String(prefix + ".esb.appCode")
+	esbAppCode, err := cc.String(prefix + "esb.appCode")
 	if err != nil {
 		blog.Errorf("esb appCode not found, unable to call esb service")
 		lastConfigErr = errors.NewCCError(common.CCErrCommConfMissItem, "Configuration file missing [esb.esbAppCode] configuration item")
 		return nil, lastConfigErr
 	}
 
-	esbAppSecret, err := cc.String(prefix + ".esb.appSecret")
+	esbAppSecret, err := cc.String(prefix + "esb.appSecret")
 	if err != nil {
 		blog.Errorf("esb appSecretOk not found,unable to call esb service")
 		lastConfigErr = errors.NewCCError(common.CCErrCommConfMissItem, "Configuration file missing [esb.appSecret] configuration item")
@@ -59,7 +63,7 @@ func ParseEsbConfig(prefix string) (*esbutil.EsbConfig, errors.CCErrorCoder) {
 	}
 
 	// 不支持热更新
-	tlsConfig, err = util.NewTLSClientConfigFromConfig(prefix+".esb", nil)
+	tlsConfig, err = util.NewTLSClientConfigFromConfig(prefix+"esb", nil)
 	if err != nil {
 		lastInitErr = errors.NewCCError(common.CCErrCommResourceInitFailed, "'esb' initialization failed")
 		return nil, lastInitErr

--- a/src/scene_server/admin_server/app/options/options.go
+++ b/src/scene_server/admin_server/app/options/options.go
@@ -45,15 +45,16 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 }
 
 type Config struct {
-	MongoDB       mongo.Config
-	WatchDB       mongo.Config
-	Errors        ErrorConfig
-	Language      LanguageConfig
-	Configures    ConfConfig
-	Register      RegisterConfig
-	ProcSrvConfig ProcSrvConfig
-	Redis         redis.Config
-	Iam           iam.AuthConfig
+	MongoDB    mongo.Config
+	WatchDB    mongo.Config
+	Errors     ErrorConfig
+	Language   LanguageConfig
+	Configures ConfConfig
+	Register   RegisterConfig
+	Redis      redis.Config
+	SnapRedis  redis.Config
+	Iam        iam.AuthConfig
+	SnapDataID int64
 }
 
 type LanguageConfig struct {
@@ -70,8 +71,4 @@ type ConfConfig struct {
 
 type RegisterConfig struct {
 	Address string
-}
-
-type ProcSrvConfig struct {
-	CCApiSrvAddr string
 }

--- a/src/scene_server/admin_server/app/server.go
+++ b/src/scene_server/admin_server/app/server.go
@@ -22,6 +22,7 @@ import (
 	"configcenter/src/common/backbone"
 	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
+	"configcenter/src/common/resource/esb"
 	"configcenter/src/common/types"
 	"configcenter/src/scene_server/admin_server/app/options"
 	"configcenter/src/scene_server/admin_server/configures"
@@ -31,6 +32,9 @@ import (
 )
 
 func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOption) error {
+	// init esb client
+	esb.InitEsbClient(nil)
+
 	svrInfo, err := types.NewServerInfo(op.ServConf)
 	if err != nil {
 		return fmt.Errorf("wrap server info failed, err: %v", err)
@@ -41,6 +45,30 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	if err := cc.SetMigrateFromFile(op.ServConf.ExConfig); err != nil {
 		return fmt.Errorf("parse config file error %s", err.Error())
 	}
+
+	process.Config.Errors.Res, _ = cc.String("errors.res")
+	process.Config.Language.Res, _ = cc.String("language.res")
+	process.Config.Configures.Dir, _ = cc.String("confs.dir")
+	process.Config.Register.Address, _ = cc.String("registerServer.addrs")
+	snapDataID, _ := cc.Int("hostsnap.dataID")
+	process.Config.SnapDataID = int64(snapDataID)
+
+	// load mongodb, redis and common config from configure directory
+	mongodbPath := process.Config.Configures.Dir + "/" + types.CCConfigureMongo
+	if err := cc.SetMongodbFromFile(mongodbPath); err != nil {
+		return fmt.Errorf("parse mongodb config from file[%s] failed, err: %v", mongodbPath, err)
+	}
+
+	redisPath := process.Config.Configures.Dir + "/" + types.CCConfigureRedis
+	if err := cc.SetRedisFromFile(redisPath); err != nil {
+		return fmt.Errorf("parse redis config from file[%s] failed, err: %v", redisPath, err)
+	}
+
+	commonPath := process.Config.Configures.Dir + "/" + types.CCConfigureCommon
+	if err := cc.SetCommonFromFile(commonPath); err != nil {
+		return fmt.Errorf("parse common config from file[%s] failed, err: %v", commonPath, err)
+	}
+
 	mongoConf, err := cc.Mongo("mongodb")
 	if err != nil {
 		return err
@@ -58,13 +86,14 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 		return err
 	}
 	process.Config.Redis = redisConf
-	process.Config.Errors.Res, _ = cc.String("errors.res")
-	process.Config.Language.Res, _ = cc.String("language.res")
-	process.Config.Configures.Dir, _ = cc.String("confs.dir")
-	process.Config.Register.Address, _ = cc.String("registerServer.addrs")
-	process.Config.ProcSrvConfig.CCApiSrvAddr, _ = cc.String("procsrv.ccApi")
 
-	process.Config.Iam, err = iam.ParseConfigFromKV("auth", nil)
+	snapRedisConf, err := cc.Redis("redis.snap")
+	if err != nil {
+		return fmt.Errorf("get host snapshot redis configuration failed, err: %v", err)
+	}
+	process.Config.SnapRedis = snapRedisConf
+
+	process.Config.Iam, err = iam.ParseConfigFromKV("authServer", nil)
 	if err != nil && auth.EnableAuthorize() {
 		blog.Errorf("parse iam error: %v", err)
 	}
@@ -124,7 +153,6 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 			return fmt.Errorf("connect redis server failed, err: %s", err.Error())
 		}
 		process.Service.SetCache(cache)
-		process.Service.SetApiSrvAddr(process.Config.ProcSrvConfig.CCApiSrvAddr)
 
 		if auth.EnableAuthorize() {
 			blog.Info("enable auth center access.")
@@ -136,6 +164,10 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 			process.Service.SetIam(iamCli)
 		} else {
 			blog.Infof("disable auth center access.")
+		}
+
+		if esbConfig, err := esb.ParseEsbConfig(""); err == nil {
+			esb.UpdateEsbConfig(*esbConfig)
 		}
 		break
 	}

--- a/src/scene_server/admin_server/service/dataid.go
+++ b/src/scene_server/admin_server/service/dataid.go
@@ -1,0 +1,383 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"configcenter/src/common"
+	"configcenter/src/common/blog"
+	"configcenter/src/common/errors"
+	"configcenter/src/common/json"
+	"configcenter/src/common/metadata"
+	"configcenter/src/common/resource/esb"
+	"configcenter/src/common/util"
+
+	"github.com/emicklei/go-restful"
+)
+
+const (
+	snapStreamToName   = "cc_hostsnap_streamto"
+	snapRouteName      = "cc_hostsnap_route"
+	gseStreamToIDDBKey = "gse_stream_to_id"
+)
+
+var (
+	snapStreamTo *metadata.GseConfigStreamTo
+	snapChannel  *metadata.GseConfigChannel
+)
+
+// migrateDataID register, update or delete cc related data id in gse
+func (s *Service) migrateDataID(req *restful.Request, resp *restful.Response) {
+	header := req.Request.Header
+	rid := util.GetHTTPCCRequestID(header)
+	user := util.GetUser(header)
+	defErr := s.CCErr.CreateDefaultCCErrorIf(util.GetLanguage(header))
+
+	if s.Config.SnapDataID == 0 {
+		blog.Errorf("host snap data id not set in configuration, rid: %s", rid)
+		result := &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommParamsNeedSet, "hostsnap.dataid")}
+		_ = resp.WriteError(http.StatusOK, result)
+		return
+	}
+
+	// get stream to config by db id from gse, if not found, register it, else update it
+	streamTo, err := s.generateGseConfigStreamTo(header, user, defErr, rid)
+	if err != nil {
+		_ = resp.WriteError(http.StatusOK, err)
+		return
+	}
+
+	streamToID, streamTos, err := s.gseConfigQueryStreamTo(header, user, defErr, rid)
+	if err != nil {
+		_ = resp.WriteError(http.StatusOK, err)
+		return
+	}
+
+	if len(streamTos) == 0 {
+		if streamToID, err = s.gseConfigAddStreamTo(streamTo, header, user, defErr, rid); err != nil {
+			_ = resp.WriteError(http.StatusOK, err)
+			return
+		}
+	} else if len(streamTos) != 1 {
+		blog.ErrorJSON("get multiple stream to(%s), rid: %s", streamTos, rid)
+		result := &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommParamsInvalid, "stream to id")}
+		_ = resp.WriteError(http.StatusOK, result)
+		return
+	} else {
+		if !reflect.DeepEqual(streamTos[0].StreamTo, *streamTo) {
+			if err := s.gseConfigUpdateStreamTo(streamTo, streamToID, header, user, defErr, rid); err != nil {
+				_ = resp.WriteError(http.StatusOK, err)
+				return
+			}
+		}
+	}
+
+	// get already registered channel by host snap data id from gse, if not found, register it, else update it
+	channel, err := s.generateGseConfigChannel(streamToID, header, user, defErr, rid)
+	if err != nil {
+		_ = resp.WriteError(http.StatusOK, err)
+		return
+	}
+
+	channels, err := s.gseConfigQueryRoute(header, user, defErr, rid)
+	if err != nil {
+		blog.Errorf("query gse channel failed, ** skip this error for not exist case **, err: %v, rid: %s", err, rid)
+		// TODO clarify this error when gse returns a specified error code
+		// _ = resp.WriteError(http.StatusOK, err)
+		// return
+	}
+
+	if len(channels) == 0 {
+		if err := s.gseConfigAddRoute(channel, header, user, defErr, rid); err != nil {
+			_ = resp.WriteError(http.StatusOK, err)
+			return
+		}
+	} else if len(channels) != 1 {
+		blog.ErrorJSON("get multiple channel by data id %s, channels: %s, rid: %s", s.Config.SnapDataID, channels, rid)
+		result := &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommParamsInvalid, "hostsnap.dataid")}
+		_ = resp.WriteError(http.StatusOK, result)
+		return
+	} else {
+		if !reflect.DeepEqual(channels[0], *channel) {
+			if err := s.gseConfigUpdateRoute(channel, header, user, defErr, rid); err != nil {
+				_ = resp.WriteError(http.StatusOK, err)
+				return
+			}
+		}
+	}
+
+	_ = resp.WriteEntity(metadata.NewSuccessResp(nil))
+}
+
+// generateGseConfigStreamTo generate host snap stream to config by snap redis config
+func (s *Service) generateGseConfigStreamTo(header http.Header, user string, defErr errors.DefaultCCErrorIf, rid string) (
+	*metadata.GseConfigStreamTo, error) {
+
+	if snapStreamTo != nil {
+		return snapStreamTo, nil
+	}
+
+	redisStreamToAddresses := make([]metadata.GseConfigStorageAddress, 0)
+	snapRedisAddresses := strings.Split(s.Config.SnapRedis.Address, ",")
+	for _, addr := range snapRedisAddresses {
+		ipPort := strings.Split(addr, ":")
+		if len(ipPort) != 2 {
+			blog.Errorf("host snap redis address is invalid, addr: %s, rid: %s", addr, rid)
+			return nil, &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommParamsInvalid, "snap redis")}
+		}
+
+		port, err := strconv.ParseInt(ipPort[1], 10, 64)
+		if err != nil {
+			blog.Errorf("parse snap redis address port failed, err: %v, port: %s, rid: %s", err, ipPort[1], rid)
+			return nil, &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommParamsInvalid, "snap redis")}
+		}
+
+		redisStreamToAddresses = append(redisStreamToAddresses, metadata.GseConfigStorageAddress{
+			IP:   ipPort[0],
+			Port: port,
+		})
+	}
+
+	snapStreamTo = &metadata.GseConfigStreamTo{
+		Name:       snapStreamToName,
+		ReportMode: metadata.GseConfigReportModeRedis,
+		Redis: &metadata.GseConfigStreamToRedis{
+			StorageAddresses: redisStreamToAddresses,
+			Password:         s.Config.SnapRedis.Password,
+			MasterName:       s.Config.SnapRedis.MasterName,
+		},
+	}
+	return snapStreamTo, nil
+}
+
+type dbStreamToID struct {
+	HostSnap int64 `bson:"host_snap"`
+}
+
+// gseConfigQueryStreamTo get host snap stream to id from db, then get stream to config from gse
+func (s *Service) gseConfigQueryStreamTo(header http.Header, user string, defErr errors.DefaultCCErrorIf, rid string) (
+	int64, []metadata.GseConfigAddStreamToParams, error) {
+
+	cond := map[string]interface{}{"_id": gseStreamToIDDBKey}
+	streamToID := new(dbStreamToID)
+	if err := s.db.Table(common.BKTableNameSystem).Find(cond).One(s.ctx, &streamToID); err != nil {
+		if s.db.IsNotFoundError(err) {
+			return 0, make([]metadata.GseConfigAddStreamToParams, 0), nil
+		}
+		blog.Errorf("get stream to id from db failed, err: %v, rid: %s", err, rid)
+		return 0, nil, &metadata.RespError{Msg: defErr.Error(common.CCErrCommDBSelectFailed)}
+	}
+
+	commonOperation := metadata.GseConfigOperation{
+		OperatorName: user,
+	}
+	params := &metadata.GseConfigQueryStreamToParams{
+		Condition: metadata.GseConfigQueryStreamToCondition{
+			GseConfigStreamToCondition: metadata.GseConfigStreamToCondition{
+				StreamToID: streamToID.HostSnap,
+				PlatName:   metadata.GseConfigPlatBkmonitor,
+			},
+		},
+		Operation: commonOperation,
+	}
+
+	streamTos, err := esb.EsbClient().GseSrv().ConfigQueryStreamTo(s.ctx, header, params)
+	if err != nil {
+		blog.ErrorJSON("query stream to from gse failed, err: %s, params: %s, rid: %s", err, params, rid)
+		return streamToID.HostSnap, nil, &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommMigrateFailed, err.Error())}
+	}
+
+	return streamToID.HostSnap, streamTos, nil
+}
+
+// gseConfigAddStreamTo add host snap redis stream to config to gse, then add or update stream to id in db
+func (s *Service) gseConfigAddStreamTo(streamTo *metadata.GseConfigStreamTo, header http.Header, user string,
+	defErr errors.DefaultCCErrorIf, rid string) (int64, error) {
+
+	params := &metadata.GseConfigAddStreamToParams{
+		Metadata: metadata.GseConfigAddStreamToMetadata{
+			PlatName: metadata.GseConfigPlatBkmonitor,
+		},
+		Operation: metadata.GseConfigOperation{
+			OperatorName: user,
+		},
+		StreamTo: *streamTo,
+	}
+
+	addStreamResult, err := esb.EsbClient().GseSrv().ConfigAddStreamTo(s.ctx, header, params)
+	if err != nil {
+		blog.ErrorJSON("add stream to gse failed, err: %s, params: %s, rid: %s", err, params, rid)
+		return 0, &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommMigrateFailed, err.Error())}
+	}
+
+	cond := map[string]interface{}{"_id": gseStreamToIDDBKey}
+	streamToID := dbStreamToID{
+		HostSnap: addStreamResult.StreamToID,
+	}
+
+	if err := s.db.Table(common.BKTableNameSystem).Upsert(s.ctx, cond, &streamToID); err != nil {
+		blog.Errorf("upsert stream to id %d to db failed, err: %v, rid: %s", addStreamResult.StreamToID, err, rid)
+		return addStreamResult.StreamToID, &metadata.RespError{Msg: defErr.Error(common.CCErrCommDBSelectFailed)}
+	}
+
+	return addStreamResult.StreamToID, nil
+}
+
+// gseConfigUpdateStreamTo update host snap redis stream to config to gse
+func (s *Service) gseConfigUpdateStreamTo(streamTo *metadata.GseConfigStreamTo, streamToID int64, header http.Header,
+	user string, defErr errors.DefaultCCErrorIf, rid string) error {
+
+	params := &metadata.GseConfigUpdateStreamToParams{
+		Condition: metadata.GseConfigStreamToCondition{
+			StreamToID: streamToID,
+			PlatName:   metadata.GseConfigPlatBkmonitor,
+		},
+		Operation: metadata.GseConfigOperation{
+			OperatorName: user,
+		},
+		Specification: metadata.GseConfigUpdateStreamToSpecification{
+			StreamTo: *streamTo,
+		},
+	}
+
+	err := esb.EsbClient().GseSrv().ConfigUpdateStreamTo(s.ctx, header, params)
+	if err != nil {
+		blog.ErrorJSON("update stream to gse failed, err: %s, params: %s, rid: %s", err, params, rid)
+		return &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommMigrateFailed, err.Error())}
+	}
+	return nil
+}
+
+// generateGseConfigStreamTo generate host snap stream to config by snap redis config
+func (s *Service) generateGseConfigChannel(streamToID int64, header http.Header, user string,
+	defErr errors.DefaultCCErrorIf, rid string) (*metadata.GseConfigChannel, error) {
+
+	if snapChannel != nil {
+		return snapChannel, nil
+	}
+
+	cfgCond := map[string]interface{}{
+		"_id": common.ConfigAdminID,
+	}
+	cfg := make(map[string]string)
+	err := s.db.Table(common.BKTableNameSystem).Find(cfgCond).Fields(common.ConfigAdminValueField).One(s.ctx, &cfg)
+	if nil != err {
+		blog.Errorf("get config admin failed, err: %v", err)
+		return nil, err
+	}
+
+	configAdmin := new(metadata.ConfigAdmin)
+	if err := json.Unmarshal([]byte(cfg[common.ConfigAdminValueField]), configAdmin); err != nil {
+		blog.Errorf("unmarshal config admin failed, err: %v, config: %s", err, cfg[common.ConfigAdminValueField])
+		return nil, err
+	}
+
+	bizCond := map[string]interface{}{common.BKAppNameField: configAdmin.Backend.SnapshotBizName}
+	biz := new(metadata.BizBasicInfo)
+	if err := s.db.Table(common.BKTableNameBaseApp).Find(bizCond).One(s.ctx, biz); err != nil {
+		blog.Errorf("get snap biz failed, err: %v, biz name: %s", err, configAdmin.Backend.SnapshotBizName)
+		return nil, err
+	}
+
+	snapChannel = &metadata.GseConfigChannel{
+		Metadata: metadata.GseConfigAddRouteMetadata{
+			PlatName:  metadata.GseConfigPlatBkmonitor,
+			ChannelID: s.Config.SnapDataID,
+		},
+		Route: []metadata.GseConfigRoute{{
+			Name: snapRouteName,
+			StreamTo: metadata.GseConfigRouteStreamTo{
+				StreamToID: streamToID,
+				Redis: &metadata.GseConfigRouteRedis{
+					ChannelName: fmt.Sprintf("snapshot%d", biz.BizID),
+				},
+			},
+		}},
+	}
+	return snapChannel, nil
+}
+
+// gseConfigQueryRoute get channel by host snap data id from gse
+func (s *Service) gseConfigQueryRoute(header http.Header, user string, defErr errors.DefaultCCErrorIf, rid string) (
+	[]metadata.GseConfigChannel, error) {
+
+	commonOperation := metadata.GseConfigOperation{
+		OperatorName: user,
+	}
+	params := &metadata.GseConfigQueryRouteParams{
+		Condition: metadata.GseConfigRouteCondition{
+			ChannelID: s.Config.SnapDataID,
+			PlatName:  metadata.GseConfigPlatBkmonitor,
+		},
+		Operation: commonOperation,
+	}
+
+	channels, err := esb.EsbClient().GseSrv().ConfigQueryRoute(s.ctx, header, params)
+	if err != nil {
+		blog.ErrorJSON("query route from gse failed, err: %s, params: %s, rid: %s", err, params, rid)
+		return nil, &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommMigrateFailed, err.Error())}
+	}
+
+	return channels, nil
+}
+
+// gseConfigAddRoute add host snap channel to gse
+func (s *Service) gseConfigAddRoute(channel *metadata.GseConfigChannel, header http.Header, user string,
+	defErr errors.DefaultCCErrorIf, rid string) error {
+
+	params := &metadata.GseConfigAddRouteParams{
+		Operation: metadata.GseConfigOperation{
+			OperatorName: user,
+		},
+		GseConfigChannel: *channel,
+	}
+
+	_, err := esb.EsbClient().GseSrv().ConfigAddRoute(s.ctx, header, params)
+	if err != nil {
+		blog.ErrorJSON("add channel to gse failed, err: %s, params: %s, rid: %s", err, params, rid)
+		return &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommMigrateFailed, err.Error())}
+	}
+
+	return nil
+}
+
+// gseConfigUpdateRoute update host snap redis channel to gse
+func (s *Service) gseConfigUpdateRoute(channel *metadata.GseConfigChannel, header http.Header, user string,
+	defErr errors.DefaultCCErrorIf, rid string) error {
+
+	params := &metadata.GseConfigUpdateRouteParams{
+		Condition: metadata.GseConfigRouteCondition{
+			ChannelID: s.Config.SnapDataID,
+			PlatName:  metadata.GseConfigPlatBkmonitor,
+		},
+		Operation: metadata.GseConfigOperation{
+			OperatorName: user,
+		},
+		Specification: metadata.GseConfigUpdateRouteSpecification{
+			Route:         channel.Route,
+			StreamFilters: channel.StreamFilters,
+		},
+	}
+
+	err := esb.EsbClient().GseSrv().ConfigUpdateRoute(s.ctx, header, params)
+	if err != nil {
+		blog.ErrorJSON("update channel to gse failed, err: %s, params: %s, rid: %s", err, params, rid)
+		return &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommMigrateFailed, err.Error())}
+	}
+	return nil
+}

--- a/src/scene_server/admin_server/service/migrate.go
+++ b/src/scene_server/admin_server/service/migrate.go
@@ -40,9 +40,8 @@ func (s *Service) migrate(req *restful.Request, resp *restful.Response) {
 	defErr := s.CCErr.CreateDefaultCCErrorIf(util.GetLanguage(rHeader))
 	ownerID := common.BKDefaultOwnerID
 	updateCfg := &upgrader.Config{
-		OwnerID:      ownerID,
-		User:         common.CCSystemOperatorUserName,
-		CCApiSrvAddr: s.ccApiSrvAddr,
+		OwnerID: ownerID,
+		User:    common.CCSystemOperatorUserName,
 	}
 
 	if err := s.createWatchDBChainCollections(rid); err != nil {
@@ -191,9 +190,8 @@ func (s *Service) migrateSpecifyVersion(req *restful.Request, resp *restful.Resp
 	defErr := s.CCErr.CreateDefaultCCErrorIf(util.GetLanguage(rHeader))
 	ownerID := common.BKDefaultOwnerID
 	updateCfg := &upgrader.Config{
-		OwnerID:      ownerID,
-		User:         common.CCSystemOperatorUserName,
-		CCApiSrvAddr: s.ccApiSrvAddr,
+		OwnerID: ownerID,
+		User:    common.CCSystemOperatorUserName,
 	}
 
 	input := new(MigrateSpecifyVersionRequest)

--- a/src/scene_server/admin_server/service/service.go
+++ b/src/scene_server/admin_server/service/service.go
@@ -36,7 +36,6 @@ type Service struct {
 	db           dal.RDB
 	watchDB      dal.RDB
 	cache        redis.Client
-	ccApiSrvAddr string
 	ctx          context.Context
 	Config       options.Config
 	iam          *iam.Iam
@@ -65,10 +64,6 @@ func (s *Service) SetIam(iam *iam.Iam) {
 	s.iam = iam
 }
 
-func (s *Service) SetApiSrvAddr(ccApiSrvAddr string) {
-	s.ccApiSrvAddr = ccApiSrvAddr
-}
-
 func (s *Service) WebService() *restful.Container {
 	container := restful.NewContainer()
 
@@ -89,6 +84,7 @@ func (s *Service) WebService() *restful.Container {
 	api.Route(api.PUT("/update/system/config_admin").To(s.UpdateConfigAdmin))
 	api.Route(api.POST("/migrate/specify/version/{distribution}/{ownerID}").To(s.migrateSpecifyVersion))
 	api.Route(api.POST("/migrate/config/refresh").To(s.refreshConfig))
+	api.Route(api.POST("/migrate/dataid").To(s.migrateDataID))
 	api.Route(api.GET("/healthz").To(s.Healthz))
 
 	container.Add(api)

--- a/src/scene_server/admin_server/upgrader/register.go
+++ b/src/scene_server/admin_server/upgrader/register.go
@@ -31,9 +31,8 @@ import (
 
 // Config config for upgrader
 type Config struct {
-	OwnerID      string
-	User         string
-	CCApiSrvAddr string // cmdb nginx address
+	OwnerID string
+	User    string
 }
 
 // Upgrader define a version upgrader

--- a/src/scene_server/admin_server/upgrader/x18.10.10.01/pkg.go
+++ b/src/scene_server/admin_server/upgrader/x18.10.10.01/pkg.go
@@ -38,10 +38,5 @@ func upgrade(ctx context.Context, db dal.RDB, conf *upgrader.Config) (err error)
 		blog.Errorf("[upgrade x18.10.10.01] addProcInstanceDetailTable error  %s", err.Error())
 		return err
 	}
-	err = addProcFreshInstance(ctx, db, conf)
-	if err != nil {
-		blog.Errorf("[upgrade x18.10.10.01] addProcFreshInstance error  %s", err.Error())
-		return err
-	}
 	return
 }

--- a/src/thirdparty/esbserver/gse/api.go
+++ b/src/thirdparty/esbserver/gse/api.go
@@ -13,6 +13,7 @@ package gse
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"configcenter/src/common/metadata"
@@ -111,4 +112,212 @@ func (p *gse) UnRegisterProcInfo(ctx context.Context, h http.Header, data *metad
 		Into(resp)
 
 	return
+}
+
+func (p *gse) ConfigAddStreamTo(ctx context.Context, h http.Header, data *metadata.GseConfigAddStreamToParams) (
+	*metadata.GseConfigAddStreamToResult, error) {
+
+	resp := new(metadata.GseConfigAddStreamToResp)
+	subPath := "/v2/gse/config_add_streamto/"
+	params := &esbGseConfigAddStreamToParams{
+		EsbCommParams:              esbutil.GetEsbRequestParams(p.config.GetConfig(), h),
+		GseConfigAddStreamToParams: data,
+	}
+
+	err := p.client.Post().
+		WithContext(ctx).
+		Body(params).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	if err != nil {
+		return nil, err
+	}
+	if !resp.Result || resp.Code != 0 {
+		return nil, fmt.Errorf("gse config add streamto failed, code: %d, message: %s", resp.Code, resp.Message)
+	}
+	return resp.Data, nil
+}
+
+func (p *gse) ConfigUpdateStreamTo(ctx context.Context, h http.Header, data *metadata.GseConfigUpdateStreamToParams) error {
+	resp := new(metadata.EsbBaseResponse)
+	subPath := "/v2/gse/config_update_streamto/"
+	params := &esbGseConfigUpdateStreamToParams{
+		EsbCommParams:                 esbutil.GetEsbRequestParams(p.config.GetConfig(), h),
+		GseConfigUpdateStreamToParams: data,
+	}
+
+	err := p.client.Post().
+		WithContext(ctx).
+		Body(params).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	if err != nil {
+		return err
+	}
+	if !resp.Result || resp.Code != 0 {
+		return fmt.Errorf("gse config update streamto failed, code: %d, message: %s", resp.Code, resp.Message)
+	}
+	return nil
+}
+
+func (p *gse) ConfigDeleteStreamTo(ctx context.Context, h http.Header, data *metadata.GseConfigDeleteStreamToParams) error {
+	resp := new(metadata.EsbBaseResponse)
+	subPath := "/v2/gse/config_delete_streamto/"
+	params := &esbGseConfigDeleteStreamToParams{
+		EsbCommParams:                 esbutil.GetEsbRequestParams(p.config.GetConfig(), h),
+		GseConfigDeleteStreamToParams: data,
+	}
+
+	err := p.client.Post().
+		WithContext(ctx).
+		Body(params).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	if err != nil {
+		return err
+	}
+	if !resp.Result || resp.Code != 0 {
+		return fmt.Errorf("gse config delete streamto failed, code: %d, message: %s", resp.Code, resp.Message)
+	}
+	return nil
+}
+
+func (p *gse) ConfigQueryStreamTo(ctx context.Context, h http.Header, data *metadata.GseConfigQueryStreamToParams) (
+	[]metadata.GseConfigAddStreamToParams, error) {
+
+	resp := new(metadata.GseConfigQueryStreamToResp)
+	subPath := "/v2/gse/config_query_streamto/"
+	params := &esbGseConfigQueryStreamToParams{
+		EsbCommParams:                esbutil.GetEsbRequestParams(p.config.GetConfig(), h),
+		GseConfigQueryStreamToParams: data,
+	}
+
+	err := p.client.Post().
+		WithContext(ctx).
+		Body(params).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	if err != nil {
+		return nil, err
+	}
+	if !resp.Result || resp.Code != 0 {
+		return nil, fmt.Errorf("gse config query streamto failed, code: %d, message: %s", resp.Code, resp.Message)
+	}
+	return resp.Data, nil
+}
+
+func (p *gse) ConfigAddRoute(ctx context.Context, h http.Header, data *metadata.GseConfigAddRouteParams) (
+	*metadata.GseConfigAddRouteResult, error) {
+
+	resp := new(metadata.GseConfigAddRouteResp)
+	subPath := "/v2/gse/config_add_route/"
+	params := &esbGseConfigAddRouteParams{
+		EsbCommParams:           esbutil.GetEsbRequestParams(p.config.GetConfig(), h),
+		GseConfigAddRouteParams: data,
+	}
+
+	err := p.client.Post().
+		WithContext(ctx).
+		Body(params).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	if err != nil {
+		return nil, err
+	}
+	if !resp.Result || resp.Code != 0 {
+		return nil, fmt.Errorf("gse config add route failed, code: %d, message: %s", resp.Code, resp.Message)
+	}
+	return resp.Data, nil
+}
+
+func (p *gse) ConfigUpdateRoute(ctx context.Context, h http.Header, data *metadata.GseConfigUpdateRouteParams) error {
+	resp := new(metadata.EsbBaseResponse)
+	subPath := "/v2/gse/config_update_route/"
+	params := &esbGseConfigUpdateRouteParams{
+		EsbCommParams:              esbutil.GetEsbRequestParams(p.config.GetConfig(), h),
+		GseConfigUpdateRouteParams: data,
+	}
+
+	err := p.client.Post().
+		WithContext(ctx).
+		Body(params).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	if err != nil {
+		return err
+	}
+	if !resp.Result || resp.Code != 0 {
+		return fmt.Errorf("gse config update route failed, code: %d, message: %s", resp.Code, resp.Message)
+	}
+	return nil
+}
+
+func (p *gse) ConfigDeleteRoute(ctx context.Context, h http.Header, data *metadata.GseConfigDeleteRouteParams) error {
+	resp := new(metadata.EsbBaseResponse)
+	subPath := "/v2/gse/config_delete_route/"
+	params := &esbGseConfigDeleteRouteParams{
+		EsbCommParams:              esbutil.GetEsbRequestParams(p.config.GetConfig(), h),
+		GseConfigDeleteRouteParams: data,
+	}
+
+	err := p.client.Post().
+		WithContext(ctx).
+		Body(params).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	if err != nil {
+		return err
+	}
+	if !resp.Result || resp.Code != 0 {
+		return fmt.Errorf("gse config delete route failed, code: %d, message: %s", resp.Code, resp.Message)
+	}
+	return nil
+}
+
+func (p *gse) ConfigQueryRoute(ctx context.Context, h http.Header, data *metadata.GseConfigQueryRouteParams) (
+	[]metadata.GseConfigChannel, error) {
+
+	resp := new(metadata.GseConfigQueryRouteResp)
+	subPath := "/v2/gse/config_query_route/"
+	params := &esbGseConfigQueryRouteParams{
+		EsbCommParams:             esbutil.GetEsbRequestParams(p.config.GetConfig(), h),
+		GseConfigQueryRouteParams: data,
+	}
+
+	err := p.client.Post().
+		WithContext(ctx).
+		Body(params).
+		SubResourcef(subPath).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	if err != nil {
+		return nil, err
+	}
+	if !resp.Result || resp.Code != 0 {
+		return nil, fmt.Errorf("gse config query route failed, code: %d, message: %s", resp.Code, resp.Message)
+	}
+	return resp.Data, nil
 }

--- a/src/thirdparty/esbserver/gse/esbserv.go
+++ b/src/thirdparty/esbserver/gse/esbserv.go
@@ -26,6 +26,18 @@ type GseClientInterface interface {
 	QueryProcStatus(ctx context.Context, h http.Header, data *metadata.GseProcRequest) (resp *metadata.EsbResponse, err error)
 	RegisterProcInfo(ctx context.Context, h http.Header, data *metadata.GseProcRequest) (resp *metadata.EsbResponse, err error)
 	UnRegisterProcInfo(ctx context.Context, h http.Header, data *metadata.GseProcRequest) (resp *metadata.EsbResponse, err error)
+	ConfigAddStreamTo(ctx context.Context, h http.Header, data *metadata.GseConfigAddStreamToParams) (
+		*metadata.GseConfigAddStreamToResult, error)
+	ConfigUpdateStreamTo(ctx context.Context, h http.Header, data *metadata.GseConfigUpdateStreamToParams) error
+	ConfigDeleteStreamTo(ctx context.Context, h http.Header, data *metadata.GseConfigDeleteStreamToParams) error
+	ConfigQueryStreamTo(ctx context.Context, h http.Header, data *metadata.GseConfigQueryStreamToParams) (
+		[]metadata.GseConfigAddStreamToParams, error)
+	ConfigAddRoute(ctx context.Context, h http.Header, data *metadata.GseConfigAddRouteParams) (
+		resp *metadata.GseConfigAddRouteResult, err error)
+	ConfigUpdateRoute(ctx context.Context, h http.Header, data *metadata.GseConfigUpdateRouteParams) error
+	ConfigDeleteRoute(ctx context.Context, h http.Header, data *metadata.GseConfigDeleteRouteParams) error
+	ConfigQueryRoute(ctx context.Context, h http.Header, data *metadata.GseConfigQueryRouteParams) (
+		[]metadata.GseConfigChannel, error)
 }
 
 func NewGsecClientInterface(client rest.ClientInterface, config *esbutil.EsbConfigSrv) GseClientInterface {
@@ -42,10 +54,50 @@ type gse struct {
 
 type esbGseProcParams struct {
 	*esbutil.EsbCommParams
-	*metadata.GseProcRequest `json:"inline"`
+	*metadata.GseProcRequest `json:",inline"`
 }
 
 type esbTaskIDParams struct {
 	*esbutil.EsbCommParams
 	TaskID string `json:"task_id"`
+}
+
+type esbGseConfigAddStreamToParams struct {
+	*esbutil.EsbCommParams
+	*metadata.GseConfigAddStreamToParams `json:",inline"`
+}
+
+type esbGseConfigUpdateStreamToParams struct {
+	*esbutil.EsbCommParams
+	*metadata.GseConfigUpdateStreamToParams `json:",inline"`
+}
+
+type esbGseConfigDeleteStreamToParams struct {
+	*esbutil.EsbCommParams
+	*metadata.GseConfigDeleteStreamToParams `json:",inline"`
+}
+
+type esbGseConfigQueryStreamToParams struct {
+	*esbutil.EsbCommParams
+	*metadata.GseConfigQueryStreamToParams `json:",inline"`
+}
+
+type esbGseConfigAddRouteParams struct {
+	*esbutil.EsbCommParams
+	*metadata.GseConfigAddRouteParams `json:",inline"`
+}
+
+type esbGseConfigUpdateRouteParams struct {
+	*esbutil.EsbCommParams
+	*metadata.GseConfigUpdateRouteParams `json:",inline"`
+}
+
+type esbGseConfigDeleteRouteParams struct {
+	*esbutil.EsbCommParams
+	*metadata.GseConfigDeleteRouteParams `json:",inline"`
+}
+
+type esbGseConfigQueryRouteParams struct {
+	*esbutil.EsbCommParams
+	*metadata.GseConfigQueryRouteParams `json:",inline"`
 }


### PR DESCRIPTION
### 新加的功能:
- 添加注册主机静态快照采集的dataid的接口，支持dataid的新增、更新、和删除功能
### 优化的功能:
- adminserver的mongodb、redis和common配置从相应配置文件读取
