### PR TITLE
cacheservice事件监听忽略context cancelled错误

### DIFF
--- a/src/storage/stream/event/watch.go
+++ b/src/storage/stream/event/watch.go
@@ -75,6 +75,10 @@ func (e *Event) Watch(ctx context.Context, opts *types.WatchOptions) (*types.Wat
 		}
 
 		if err != nil {
+			if err == context.Canceled {
+				// if error is context cancelled, then loop watch will exit at the same time
+				return
+			}
 			blog.Fatalf("mongodb watch failed with conf: %+v, err: %v", *opts, err)
 		}
 


### PR DESCRIPTION
### 修复的问题：
- 修复cacheservice未全部监听完成时切主导致重试时取消context，引起的监听时报错导致panic退出的问题
