### PR TITLE
修复upgrader中一部分bind ip已转为正确格式时校验不通过的问题

### DIFF
--- a/src/scene_server/admin_server/upgrader/x19.05.16.01/upgrade_service_template.go
+++ b/src/scene_server/admin_server/upgrader/x19.05.16.01/upgrade_service_template.go
@@ -15,6 +15,7 @@ package x19_05_16_01
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -356,15 +357,22 @@ func upgradeServiceTemplate(ctx context.Context, db dal.RDB, conf *upgrader.Conf
 							if tplBindIP == "" {
 								*inst.BindIP = "127.0.0.1"
 							} else {
-								bindIP, err := tplBindIP.IP(hostMap[moduleHost.HostID])
+								matched, err := regexp.MatchString(common.PatternIP, *inst.BindIP)
 								if err != nil {
 									return err
 								}
 
-								*inst.BindIP = bindIP
+								if !matched {
+									bindIP, err := tplBindIP.IP(hostMap[moduleHost.HostID])
+									if err != nil {
+										return err
+									}
+									*inst.BindIP = bindIP
+								}
 							}
 						} else {
-							inst.BindIP = new(string)
+							bindIP := "127.0.0.1"
+							inst.BindIP = &bindIP
 						}
 						inst.SupplierAccount = ownerID
 						blog.InfoJSON("procInst: %s", inst)


### PR DESCRIPTION
### 修复的问题：
- 修复upgrader中一部分bind ip已转为正确格式时校验不通过的问题
