### PR TITLE
DeleteAssociationInstBatch函数，入参改为bk_obj_id和id列表。

### DIFF
--- a/src/common/metadata/association.go
+++ b/src/common/metadata/association.go
@@ -134,7 +134,8 @@ type DeleteAssociationInstRequest struct {
 }
 
 type DeleteAssociationInstBatchRequest struct {
-	ID []int64 `json:"id"`
+	ObjectID string  `json:"bk_obj_id"`
+	ID       []int64 `json:"id"`
 }
 
 type DeleteAssociationInstResult struct {

--- a/src/scene_server/admin_server/configures/checkconf.go
+++ b/src/scene_server/admin_server/configures/checkconf.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -31,8 +32,19 @@ func (cc *ConfCenter) checkFile(confFilePath string) error {
 	split := strings.Split(file, ".")
 	fileName := split[0]
 	v := viper.New()
-	v.SetConfigName(fileName)
-	v.AddConfigPath(path.Dir(confFilePath))
+
+	if runtime.GOOS == "windows" {
+		nameWithPointList := strings.Split(file, `\`)
+		nameWithPoint := nameWithPointList[len(nameWithPointList)-1]
+		name := strings.Split(nameWithPoint, ".")[0]
+		filePath := strings.TrimSuffix(confFilePath, nameWithPoint)
+		v.SetConfigName(name)
+		v.AddConfigPath(filePath)
+	} else {
+		v.SetConfigName(fileName)
+		v.AddConfigPath(path.Dir(confFilePath))
+	}
+
 	err := v.ReadInConfig()
 	if err != nil {
 		blog.Errorf("fail to read configure from %s ", file)

--- a/src/scene_server/topo_server/core/operation/association.go
+++ b/src/scene_server/topo_server/core/operation/association.go
@@ -962,17 +962,17 @@ func (assoc *association) DeleteInst(kit *rest.Kit, asstIDList []int64, bkObjID 
 	}
 
 	// asstIDList check duplicate
-	idMap := map[int64]interface{}{}
-	for i, id := range asstIDList {
+	idMap := make(map[int64]struct{})
+	for _, id := range asstIDList {
 		if id <= 0 {
 			blog.ErrorJSON("Delete instance association failed, input id list contains illegal id %d, kit: %+v, rid: %s", id, kit, kit.Rid)
 			return nil, fmt.Errorf("input id list contains illegal id %d", id)
 		}
-		idMap[id] = i
-	}
-	if len(idMap) != len(asstIDList) {
-		blog.ErrorJSON("Delete instance association failed, input id list contains duplicate id, kit: %+v, rid: %s", kit, kit.Rid)
-		return nil, fmt.Errorf("input id list contains duplicate id")
+		if _, exists := idMap[id]; exists {
+			blog.ErrorJSON("Delete instance association failed, input id list contains duplicate id %d, kit: %+v, rid: %s", kit, kit.Rid)
+			return nil, fmt.Errorf("input id list contains duplicate id %d", id)
+		}
+		idMap[id] = struct{}{}
 	}
 
 	searchCondition := metadata.QueryCondition{

--- a/src/scene_server/topo_server/core/operation/association.go
+++ b/src/scene_server/topo_server/core/operation/association.go
@@ -70,7 +70,7 @@ type AssociationOperationInterface interface {
 	SearchInst(kit *rest.Kit, request *metadata.SearchAssociationInstRequest) (resp *metadata.SearchAssociationInstResult, err error)
 	SearchAssociationRelatedInst(kit *rest.Kit, request *metadata.SearchAssociationRelatedInstRequest) (resp *metadata.SearchAssociationInstResult, err error)
 	CreateInst(kit *rest.Kit, request *metadata.CreateAssociationInstRequest) (resp *metadata.CreateAssociationInstResult, err error)
-	DeleteInst(kit *rest.Kit, assoID int64) (resp *metadata.DeleteAssociationInstResult, err error)
+	DeleteInst(kit *rest.Kit, assoIDList []int64, bkObjId string) (resp *metadata.DeleteAssociationInstResult, err error)
 
 	ImportInstAssociation(ctx context.Context, kit *rest.Kit, objID string, importData map[int]metadata.ExcelAssocation, languageIf language.CCLanguageIf) (resp metadata.ResponeImportAssociationData, err error)
 
@@ -953,41 +953,44 @@ func (assoc *association) CreateInst(kit *rest.Kit, request *metadata.CreateAsso
 	return resp, err
 }
 
-func (assoc *association) DeleteInst(kit *rest.Kit, assoID int64) (resp *metadata.DeleteAssociationInstResult, err error) {
-	// record audit log
+func (assoc *association) DeleteInst(kit *rest.Kit, asstIDList []int64, bkObjID string) (resp *metadata.DeleteAssociationInstResult, err error) {
+
+	cond := condition.CreateCondition().Field(common.BKFieldID).In(asstIDList)
+	// The bkObjID should not be empty has been checked before, the logic here is to adapt to other scene.
+	if bkObjID != "" {
+		cond.Field(common.BKObjIDField).Eq(bkObjID)
+	}
+
 	searchCondition := metadata.QueryCondition{
-		Condition: condition.CreateCondition().Field(common.BKFieldID).Eq(assoID).ToMapStr(),
+		Condition:      cond.ToMapStr(),
+		DisableCounter: true,
 	}
 	data, err := assoc.clientSet.CoreService().Association().ReadInstAssociation(kit.Ctx, kit.Header, &searchCondition)
 	if err != nil {
 		blog.Errorf("DeleteInst failed, get instance association failed, kit: %+v, err: %+v, rid: %s", kit, err, kit.Rid)
 		return nil, err
 	}
-	if len(data.Data.Info) == 0 {
-		blog.Errorf("DeleteInst failed, instance association not found, searchCondition: %+v, err: %+v, rid: %s", searchCondition, err, kit.Rid)
-		return nil, kit.CCError.Error(common.CCErrCommNotFound)
-	}
-	if len(data.Data.Info) > 1 {
-		blog.Errorf("DeleteInst failed, get instance association with id:%d get multiple, err: %+v, rid: %s", assoID, err, kit.Rid)
+	if len(data.Data.Info) != len(asstIDList) {
+		blog.Errorf("DeleteInst failed, got unexpected number of instance associations %d which should be %d, searchCondition: %+v, err: %+v, rid: %s", len(data.Data.Info), len(asstIDList), searchCondition, err, kit.Rid)
 		return nil, kit.CCError.Error(common.CCErrCommNotFound)
 	}
 
 	instanceAssociation := data.Data.Info[0]
 
-	cond := condition.CreateCondition()
-	cond.Field(common.AssociationObjAsstIDField).Eq(instanceAssociation.ObjectAsstID)
-	assInfoResult, err := assoc.SearchObject(kit, &metadata.SearchAssociationObjectRequest{Condition: cond.ToMapStr()})
+	searchCond := condition.CreateCondition()
+	searchCond.Field(common.AssociationObjAsstIDField).Eq(instanceAssociation.ObjectAsstID)
+	assInfoResult, err := assoc.SearchObject(kit, &metadata.SearchAssociationObjectRequest{Condition: searchCond.ToMapStr()})
 	if err != nil {
-		blog.Errorf("create association instance, but search object association with cond[%v] failed, err: %v, rid: %s", cond, err, kit.Rid)
+		blog.Errorf("DeleteInst failed, search object association with cond[%v] failed, err: %v, rid: %s", cond, err, kit.Rid)
 		return nil, kit.CCError.Error(common.CCErrCommHTTPDoRequestFailed)
 	}
 	if !assInfoResult.Result {
-		blog.Errorf("create association instance, but search object association with cond[%v] failed, err: %s, rid: %s", cond, assInfoResult.ErrMsg, kit.Rid)
+		blog.Errorf("DeleteInst failed, search object association with cond[%v] failed, err: %s, rid: %s", cond, assInfoResult.ErrMsg, kit.Rid)
 		return nil, assInfoResult.CCError()
 	}
 
 	input := metadata.DeleteOption{
-		Condition: condition.CreateCondition().Field(common.BKFieldID).Eq(assoID).ToMapStr(),
+		Condition: cond.ToMapStr(),
 	}
 	rsp, err := assoc.clientSet.CoreService().Association().DeleteInstAssociation(kit.Ctx, kit.Header, &input)
 	if err != nil {
@@ -1001,17 +1004,20 @@ func (assoc *association) DeleteInst(kit *rest.Kit, assoID int64) (resp *metadat
 	// generate audit log.
 	audit := auditlog.NewInstanceAssociationAudit(assoc.clientSet.CoreService())
 	generateAuditParameter := auditlog.NewGenerateAuditCommonParameter(kit, metadata.AuditDelete)
-	auditLog, err := audit.GenerateAuditLog(generateAuditParameter, assoID, &instanceAssociation)
-	if err != nil {
-		blog.Errorf(" delete inst asst, generate audit log failed, err: %v, rid: %s", err, kit.Rid)
-		return nil, err
-	}
 
-	// save audit log.
-	err = audit.SaveAuditLog(kit, *auditLog)
-	if err != nil {
-		blog.Errorf("delete inst asst, save audit log failed, err: %v, rid: %s", err, kit.Rid)
-		return nil, kit.CCError.Error(common.CCErrAuditSaveLogFailed)
+	for i, asstID := range asstIDList {
+		auditLog, err := audit.GenerateAuditLog(generateAuditParameter, asstID, &data.Data.Info[i])
+		if err != nil {
+			blog.Errorf(" delete inst asst, generate audit log failed, err: %v, rid: %s", err, kit.Rid)
+			return nil, err
+		}
+
+		// save audit log.
+		err = audit.SaveAuditLog(kit, *auditLog)
+		if err != nil {
+			blog.Errorf("delete inst asst, save audit log failed, err: %v, rid: %s", err, kit.Rid)
+			return nil, kit.CCError.Error(common.CCErrAuditSaveLogFailed)
+		}
 	}
 
 	return resp, nil

--- a/src/scene_server/topo_server/service/association.go
+++ b/src/scene_server/topo_server/service/association.go
@@ -758,7 +758,7 @@ func (s *Service) DeleteAssociationInstBatch(ctx *rest.Contexts) {
 		if err = ret.CCError(); err != nil {
 			return err
 		}
-		result.Data++
+		result.Data = len(request.ID)
 		return nil
 	})
 	if txnErr != nil {

--- a/src/source_controller/coreservice/core/association/instance.go
+++ b/src/source_controller/coreservice/core/association/instance.go
@@ -240,10 +240,9 @@ func (m *associationInstance) SearchInstanceAssociation(kit *rest.Kit, inputPara
 	}
 
 	dataResult := &metadata.QueryResult{}
-	var count uint64
 	// the InstAsst number will be counted by default.
 	if !inputParam.DisableCounter {
-		count, err = m.countInstanceAssociation(kit, inputParam.Condition)
+		count, err := m.countInstanceAssociation(kit, inputParam.Condition)
 		if nil != err {
 			blog.Errorf("search inst association count err [%#v], rid: %s", err, kit.Rid)
 			return &metadata.QueryResult{}, err

--- a/src/source_controller/coreservice/core/association/instance.go
+++ b/src/source_controller/coreservice/core/association/instance.go
@@ -240,12 +240,17 @@ func (m *associationInstance) SearchInstanceAssociation(kit *rest.Kit, inputPara
 	}
 
 	dataResult := &metadata.QueryResult{}
-	dataResult.Count, err = m.countInstanceAssociation(kit, inputParam.Condition)
-	dataResult.Info = make([]mapstr.MapStr, 0)
-	if nil != err {
-		blog.Errorf("search inst association count err [%#v], rid: %s", err, kit.Rid)
-		return &metadata.QueryResult{}, err
+	var count uint64
+	// the InstAsst number will be counted by default.
+	if !inputParam.DisableCounter {
+		count, err = m.countInstanceAssociation(kit, inputParam.Condition)
+		if nil != err {
+			blog.Errorf("search inst association count err [%#v], rid: %s", err, kit.Rid)
+			return &metadata.QueryResult{}, err
+		}
+		dataResult.Count = count
 	}
+	dataResult.Info = make([]mapstr.MapStr, 0)
 	for _, item := range instAsstItems {
 		dataResult.Info = append(dataResult.Info, mapstr.NewFromStruct(item, "field"))
 	}

--- a/src/test/topo_server/asst_test.go
+++ b/src/test/topo_server/asst_test.go
@@ -189,10 +189,22 @@ var _ = Describe("inst test", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rsp.Result).To(Equal(false))
 	})
+	//check "DeleteInstBatch" necessary input: bk_obj_id
+	It("delete inst association batch", func() {
+		input := &metadata.DeleteAssociationInstBatchRequest{
+			ID:       []int64{instAsst1, instAsst2},
+			ObjectID: "",
+		}
+		rsp, err := asstClient.DeleteInstBatch(context.Background(), header, input)
+		util.RegisterResponse(rsp)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rsp.Result).To(Equal(false))
+	})
 	//check "DeleteInstBatch" features available.
 	It("delete inst association batch", func() {
 		input := &metadata.DeleteAssociationInstBatchRequest{
-			ID: []int64{instAsst1, instAsst2},
+			ID:       []int64{instAsst1, instAsst2},
+			ObjectID: "bk_router",
 		}
 		rsp, err := asstClient.DeleteInstBatch(context.Background(), header, input)
 		util.RegisterResponse(rsp)
@@ -200,5 +212,4 @@ var _ = Describe("inst test", func() {
 		Expect(rsp.Result).To(Equal(true))
 		Expect(rsp.Data).To(Equal(2))
 	})
-
 })


### PR DESCRIPTION
### 优化的功能:
- DeleteAssociationInstBatch函数，入参改为bk_obj_id和id列表。考虑到后续分表的规划，此接口需要限制为只能删除相同源模型的关联关系实例。

