### PR TITLE
时间类型字段兼容带时区的格式

### DIFF
--- a/src/common/metadata/attribute.go
+++ b/src/common/metadata/attribute.go
@@ -194,7 +194,7 @@ func (attribute *Attribute) validTime(ctx context.Context, val interface{}, key 
 		}
 	}
 
-	result := util.IsTime(valStr)
+	_, result := util.IsTime(valStr)
 	if !result {
 		blog.Errorf("params not valid, rid: %s", rid)
 		return errors.RawErrorInfo{

--- a/src/common/paraparse/host.go
+++ b/src/common/paraparse/host.go
@@ -101,8 +101,8 @@ func ParseHostParams(input []metadata.ConditionItem, output map[string]interface
 			}
 			switch rawVal := i.Value.(type) {
 			case string:
-				if util.IsTime(rawVal) {
-					i.Value = util.Str2Time(rawVal)
+				if timeType, isTime := util.IsTime(rawVal); isTime {
+					i.Value = util.Str2Time(rawVal, timeType)
 				}
 			}
 			queryCondItem[i.Operator] = i.Value

--- a/src/common/util/struti.go
+++ b/src/common/util/struti.go
@@ -23,8 +23,9 @@ const (
 	charPattern    = `^[a-zA-Z]*$`
 	numCharPattern = `^[a-zA-Z0-9]*$`
 	// mailPattern     = `^[a-z0-9A-Z]+([\-_\.][a-z0-9A-Z]+)*@([a-z0-9A-Z]+(-[a-z0-9A-Z]+)*\.)+[a-zA-Z]{2,4}$`
-	datePattern     = `^[0-9]{4}[\-]{1}[0-9]{2}[\-]{1}[0-9]{2}$`
-	dateTimePattern = `^[0-9]{4}[\-]{1}[0-9]{2}[\-]{1}[0-9]{2}[\s]{1}[0-9]{2}[\:]{1}[0-9]{2}[\:]{1}[0-9]{2}$`
+	datePattern             = `^[0-9]{4}[\-]{1}[0-9]{2}[\-]{1}[0-9]{2}$`
+	dateTimePattern         = `^[0-9]{4}[\-]{1}[0-9]{2}[\-]{1}[0-9]{2}[\s]{1}[0-9]{2}[\:]{1}[0-9]{2}[\:]{1}[0-9]{2}$`
+	timeWithLocationPattern = `^[0-9]{4}[\-]{1}[0-9]{2}[\-]{1}[0-9]{2}[T]{1}[0-9]{2}[\:]{1}[0-9]{2}[\:]{1}[0-9]{2}([\.]{1}[0-9]+)?[\+]{1}[0-9]{2}[\:]{1}[0-9]{2}$`
 	// timeZonePattern    = `^[a-zA-Z]+/[a-z\-\_+\-A-Z]+$`
 	timeZonePattern = `^[a-zA-Z0-9\-−_\/\+]+$`
 	//userPattern the user names regex expression
@@ -36,10 +37,11 @@ var (
 	charRegexp    = regexp.MustCompile(charPattern)
 	numCharRegexp = regexp.MustCompile(numCharPattern)
 	// mailRegexp        = regexp.MustCompile(mailPattern)
-	dateRegexp     = regexp.MustCompile(datePattern)
-	dateTimeRegexp = regexp.MustCompile(dateTimePattern)
-	timeZoneRegexp = regexp.MustCompile(timeZonePattern)
-	userRegexp     = regexp.MustCompile(userPattern)
+	dateRegexp             = regexp.MustCompile(datePattern)
+	dateTimeRegexp         = regexp.MustCompile(dateTimePattern)
+	timeWithLocationRegexp = regexp.MustCompile(timeWithLocationPattern)
+	timeZoneRegexp         = regexp.MustCompile(timeZonePattern)
+	userRegexp             = regexp.MustCompile(userPattern)
 )
 
 // 字符串输入长度
@@ -65,9 +67,25 @@ func IsDate(sInput string) bool {
 	return dateRegexp.MatchString(sInput)
 }
 
+type DateTimeFieldType string
+
+const (
+	// timeWithoutLocationType the common date time type which is used by front end and api
+	timeWithoutLocationType DateTimeFieldType = "time_without_location"
+	// timeWithLocationType the date time type compatible for values from db which is marshaled with time zone
+	timeWithLocationType DateTimeFieldType = "time_with_location"
+	invalidDateTimeType  DateTimeFieldType = "invalid"
+)
+
 // 是否时间
-func IsTime(sInput string) bool {
-	return dateTimeRegexp.MatchString(sInput)
+func IsTime(sInput string) (DateTimeFieldType, bool) {
+	if dateTimeRegexp.MatchString(sInput) {
+		return timeWithoutLocationType, true
+	}
+	if timeWithLocationRegexp.MatchString(sInput) {
+		return timeWithLocationType, true
+	}
+	return invalidDateTimeType, false
 }
 
 // 是否时区
@@ -81,13 +99,22 @@ func IsUser(sInput string) bool {
 }
 
 // str2time
-func Str2Time(timeStr string) time.Time {
-	fTime, err := time.ParseInLocation("2006-01-02 15:04:05", timeStr, time.Local)
+func Str2Time(timeStr string, timeType DateTimeFieldType) time.Time {
+	var layout string
+	switch timeType {
+	case timeWithoutLocationType:
+		layout = "2006-01-02 15:04:05"
+	case timeWithLocationType:
+		layout = "2006-01-02T15:04:05+08:00"
+	default:
+		return time.Time{}
+	}
+
+	fTime, err := time.ParseInLocation(layout, timeStr, time.Local)
 	if nil != err {
 		return fTime
 	}
 	return fTime.UTC()
-
 }
 
 // FirstNotEmptyString return the first string in slice strs that is not empty

--- a/src/common/util/struti_test.go
+++ b/src/common/util/struti_test.go
@@ -1,15 +1,15 @@
 /*
  * Tencent is pleased to support the open source community by making 蓝鲸 available.
  * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
- * Licensed under the MIT License (the "License"); you may not use this file except 
+ * Licensed under the MIT License (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  * http://opensource.org/licenses/MIT
  * Unless required by applicable law or agreed to in writing, software distributed under
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific language governing permissions and 
+ * either express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package util
 
 import (
@@ -133,10 +133,11 @@ func TestIsTime(t *testing.T) {
 		{args: args{"2018-10-10 10:56:67"}, want: true},
 		{args: args{"105667"}, want: false},
 		{args: args{`10-56-67`}, want: false},
+		{args: args{"2021-04-07T21:50:50.351153+08:00"}, want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsTime(tt.args.sInput); got != tt.want {
+			if _, got := IsTime(tt.args.sInput); got != tt.want {
 				t.Errorf("IsTime() = %v, want %v", got, tt.want)
 			}
 		})

--- a/src/scene_server/admin_server/upgrader/y3.9.202010281615/update_inst_time_val.go
+++ b/src/scene_server/admin_server/upgrader/y3.9.202010281615/update_inst_time_val.go
@@ -36,7 +36,7 @@ func updateInstTimeVal(ctx context.Context, db dal.RDB, conf *upgrader.Config) e
 		// find attributes of model time type
 		propertyIDArray := make([]map[string]string, 0)
 		filter := mapstr.MapStr{
-			common.BKObjIDField: objID,
+			common.BKObjIDField:        objID,
 			common.BKPropertyTypeField: common.FieldTypeTime,
 		}
 		if err := db.Table(common.BKTableNameObjAttDes).Find(filter).Fields(common.BKPropertyIDField).All(ctx, &propertyIDArray); err != nil {
@@ -94,8 +94,8 @@ func updateInstTimeVal(ctx context.Context, db dal.RDB, conf *upgrader.Config) e
 					if ok == false {
 						continue
 					}
-					if util.IsTime(valStr) {
-						doc[field] = util.Str2Time(valStr)
+					if timeType, isTime := util.IsTime(valStr); isTime {
+						doc[field] = util.Str2Time(valStr, timeType)
 						continue
 					}
 					blog.ErrorJSON("It is not a time type string, table: %s, filed: %s, val: %s", instTable, field, val)
@@ -106,11 +106,11 @@ func updateInstTimeVal(ctx context.Context, db dal.RDB, conf *upgrader.Config) e
 				}
 
 				filter := map[string]interface{}{
-					instIDField : inst[instIDField],
+					instIDField: inst[instIDField],
 				}
 
 				if err := db.Table(instTable).Update(ctx, filter, doc); err != nil {
-					blog.ErrorJSON("update the value of the instance time type failed, " +
+					blog.ErrorJSON("update the value of the instance time type failed, "+
 						"table: %s, filter: %s, doc: %s, err: %s", instTable, filter, doc, err)
 					return err
 				}

--- a/src/source_controller/coreservice/core/instances/instance_validate.go
+++ b/src/source_controller/coreservice/core/instances/instance_validate.go
@@ -417,8 +417,8 @@ func (m *instanceManager) changeStringToTime(valData mapstr.MapStr, propertys []
 		if ok == false {
 			return stderr.New("it is not a string of time type")
 		}
-		if util.IsTime(valStr) {
-			valData[field.PropertyID] = util.Str2Time(valStr)
+		if timeType, isTime := util.IsTime(valStr); isTime {
+			valData[field.PropertyID] = util.Str2Time(valStr, timeType)
 			continue
 		}
 		return stderr.New("can not convert value from string type to time type")


### PR DESCRIPTION
### 优化的功能:
- 时间类型字段兼容带时区的格式
_因为db中的时间类型字段返回时会被marshal为带时区的格式，所以需要兼容直接将返回值传回的情况_