### PR TITLE
bugfix 修复导入实例报错信息不正确问题 issue #5186

### DIFF
--- a/src/scene_server/topo_server/core/operation/inst.go
+++ b/src/scene_server/topo_server/core/operation/inst.go
@@ -252,7 +252,7 @@ func (c *commonInst) CreateInstBatch(kit *rest.Kit, obj model.Object, batchInfo 
 	//sort error
 	sort.Ints(colIdxList)
 	for colIdx := range colIdxList {
-		results.Errors = append(results.Errors, colIdxErrMap[colIdx])
+		results.Errors = append(results.Errors, colIdxErrMap[colIdxList[colIdx]])
 	}
 
 	return results, nil


### PR DESCRIPTION

### 修复的问题：
- 修复导入实例报错信息不正确问题：
    问题原因为实例创建函数中获取报错信息字典的key值时，在报错信息key值数组中拿出的是索引而不是索引对应的值导致存在字典中检索不到对应的值从而出现空的报错信息
