### PR TITLE
fix: DeleteAssociationInstBatch function adapt to new DB-model

### DIFF
--- a/src/scene_server/topo_server/service/association.go
+++ b/src/scene_server/topo_server/service/association.go
@@ -728,9 +728,7 @@ func (s *Service) DeleteAssociationInst(ctx *rest.Contexts) {
 	txnErr := s.Engine.CoreAPI.CoreService().Txn().AutoRunTxn(ctx.Kit.Ctx, ctx.Kit.Header, func() error {
 		var err error
 		idList := []int64{id}
-		// bkObjID has no actual effect here for now.
-		bkObjID := ""
-		ret, err = s.Core.AssociationOperation().DeleteInst(ctx.Kit, bkObjID, idList)
+		ret, err = s.Core.AssociationOperation().DeleteInst(ctx.Kit, objID, idList)
 		if err != nil {
 			return err
 		}

--- a/src/source_controller/coreservice/core/association/instance.go
+++ b/src/source_controller/coreservice/core/association/instance.go
@@ -111,7 +111,7 @@ func (m *associationInstance) deleteInstanceAssociation(kit *rest.Kit, objID str
 		} else if asst.AsstObjectID != objID {
 			asstObjID = asst.AsstObjectID
 		} else {
-			// 自关联再循环外处理
+			// 自关联在循环外处理
 			continue
 		}
 


### PR DESCRIPTION
### 修复的问题：
- 批量删除关联关系实例--函数适配拆表后的数据库模型。
