### PR TITLE
fix: 修服务集群模板实例展示问题

### DIFF
--- a/src/apimachinery/rest/request.go
+++ b/src/apimachinery/rest/request.go
@@ -36,6 +36,7 @@ import (
 	"configcenter/src/common/json"
 	"configcenter/src/common/metadata"
 	commonUtil "configcenter/src/common/util"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tidwall/gjson"
 )

--- a/src/scene_server/topo_server/core/settemplate/settemplate.go
+++ b/src/scene_server/topo_server/core/settemplate/settemplate.go
@@ -34,6 +34,8 @@ type SetTemplate interface {
 	GetLatestSyncTaskDetail(kit *rest.Kit, setID int64) (*metadata.APITaskDetail, errors.CCErrorCoder)
 	CheckSetInstUpdateToDateStatus(kit *rest.Kit, bizID int64, setTemplateID int64) (metadata.SetTemplateUpdateToDateStatus, errors.CCErrorCoder)
 	TriggerCheckSetTemplateSyncingStatus(kit *rest.Kit, bizID, setTemplateID, setID int64) errors.CCErrorCoder
+	ListSetTemplateSyncStatus(kit *rest.Kit, bizID int64,
+		option metadata.ListSetTemplateSyncStatusOption) (metadata.MultipleSetTemplateSyncStatus, errors.CCErrorCoder)
 }
 
 func NewSetTemplate(client apimachinery.ClientSetInterface) SetTemplate {

--- a/src/scene_server/topo_server/service/set_template.go
+++ b/src/scene_server/topo_server/service/set_template.go
@@ -823,21 +823,11 @@ func (s *Service) ListSetTemplateSyncStatus(ctx *rest.Contexts) {
 		return
 	}
 
-	result, err := s.Engine.CoreAPI.CoreService().SetTemplate().ListSetTemplateSyncStatus(ctx.Kit.Ctx, ctx.Kit.Header, bizID, option)
+	result, err := s.Core.SetTemplateOperation().ListSetTemplateSyncStatus(ctx.Kit, bizID, option)
 	if err != nil {
 		blog.ErrorJSON("ListSetTemplateSyncStatus failed, core service search failed, option: %s, err: %s, rid: %s", option, err.Error(), ctx.Kit.Rid)
 		ctx.RespAutoError(err)
 		return
-	}
-
-	// 处理当前需要同步任务的状态
-	for _, info := range result.Info {
-		if !info.Status.IsFinished() {
-			go func(info metadata.SetTemplateSyncStatus) {
-				s.Core.SetTemplateOperation().TriggerCheckSetTemplateSyncingStatus(ctx.NewContexts().Kit, info.BizID, info.SetTemplateID, info.SetID)
-			}(info)
-		}
-
 	}
 
 	ctx.RespEntity(result)


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- 集群被删除后， 集群同步表数据还存在，依然展示在集群模板实例中展示
- 集群同步表中没有集群同步市局的时候，在集群模板实例中不显示的



close   #5238