### PR TITLE
demand: event flow support cursor with unique key function. and common instance use unique key with bk_inst_id

### DIFF
--- a/src/common/watch/cursor.go
+++ b/src/common/watch/cursor.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	"strings"
 
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
@@ -294,17 +293,15 @@ func GetEventCursor(coll string, e *types.Event, instID int64) (string, error) {
 		curType = Module
 	case common.BKTableNameSetTemplate:
 		curType = SetTemplate
+	case common.BKTableNameBaseInst:
+		curType = ObjectBase
 	case common.BKTableNameBaseProcess:
 		curType = Process
 	case common.BKTableNameProcessInstanceRelation:
 		curType = ProcessInstanceRelation
 	default:
-		if strings.HasPrefix(coll, common.BKTableNameBaseInst) {
-			curType = ObjectBase
-		} else {
-			blog.Errorf("unsupported cursor type collection: %s, oid: %s", e.Oid)
-			return "", fmt.Errorf("unsupported cursor type collection: %s", coll)
-		}
+		blog.Errorf("unsupported cursor type collection: %s, oid: %s", e.ID())
+		return "", fmt.Errorf("unsupported cursor type collection: %s", coll)
 	}
 
 	hCursor := &Cursor{

--- a/src/common/watch/cursor.go
+++ b/src/common/watch/cursor.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
@@ -137,6 +138,13 @@ type Cursor struct {
 	// a random hex string to avoid the caller to generated a self-defined cursor.
 	Oid  string
 	Oper types.OperType
+	// UniqKey is an optional key which is used to ensure that a cursor is unique among a same resources(
+	// as is Type field).
+	// This key is used when the upper fields can not describe a unique cursor. such as the common object instance
+	// event, all these instance event all have a same cursor type, as is object instance. but the instance id is
+	// unique which can be used as a unique key, and is REENTRANT when a retry operation happens which is
+	// **VERY IMPORTANT**.
+	UniqKey string
 }
 
 const cursorVersion = "1"
@@ -187,6 +195,10 @@ func (c Cursor) Encode() (string, error) {
 
 	// cluster time nano field
 	pool.WriteString(nano)
+	pool.WriteByte('\r')
+
+	// unique key field
+	pool.WriteString(c.UniqKey)
 
 	return base64.StdEncoding.EncodeToString(pool.Bytes()), nil
 }
@@ -219,7 +231,8 @@ func (c *Cursor) Decode(cur string) error {
 		}
 	}
 
-	if len(elements) != 6 {
+	// at least have 6 fields, UniqKey is an optional field.
+	if len(elements) < 6 {
 		return errors.New("invalid cursor string")
 	}
 
@@ -257,10 +270,16 @@ func (c *Cursor) Decode(cur string) error {
 		return fmt.Errorf("got invalid nano field %s, err: %v", elements[5], err)
 	}
 	c.ClusterTime.Nano = uint32(nano)
+
+	// cause unique key is an optional key.
+	if len(elements) >= 7 {
+		c.UniqKey = elements[6]
+	}
+
 	return nil
 }
 
-func GetEventCursor(coll string, e *types.Event) (string, error) {
+func GetEventCursor(coll string, e *types.Event, instID int64) (string, error) {
 	curType := UnknownType
 	switch coll {
 	case common.BKTableNameBaseHost:
@@ -275,15 +294,17 @@ func GetEventCursor(coll string, e *types.Event) (string, error) {
 		curType = Module
 	case common.BKTableNameSetTemplate:
 		curType = SetTemplate
-	case common.BKTableNameBaseInst:
-		curType = ObjectBase
 	case common.BKTableNameBaseProcess:
 		curType = Process
 	case common.BKTableNameProcessInstanceRelation:
 		curType = ProcessInstanceRelation
 	default:
-		blog.Errorf("unsupported cursor type collection: %s, oid: %s", e.Oid)
-		return "", fmt.Errorf("unsupported cursor type collection: %s", coll)
+		if strings.HasPrefix(coll, common.BKTableNameBaseInst) {
+			curType = ObjectBase
+		} else {
+			blog.Errorf("unsupported cursor type collection: %s, oid: %s", e.Oid)
+			return "", fmt.Errorf("unsupported cursor type collection: %s", coll)
+		}
 	}
 
 	hCursor := &Cursor{
@@ -291,6 +312,15 @@ func GetEventCursor(coll string, e *types.Event) (string, error) {
 		ClusterTime: e.ClusterTime,
 		Oid:         e.Oid,
 		Oper:        e.OperationType,
+	}
+
+	if curType == ObjectBase {
+		if instID <= 0 {
+			return "", errors.New("invalid instance id")
+		}
+
+		// add unique key for common object instance.
+		hCursor.UniqKey = strconv.FormatInt(instID, 10)
 	}
 
 	hCursorEncode, err := hCursor.Encode()

--- a/src/common/watch/cursor_test.go
+++ b/src/common/watch/cursor_test.go
@@ -13,12 +13,13 @@
 package watch
 
 import (
+	"strconv"
 	"testing"
 
 	"configcenter/src/storage/stream/types"
 )
 
-const cursorSample = "MQ0yDTVlYjM4NTk3NDc3MGExMThmNDkyMmFiZQ1pbnNlcnQNMTU4ODg1MzY1Mg0w"
+const cursorSample = "MQ0yDTVlYjM4NTk3NDc3MGExMThmNDkyMmFiZQ1pbnNlcnQNMTU4ODg1MzY1Mg0wDTE="
 
 func TestCursorEncode(t *testing.T) {
 	cursor := Cursor{
@@ -26,9 +27,10 @@ func TestCursorEncode(t *testing.T) {
 			Sec:  uint32(1588853652),
 			Nano: 0,
 		},
-		Oid:  "5eb385974770a118f4922abe",
-		Type: Host,
-		Oper: types.Insert,
+		Oid:     "5eb385974770a118f4922abe",
+		Type:    Host,
+		Oper:    types.Insert,
+		UniqKey: strconv.Itoa(1),
 	}
 	encode, err := cursor.Encode()
 	if err != nil {
@@ -37,7 +39,7 @@ func TestCursorEncode(t *testing.T) {
 	}
 
 	if encode != cursorSample {
-		t.Errorf("encode cursor failed")
+		t.Errorf("encode cursor failed: %s", encode)
 		return
 	}
 }
@@ -71,6 +73,11 @@ func TestCursorDecode(t *testing.T) {
 
 	if cursor.Oper != types.Insert {
 		t.Errorf("decode cursor, got invalid operation type: %s", cursor.Oper)
+		return
+	}
+
+	if cursor.UniqKey != "1" {
+		t.Errorf("decode cursor, unique key is invalid: %s", cursor.UniqKey)
 		return
 	}
 }

--- a/src/source_controller/cacheservice/event/flow/flow.go
+++ b/src/source_controller/cacheservice/event/flow/flow.go
@@ -183,6 +183,8 @@ func (f *Flow) doBatch(es []*types.Event) (retry bool) {
 					f.key.Collection(), e.Oid, err, rid)
 				continue
 			}
+			// update delete event detail doc bytes.
+			e.DocBytes = doc
 
 			// validate the event is valid or not.
 			// the invalid event will be dropped.
@@ -202,7 +204,8 @@ func (f *Flow) doBatch(es []*types.Event) (retry bool) {
 		oids[index] = e.ID()
 		id := ids[index]
 		name := f.key.Name(e.DocBytes)
-		currentCursor, err := watch.GetEventCursor(f.key.Collection(), e, f.key.InstanceID(e.DocBytes))
+		instID := f.key.InstanceID(e.DocBytes)
+		currentCursor, err := watch.GetEventCursor(f.key.Collection(), e, instID)
 		if err != nil {
 			blog.Errorf("get %s event cursor failed, name: %s, err: %v, oid: %s, rid: %s", f.key.Collection(), name,
 				err, e.ID(), rid)
@@ -211,7 +214,7 @@ func (f *Flow) doBatch(es []*types.Event) (retry bool) {
 				RequestID: rid,
 				Type:      meta.FlowFatalError,
 				Detail: fmt.Sprintf("run event flow, but get invalid %s cursor, inst id: %d, name: %s",
-					f.key.Collection(), f.key.InstanceID(e.DocBytes), name),
+					f.key.Collection(), instID, name),
 				Module:    types2.CC_MODULE_CACHESERVICE,
 				Dimension: map[string]string{"hit_invalid_cursor": "yes"},
 			})
@@ -237,18 +240,13 @@ func (f *Flow) doBatch(es []*types.Event) (retry bool) {
 			Cursor:      currentCursor,
 		}
 
-		if instanceID := f.key.InstanceID(e.DocBytes); instanceID > 0 {
-			chainNode.InstanceID = instanceID
+		if instID > 0 {
+			chainNode.InstanceID = instID
 		}
 		chainNodes = append(chainNodes, chainNode)
 
-		docBytes := e.DocBytes
-		if e.OperationType == types.Delete {
-			docBytes = oidDetailMap[e.Oid]
-		}
-
 		detail := types.EventDetail{
-			Detail:        types.JsonString(docBytes),
+			Detail:        types.JsonString(e.DocBytes),
 			UpdatedFields: e.ChangeDesc.UpdatedFields,
 			RemovedFields: e.ChangeDesc.RemovedFields,
 		}

--- a/src/source_controller/cacheservice/event/key.go
+++ b/src/source_controller/cacheservice/event/key.go
@@ -145,23 +145,24 @@ var SetTemplateKey = Key{
 	},
 }
 
-var objectBaseFields = []string{common.BKInstIDField, common.BKInstNameField}
 var ObjectBaseKey = Key{
 	namespace:  watchCacheNamespace + common.BKInnerObjIDObject,
 	collection: common.BKTableNameBaseInst,
 	ttlSeconds: 6 * 60 * 60,
 	validator: func(doc []byte) error {
-		fields := gjson.GetManyBytes(doc, objectBaseFields...)
-		for idx := range objectBaseFields {
-			if !fields[idx].Exists() {
-				return fmt.Errorf("field %s not exist", objectBaseFields[idx])
-			}
+		field := gjson.GetBytes(doc, common.BKInstIDField)
+		if !field.Exists() {
+			return fmt.Errorf("field %s not exist", common.BKInstIDField)
 		}
+
+		if field.Int() <= 0 {
+			return fmt.Errorf("invalid bk_inst_id: %s, should be integer type and >= 0", field.Raw)
+		}
+
 		return nil
 	},
 	instName: func(doc []byte) string {
-		fields := gjson.GetManyBytes(doc, objectBaseFields...)
-		return fields[1].String()
+		return gjson.GetBytes(doc, common.BKInstNameField).String()
 	},
 	instID: func(doc []byte) int64 {
 		return gjson.GetBytes(doc, common.BKInstIDField).Int()

--- a/src/tools/cmdb_ctl/cmd/watch.go
+++ b/src/tools/cmdb_ctl/cmd/watch.go
@@ -91,6 +91,7 @@ func runDecodeCursor(c *watchConf) error {
 	fmt.Printf("         type: %s\n", cursor.Type)
 	fmt.Printf("          oid: %s\n", cursor.Oid)
 	fmt.Printf("         oper: %s\n", cursor.Oper)
+	fmt.Printf("      uniqKey: %s\n", cursor.UniqKey)
 	fmt.Printf("     unixTime: %d:%d\n", cursor.ClusterTime.Sec, cursor.ClusterTime.Nano)
 	fmt.Printf("  clusterTime: %s\n\n", time.Unix(int64(cursor.ClusterTime.Sec), int64(cursor.ClusterTime.Nano)).Format(time.RFC3339))
 	return nil


### PR DESCRIPTION
### 新加的功能:
- 事件服务Cursor新增支持UniqueKey功能，保证cursor唯一
