### PR TITLE
feature：操作审计支持账号In与NotIn操作

### DIFF
--- a/src/common/metadata/audit.go
+++ b/src/common/metadata/audit.go
@@ -17,6 +17,7 @@ import (
 
 	"configcenter/src/common"
 	"configcenter/src/common/errors"
+	"configcenter/src/common/querybuilder"
 
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -81,6 +82,16 @@ type AuditQueryCondition struct {
 	ObjID string `json:"bk_obj_id"`
 	// FuzzyQuery is used for searching for resource name using regex, use accurate query by default when it is not set
 	FuzzyQuery bool `json:"fuzzy_query"`
+	// Condition is used for new way to search audit log by user or resource_name
+	Condition []querybuilder.AtomRule `json:"condition"`
+}
+
+// Validate is a AuditQueryCondition validator to validate user resource_name condition whether exist at the same time
+func (a *AuditQueryCondition) Validate() error {
+	if (len(a.User) != 0 || len(a.ResourceName) != 0) && len(a.Condition) != 0 {
+		return errors.New(common.CCErrCommParamsInvalid, "condition, user and resource_name cannot exist at the same time")
+	}
+	return nil
 }
 
 type OperationTimeCondition struct {

--- a/src/scene_server/topo_server/service/auditlog.go
+++ b/src/scene_server/topo_server/service/auditlog.go
@@ -16,7 +16,9 @@ import (
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/http/rest"
+	"configcenter/src/common/mapstr"
 	"configcenter/src/common/metadata"
+	"configcenter/src/common/querybuilder"
 )
 
 // SearchAuditDict returns all audit types with their name and actions for front-end display
@@ -41,16 +43,47 @@ func (s *Service) SearchAuditList(ctx *rest.Contexts) {
 	fields := []string{common.BKFieldID, common.BKUser, common.BKResourceTypeField, common.BKActionField,
 		common.BKOperationTimeField, common.BKAppIDField, common.BKResourceIDField, common.BKResourceNameField}
 
-	cond := make(map[string]interface{})
+	cond := mapstr.MapStr{}
 	condition := query.Condition
+	if err := condition.Validate(); err != nil {
+		blog.Errorf("condition, user and resource_name cannot exist at the same time")
+		ctx.RespAutoError(err)
+		return
+	}
 
 	// parse front-end condition to db search cond
-	if condition.ResourceType != "" {
-		cond[common.BKResourceTypeField] = condition.ResourceType
+	for _, item := range condition.Condition {
+		if item.Operator != querybuilder.OperatorIn && item.Operator != querybuilder.OperatorNotIn {
+			blog.Errorf("operator invalid, %s wrong, only can be in or not_in", item.Operator)
+			ctx.RespAutoError(ctx.Kit.CCError.CCErrorf(common.CCErrCommParamsInvalid, "operator only can be in or not_in"))
+			return
+		}
+		condField, key, err := item.ToMgo()
+		if err != nil {
+			blog.Errorf("condition invalid, %s wrong, err: %s", key, err.Error())
+			ctx.RespAutoError(err)
+			return
+		}
+		cond.Merge(condField)
 	}
 
 	if condition.User != "" {
 		cond[common.BKUser] = condition.User
+	}
+
+	if condition.ResourceName != "" {
+		if condition.FuzzyQuery {
+			cond[common.BKResourceNameField] = map[string]interface{}{
+				common.BKDBLIKE:    condition.ResourceName,
+				common.BKDBOPTIONS: "i",
+			}
+		} else {
+			cond[common.BKResourceNameField] = condition.ResourceName
+		}
+	}
+
+	if condition.ResourceType != "" {
+		cond[common.BKResourceTypeField] = condition.ResourceType
 	}
 
 	if condition.OperateFrom != "" {
@@ -69,16 +102,6 @@ func (s *Service) SearchAuditList(ctx *rest.Contexts) {
 
 	if condition.ResourceID != nil {
 		cond[common.BKResourceIDField] = condition.ResourceID
-	}
-
-	if condition.ResourceName != "" {
-		if condition.FuzzyQuery {
-			cond[common.BKResourceNameField] = map[string]interface{}{
-				common.BKDBLIKE: condition.ResourceName,
-			}
-		} else {
-			cond[common.BKResourceNameField] = condition.ResourceName
-		}
 	}
 
 	if condition.ObjID != "" {


### PR DESCRIPTION
### 新加的功能:
- 操作审计的“账号”字段增加条件查询选择 ——> <包含> 和 <不包含>
- 拓展了resource_name 增加条件查询选择
issue #5283
