### PR TITLE
feature：查询多个模型的实例数量

### DIFF
--- a/src/common/metadata/object.go
+++ b/src/common/metadata/object.go
@@ -37,14 +37,14 @@ const (
 
 // Object object metadata definition
 type Object struct {
-	ID          int64  `field:"id" json:"id" bson:"id"`
-	ObjCls      string `field:"bk_classification_id" json:"bk_classification_id" bson:"bk_classification_id"`
-	ObjIcon     string `field:"bk_obj_icon" json:"bk_obj_icon" bson:"bk_obj_icon"`
-	ObjectID    string `field:"bk_obj_id" json:"bk_obj_id" bson:"bk_obj_id"`
-	ObjectName  string `field:"bk_obj_name" json:"bk_obj_name" bson:"bk_obj_name"`
+	ID         int64  `field:"id" json:"id" bson:"id"`
+	ObjCls     string `field:"bk_classification_id" json:"bk_classification_id" bson:"bk_classification_id"`
+	ObjIcon    string `field:"bk_obj_icon" json:"bk_obj_icon" bson:"bk_obj_icon"`
+	ObjectID   string `field:"bk_obj_id" json:"bk_obj_id" bson:"bk_obj_id"`
+	ObjectName string `field:"bk_obj_name" json:"bk_obj_name" bson:"bk_obj_name"`
 
 	// IsHidden front-end don't display the object if IsHidden is true
-	IsHidden    bool   `field:"bk_ishidden" json:"bk_ishidden" bson:"bk_ishidden"`
+	IsHidden bool `field:"bk_ishidden" json:"bk_ishidden" bson:"bk_ishidden"`
 
 	IsPre       bool   `field:"ispre" json:"ispre" bson:"ispre"`
 	IsPaused    bool   `field:"bk_ispaused" json:"bk_ispaused" bson:"bk_ispaused"`
@@ -222,4 +222,27 @@ type ObjectTopo struct {
 	From      TopoItem `json:"from"`
 	To        TopoItem `json:"to"`
 	Arrows    string   `json:"arrows"`
+}
+
+//ObjectCountParams define parameter of search objects count
+type ObjectCountParams struct {
+	Condition ObjectIDArray `json:"condition"`
+}
+
+//ObjectIDArray a slice of object ids
+type ObjectIDArray struct {
+	ObjectIDs []string `json:"obj_ids"`
+}
+
+//ObjectCountResult result by searching object count
+type ObjectCountResult struct {
+	BaseResp `json:",inline"`
+	Data     []ObjectCountDetails `json:"data"`
+}
+
+//ObjectCountDetails one object count or error message of searching
+type ObjectCountDetails struct {
+	ObjectID  string `json:"bk_obj_id"`
+	InstCount uint64 `json:"inst_count"`
+	Error     string `json:"error"`
 }

--- a/src/web_server/logics/object.go
+++ b/src/web_server/logics/object.go
@@ -17,10 +17,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync"
 
 	"configcenter/src/common"
+	"configcenter/src/common/blog"
+	"configcenter/src/common/errors"
 	"configcenter/src/common/language"
 	"configcenter/src/common/mapstr"
+	"configcenter/src/common/metadata"
+	"configcenter/src/common/util"
 )
 
 // GetObjectData get object data
@@ -106,4 +111,133 @@ func ConvAttrOption(attrItems map[int]map[string]interface{}) {
 			attrItems[index][common.BKOptionField] = iOption
 		}
 	}
+}
+
+func (lgc *Logics) GetObjectCount(ctx context.Context, header http.Header,
+	cond *metadata.ObjectCountParams) (*metadata.ObjectCountResult, error) {
+	rid := util.GetHTTPCCRequestID(header)
+	defErr := lgc.CCErr.CreateDefaultCCErrorIf(util.GetLanguage(header))
+
+	objIDs := cond.Condition.ObjectIDs
+	if len(objIDs) > 20 {
+		blog.Errorf("field obj_ids number %d exceeds the max number 20, rid: %s", len(objIDs), rid)
+		return nil, defErr.CCErrorf(common.CCErrCommValExceedMaxFailed, "obj_ids", 20)
+	}
+	objArray, nonexistentObjects, err := lgc.ProcessObjectIDArray(ctx, header, objIDs)
+	if err != nil {
+		blog.Errorf("process object array failed, err %s, rid: %s", err.Error(), rid)
+		return nil, err
+	}
+	resp := &metadata.ObjectCountResult{}
+	for _, nonexistentObject := range nonexistentObjects {
+		objCount := metadata.ObjectCountDetails{
+			ObjectID: nonexistentObject,
+			Error:    defErr.CCError(common.CCErrorModelNotFound).Error(),
+		}
+		resp.Data = append(resp.Data, objCount)
+	}
+
+	var wg sync.WaitGroup
+	var apiErr errors.CCErrorCoder
+	existObjResult := make([]metadata.ObjectCountDetails, len(objArray))
+	pipeline := make(chan bool, 10)
+	for idx, objID := range objArray {
+		objCount := metadata.ObjectCountDetails{ObjectID: objID}
+		pipeline <- true
+		wg.Add(1)
+		go func(ctx context.Context, header http.Header, objID string, idx int, objCount metadata.ObjectCountDetails) {
+			defer func() {
+				wg.Done()
+				<-pipeline
+			}()
+			if metadata.IsCommon(objID) {
+				params := &metadata.Condition{Condition: map[string]interface{}{common.BKObjIDField: objID}}
+				count, err := lgc.CoreAPI.CoreService().Instance().CountInstances(ctx, header, objID, params)
+				if err != nil {
+					blog.Errorf("get %s instance count failed, err: %s, rid: %s", objID, err.Error(), rid)
+					apiErr = defErr.CCErrorf(common.CCErrCommHTTPDoRequestFailed)
+					return
+				}
+				if count == nil {
+					apiErr = defErr.CCErrorf(common.CCErrCommHTTPDoRequestFailed)
+					return
+				}
+				if !count.Result {
+					objCount.Error = count.ErrMsg
+				} else {
+					objCount.InstCount = count.Data.Count
+				}
+
+			} else {
+				tableName := common.GetInstTableName(objID, common.BKDefaultOwnerID)
+				count, err := lgc.CoreAPI.CoreService().Count().GetCountByFilter(ctx, header, tableName,
+					[]map[string]interface{}{{}})
+				if err != nil {
+					blog.Errorf("get %s instance count failed, err: %s, rid: %s", objID, err.Error(), rid)
+					apiErr = defErr.CCErrorf(common.CCErrCommHTTPDoRequestFailed)
+					return
+				}
+				if len(count) == 0 {
+					apiErr = defErr.CCErrorf(common.CCErrCommHTTPDoRequestFailed)
+					return
+				}
+				objCount.InstCount = uint64(count[0])
+			}
+
+			existObjResult[idx] = objCount
+
+		}(ctx, header, objID, idx, objCount)
+	}
+
+	wg.Wait()
+	resp.Data = append(resp.Data, existObjResult...)
+
+	if apiErr != nil {
+		return nil, apiErr
+	}
+
+	resp.Result = true
+	return resp, nil
+}
+
+func (lgc *Logics) ProcessObjectIDArray(ctx context.Context, header http.Header,
+	objectArray []string) ([]string, []string, error) {
+	rid := util.GetHTTPCCRequestID(header)
+	defErr := lgc.CCErr.CreateDefaultCCErrorIf(util.GetLanguage(header))
+
+	objArray := util.RemoveDuplicatesAndEmpty(objectArray)
+	objects, err := lgc.CoreAPI.CoreService().Model().ReadModel(ctx, header, &metadata.QueryCondition{
+		Condition: map[string]interface{}{
+			common.BKObjIDField: map[string]interface{}{
+				common.BKDBIN: objArray,
+			},
+		},
+	})
+	if err != nil {
+		blog.Errorf("get object by object id failed, err: %s, rid: %s", err.Error(), rid)
+		return nil, nil, defErr.CCError(common.CCErrTopoModuleSelectFailed)
+	}
+	if !objects.Result {
+		blog.Errorf("get object by object id failed, err: %s, rid: %s", objects.ErrMsg, rid)
+		if objects.Code == 0 {
+			return nil, nil, defErr.CCError(common.CCErrTopoModuleSelectFailed)
+		}
+		return nil, nil, defErr.CCError(objects.Code)
+	}
+	if objects.Data.Count == 0 {
+		blog.Errorf("none object exist, object id: %v, err: %s, rid: %s", objectArray,
+			defErr.CCError(common.CCErrorModelNotFound).Error(), rid)
+		return nil, nil, defErr.CCError(common.CCErrorModelNotFound)
+	}
+	var nonexistentObjects []string
+	if objects.Data.Count < int64(len(objArray)) {
+		var temp []string
+		for _, object := range objects.Data.Info {
+			temp = append(temp, object.Spec.ObjectID)
+		}
+		nonexistentObjects = util.StrArrDiff(objArray, temp)
+		objArray = temp
+	}
+
+	return objArray, nonexistentObjects, nil
 }

--- a/src/web_server/service/object.go
+++ b/src/web_server/service/object.go
@@ -371,3 +371,30 @@ func (s *Service) SearchBusiness(c *gin.Context) {
 	c.JSON(http.StatusOK, biz)
 	return
 }
+
+func (s *Service) GetObjectInstanceCount(c *gin.Context) {
+	header := c.Request.Header
+	rid := util.GetHTTPCCRequestID(header)
+	ctx := util.NewContextFromGinContext(c)
+	webCommon.SetProxyHeader(c)
+	cond := &metadata.ObjectCountParams{}
+
+	err := c.BindJSON(&cond)
+	if err != nil {
+		blog.Errorf("unmarshal body to json failed, err: %s, rid: %s", err.Error(), rid)
+		msg := getReturnStr(common.CCErrCommJSONUnmarshalFailed, err.Error(), nil)
+		_, _ = c.Writer.Write([]byte(msg))
+		return
+	}
+
+	resp, err := s.Logics.GetObjectCount(ctx, header, cond)
+	if err != nil {
+		blog.Errorf("get object count failed, err: %s, rid: %s", err.Error(), rid)
+		msg := getReturnStr(common.CCErrCommHTTPDoRequestFailed, err.Error(), nil)
+		_, _ = c.Writer.Write([]byte(msg))
+		return
+	}
+
+	c.JSON(http.StatusOK, resp)
+	return
+}

--- a/src/web_server/service/service.go
+++ b/src/web_server/service/service.go
@@ -109,6 +109,7 @@ func (s *Service) WebService() *gin.Engine {
 	ws.POST("/netproperty/export", s.ExportNetProperty)
 	ws.GET("/netcollect/importtemplate/netproperty", s.BuildDownLoadNetPropertyExcelTemplate)
 
+	ws.POST("/object/count", s.GetObjectInstanceCount)
 	// if no route, redirect to 404 page
 	ws.NoRoute(func(c *gin.Context) {
 		c.Redirect(302, "/#/404")


### PR DESCRIPTION
### 新加的功能:
- 查询多个模型实例的数量
- 单次最多支持查询二十个模型
- 重复模型id会去重后再查询

issue #5322  
