### PR TITLE
调整通用模型实例表的es索引名

### DIFF
--- a/src/scene_server/topo_server/service/fulltextsearch.go
+++ b/src/scene_server/topo_server/service/fulltextsearch.go
@@ -57,8 +57,9 @@ var esIndexesNameTypeMap = map[string]string{
 var esIndexesTypeNameMap = map[string]string{
 	TypeApplication: esBizIndex,
 	TypeHost:        esHostIndex,
-	TypeInstance:    esInstanceIndex,
-	TypeModel:       esModelIndex + "*",
+	// the wildcard * can match multiple indexes whose name start with "cc_ObjectBase"
+	TypeInstance: esInstanceIndex + "*",
+	TypeModel:    esModelIndex,
 }
 
 var esIndexesTypeKindMap = map[string]string{


### PR DESCRIPTION
### 修复的问题：
- 调整通用模型实例表的es索引名,以兼容实例表拆分前后的情况
