### PR TITLE
修复查询关联的实例的接口在自关联的情况下返回错误的问题+调整唯一校验失败时的报错信息

### DIFF
--- a/src/scene_server/topo_server/core/operation/association.go
+++ b/src/scene_server/topo_server/core/operation/association.go
@@ -50,7 +50,8 @@ type AssociationOperationInterface interface {
 	SearchInstAssociation(kit *rest.Kit, objID string, query *metadata.QueryInput) ([]metadata.InstAsst, error)
 	SearchInstAssociationList(kit *rest.Kit, objID string, query *metadata.QueryCondition) ([]metadata.InstAsst, uint64, error)
 	SearchInstAssociationUIList(kit *rest.Kit, objID string, query *metadata.QueryCondition) (result interface{}, asstCnt uint64, err error)
-	SearchInstAssociationSingleObjectInstInfo(kit *rest.Kit, returnInstInfoObjID string, query *metadata.QueryCondition) (result []metadata.InstBaseInfo, cnt uint64, err error)
+	SearchInstAssociationSingleObjectInstInfo(kit *rest.Kit, returnInstInfoObjID string, query *metadata.QueryCondition,
+		isTargetObject bool) (result []metadata.InstBaseInfo, cnt uint64, err error)
 	CreateCommonInstAssociation(kit *rest.Kit, data *metadata.InstAsst) error
 	DeleteInstAssociation(kit *rest.Kit, objID string, cond map[string]interface{}) error
 	CheckAssociation(kit *rest.Kit, objectID string, instID int64) error
@@ -1261,7 +1262,8 @@ func (assoc *association) SearchInstAssociationUIList(kit *rest.Kit, objID strin
 
 // SearchInstAssociationUIList 与实例有关系的实例关系数据,以分页的方式返回
 // returnInstInfoObjID 根据条件查询出来关联关系，需要返回实例信息（实例名，实例ID）的模型ID
-func (assoc *association) SearchInstAssociationSingleObjectInstInfo(kit *rest.Kit, returnInstInfoObjID string, query *metadata.QueryCondition) (result []metadata.InstBaseInfo, cnt uint64, err error) {
+func (assoc *association) SearchInstAssociationSingleObjectInstInfo(kit *rest.Kit, returnInstInfoObjID string,
+	query *metadata.QueryCondition, isTargetObject bool) (result []metadata.InstBaseInfo, cnt uint64, err error) {
 	queryCond := &metadata.InstAsstQueryCondition{
 		ObjID: returnInstInfoObjID,
 	}
@@ -1289,11 +1291,10 @@ func (assoc *association) SearchInstAssociationSingleObjectInstInfo(kit *rest.Ki
 	var objIDInstIDArr []int64
 
 	for _, instAsst := range rsp.Data.Info {
-		if instAsst.ObjectID == returnInstInfoObjID {
+		if isTargetObject {
 			objIDInstIDArr = append(objIDInstIDArr, instAsst.InstID)
-		} else if instAsst.AsstObjectID == returnInstInfoObjID {
+		} else {
 			objIDInstIDArr = append(objIDInstIDArr, instAsst.AsstInstID)
-
 		}
 	}
 

--- a/src/scene_server/topo_server/service/inst.go
+++ b/src/scene_server/topo_server/service/inst.go
@@ -1091,8 +1091,8 @@ func (s *Service) SearchInstAssociationWithOtherObject(ctx *rest.Contexts) {
 		return
 	}
 
-	blog.V(5).Infof("input:%#v, rid:%s", input, ctx.Kit.Rid)
-	infos, cnt, err := s.Core.AssociationOperation().SearchInstAssociationSingleObjectInstInfo(ctx.Kit, reqParams.Condition.AssociationObjectID, input)
+	infos, cnt, err := s.Core.AssociationOperation().SearchInstAssociationSingleObjectInstInfo(ctx.Kit,
+		reqParams.Condition.AssociationObjectID, input, reqParams.Condition.IsTargetObject)
 	if err != nil {
 		blog.ErrorJSON("parse page illegal, input:%s, err:%s, rid:%s", input, err.Error(), ctx.Kit.Rid)
 		ctx.RespAutoError(err)
@@ -1102,6 +1102,5 @@ func (s *Service) SearchInstAssociationWithOtherObject(ctx *rest.Contexts) {
 	ctx.RespEntity(map[string]interface{}{
 		"info":  infos,
 		"count": cnt,
-		"page":  input.Page,
 	})
 }

--- a/src/source_controller/coreservice/core/instances/instance_crud.go
+++ b/src/source_controller/coreservice/core/instances/instance_crud.go
@@ -68,7 +68,7 @@ func (m *instanceManager) save(kit *rest.Kit, objID string, inputParam mapstr.Ma
 		blog.ErrorJSON("save instance error. err: %s, objID: %s, instance: %s, rid: %s",
 			err.Error(), objID, inputParam, kit.Rid)
 		if mongodb.Client().IsDuplicatedError(err) {
-			return id, kit.CCError.CCError(common.CCErrCommDuplicateItem)
+			return id, kit.CCError.CCErrorf(common.CCErrCommDuplicateItem, mongodb.GetDuplicateKey(err))
 		}
 		return 0, err
 	}

--- a/src/storage/driver/mongodb/monogdb.go
+++ b/src/storage/driver/mongodb/monogdb.go
@@ -13,6 +13,7 @@
 package mongodb
 
 import (
+	"strings"
 	"time"
 
 	"configcenter/src/common"
@@ -118,4 +119,32 @@ func Healthz() (items []metric.HealthItem) {
 	}
 
 	return
+}
+
+// GetDuplicateKey get duplicate key from error, if the error is not a duplicate error, returns the raw error message
+// mongodb raw error format example:
+// ...{E11000 duplicate key error collection: cmdb.cc_ObjectBase_... index: bkcc_unique_... dup key:
+// { bk_inst_name: \"xxx\" }}]},...
+func GetDuplicateKey(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	errString := err.Error()
+	if !strings.Contains(errString, "E11000 duplicate") {
+		return errString
+	}
+
+	start := strings.Index(errString, "dup key: ")
+	if start == -1 {
+		return errString
+	}
+	start += len("dup key: ")
+
+	end := strings.LastIndex(errString, "}]},")
+	if end == -1 || end < start {
+		return errString
+	}
+
+	return errString[start:end]
 }


### PR DESCRIPTION
### 优化的功能:
- 调整唯一校验失败时的报错信息
### 修复的问题：
- 修复查询关联的实例的接口在自关联的情况下返回错误的问题
