### PR TITLE
修复zk服务节点丢失后不能重新注册的问题

### DIFF
--- a/src/common/registerdiscover/zkregdiscv.go
+++ b/src/common/registerdiscover/zkregdiscv.go
@@ -278,7 +278,11 @@ func (zkRD *ZkRegDiscv) reconnectZk() {
 			time.Sleep(5 * time.Second)
 			continue
 		}
+		// wait some time to make the new connection available
+		time.Sleep(time.Second)
 		fmt.Println("reconnect zookeeper success")
+		zkRD.registerPath = ""
+
 		return
 	}
 }


### PR DESCRIPTION
### 修复的问题：
- 修复zk服务节点丢失后不能重新注册的问题
