### PR TITLE
将主机的自动发现信息属性分组下的属性设置为可编辑

### DIFF
--- a/src/scene_server/admin_server/imports.go
+++ b/src/scene_server/admin_server/imports.go
@@ -126,4 +126,5 @@ import (
 	_ "configcenter/src/scene_server/admin_server/upgrader/y3.9.202105261459"
 	_ "configcenter/src/scene_server/admin_server/upgrader/y3.9.202106031151"
 	_ "configcenter/src/scene_server/admin_server/upgrader/y3.9.202106291420"
+	_ "configcenter/src/scene_server/admin_server/upgrader/y3.9.202106301910"
 )

--- a/src/scene_server/admin_server/upgrader/y3.9.202106301910/change_host_attr_editable.go
+++ b/src/scene_server/admin_server/upgrader/y3.9.202106301910/change_host_attr_editable.go
@@ -1,0 +1,35 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package y3_9_202106301910
+
+import (
+	"context"
+
+	"configcenter/src/scene_server/admin_server/upgrader"
+	"configcenter/src/storage/dal"
+)
+
+// changeHostAttrEditable change host attributes that has the property group of auto to editable
+func changeHostAttrEditable(ctx context.Context, db dal.RDB, conf *upgrader.Config) (err error) {
+	filter := map[string]interface{}{
+		"bk_property_group": "auto",
+		"bk_obj_id":         "host",
+		"bk_biz_id":         0,
+		"ispre":             true,
+	}
+
+	doc := map[string]interface{}{
+		"editable": true,
+	}
+
+	return db.Table("cc_ObjAttDes").Update(ctx, filter, doc)
+}

--- a/src/scene_server/admin_server/upgrader/y3.9.202106301910/pkg.go
+++ b/src/scene_server/admin_server/upgrader/y3.9.202106301910/pkg.go
@@ -1,0 +1,34 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package y3_9_202106301910
+
+import (
+	"context"
+
+	"configcenter/src/common/blog"
+	"configcenter/src/scene_server/admin_server/upgrader"
+	"configcenter/src/storage/dal"
+)
+
+func init() {
+	upgrader.RegistUpgrader("y3.9.202106301910", upgrade)
+}
+
+func upgrade(ctx context.Context, db dal.RDB, conf *upgrader.Config) (err error) {
+	err = changeHostAttrEditable(ctx, db, conf)
+	if err != nil {
+		blog.Errorf("[upgrade y3.9.202106301910] change host auto attributes to editable err: %v", err)
+		return err
+	}
+
+	return
+}

--- a/src/test/host_server/host_test.go
+++ b/src/test/host_server/host_test.go
@@ -1346,13 +1346,13 @@ var _ = Describe("batch_update_host test", func() {
 		hostId2, err := commonutil.GetInt64ByInterface(searchRsp.Data.Info[1]["host"].(map[string]interface{})["bk_host_id"])
 		Expect(err).NotTo(HaveOccurred())
 
-		By("update host property batch, bk_host_name is not editable field")
+		By("update host property batch, bk_asset_id is not editable field")
 		updateInput := map[string]interface{}{
 			"update": []map[string]interface{}{
 				{
 					common.BKHostIDField: hostId1,
 					"properties": map[string]interface{}{
-						"bk_host_name": "batch_update1",
+						"bk_asset_id": "batch_update1",
 						"operator":     "admin",
 						"bk_comment":   "test",
 						"bk_isp_name":  "1",
@@ -1377,7 +1377,7 @@ var _ = Describe("batch_update_host test", func() {
 		util.RegisterResponse(searchRsp)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(searchRsp.Result).To(Equal(true))
-		Expect(searchRsp.Data.Info[0]["host"].(map[string]interface{})["bk_host_name"].(string)).To(Equal(""))
+		Expect(searchRsp.Data.Info[0]["host"].(map[string]interface{})["bk_asset_id"].(string)).To(Equal(""))
 		Expect(searchRsp.Data.Info[0]["host"].(map[string]interface{})["operator"].(string)).To(Equal("admin"))
 		Expect(searchRsp.Data.Info[0]["host"].(map[string]interface{})["bk_comment"].(string)).To(Equal("test"))
 		Expect(searchRsp.Data.Info[0]["host"].(map[string]interface{})["bk_isp_name"].(string)).To(Equal("1"))


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
