### PR TITLE
修改获取用户列表接口，提高cmdb实例数据导出

### DIFF
--- a/src/common/metadata/procserver.go
+++ b/src/common/metadata/procserver.go
@@ -256,6 +256,17 @@ type EsbUserListResponse struct {
 	Data            []UserInfo `json:"data"`
 }
 
+type EsbListUserResponse struct {
+	EsbBaseResponse `json:",inline"`
+	Data            []ListUserItem `json:"data"`
+}
+
+type ListUserItem struct {
+	ID          int64  `json:"id"`
+	Username    string `json:"username"`
+	DisplayName string `json:"display_name"`
+}
+
 type EsbBaseResponse struct {
 	Result       bool   `json:"result"`
 	Code         int    `json:"code"`

--- a/src/thirdpartyclient/esbserver/user/api.go
+++ b/src/thirdpartyclient/esbserver/user/api.go
@@ -34,3 +34,26 @@ func (p *user) GetAllUsers(ctx context.Context, h http.Header) (resp *metadata.E
 
 	return
 }
+
+func (p *user) ListUsers(ctx context.Context, h http.Header, params map[string]string) (resp *metadata.EsbListUserResponse, err error) {
+	resp = &metadata.EsbListUserResponse{}
+	h.Set("Accept", "application/json")
+
+	if params == nil {
+		params = make(map[string]string)
+	}
+	if _, ok := params["fields"]; ok == false {
+		params["fields"] = "username,id,display_name"
+	}
+	params["no_page"] = "true"
+	err = p.client.Get().
+		WithContext(ctx).
+		WithParams(params).
+		SubResourcef("/v2/usermanage/list_users/").
+		WithParams(esbutil.GetEsbQueryParameters(p.config.GetConfig(), h)).
+		WithHeaders(h).
+		Do().
+		Into(resp)
+
+	return
+}

--- a/src/thirdpartyclient/esbserver/user/esbserv.go
+++ b/src/thirdpartyclient/esbserver/user/esbserv.go
@@ -22,6 +22,7 @@ import (
 
 type UserClientInterface interface {
 	GetAllUsers(ctx context.Context, h http.Header) (resp *metadata.EsbUserListResponse, err error)
+	ListUsers(ctx context.Context, h http.Header, params map[string]string) (resp *metadata.EsbListUserResponse, err error)
 }
 
 func NewUserClientInterface(client rest.ClientInterface, config *esbutil.EsbConfigSrv) UserClientInterface {

--- a/src/web_server/middleware/user/plugins/method/self/userinfo.go
+++ b/src/web_server/middleware/user/plugins/method/self/userinfo.go
@@ -13,9 +13,9 @@
 package self
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"configcenter/src/apimachinery/util"
@@ -173,6 +173,18 @@ func (m *user) getEsbClient(config map[string]string) (esbserver.EsbClientInterf
 func (m *user) GetUserList(c *gin.Context, config map[string]string) ([]*metadata.LoginSystemUserInfo, error) {
 	rid := commonutil.GetHTTPCCRequestID(c.Request.Header)
 	accountURL, ok := config["site.bk_account_url"]
+	query := c.Request.URL.Query()
+	params := make(map[string]string)
+	for key, values := range query {
+		params[key] = strings.Join(values, ";")
+	}
+
+	for key, value := range config {
+		if key == "fields" || key == "exact_lookups" {
+			params[key] = value
+		}
+	}
+
 	if !ok {
 		// try to use esb user list api
 		esbClient, err := m.getEsbClient(config)
@@ -180,7 +192,7 @@ func (m *user) GetUserList(c *gin.Context, config map[string]string) ([]*metadat
 			blog.Warnf("get esb client failed, err: %+v, rid: %s", err, rid)
 			return nil, fmt.Errorf("config site.bk_account_url not found")
 		}
-		result, err := esbClient.User().GetAllUsers(context.Background(), c.Request.Header)
+		result, err := esbClient.User().ListUsers(c.Request.Context(), c.Request.Header, params)
 		if err != nil {
 			blog.Warnf("get users by esb client failed, http failed, err: %+v, rid: %s", err, rid)
 			return nil, fmt.Errorf("get users by esb client failed, http failed")
@@ -189,7 +201,7 @@ func (m *user) GetUserList(c *gin.Context, config map[string]string) ([]*metadat
 		for _, userInfo := range result.Data {
 			user := &metadata.LoginSystemUserInfo{
 				CnName: userInfo.DisplayName,
-				EnName: userInfo.BkUsername,
+				EnName: userInfo.Username,
 			}
 			users = append(users, user)
 		}

--- a/src/web_server/service/util.go
+++ b/src/web_server/service/util.go
@@ -97,18 +97,17 @@ func (s *Service) getUsernameFromEsb(c *gin.Context, userList []string) (map[str
 	usernameMap := map[string]string{}
 
 	if userList != nil && len(userList) != 0 {
-		params := make(map[string]string)
-		params["exact_lookups"] = userListStr
-		params["fields"] = "username,display_name"
+		config := s.Config.ConfigMap
+		config["exact_lookups"] = userListStr
+		config["fields"] = "username,display_name"
 		user := plugins.CurrentPlugin(c, s.Config.LoginVersion)
 
-		userListEsb, err := user.GetUserList(c, s.Config.ConfigMap)
+		userListEsb, err := user.GetUserList(c, config)
 		if err != nil {
 			blog.ErrorJSON("get user list from ESB failed, err: %s, rid: %s", err.Error(), rid)
 			userListEsb = []*metadata.LoginSystemUserInfo{}
 			return nil, err
 		}
-
 		for _, userInfo := range userListEsb {
 			username := fmt.Sprintf("%s(%s)", userInfo.EnName, userInfo.CnName)
 			usernameMap[userInfo.EnName] = username


### PR DESCRIPTION
### 优化的功能:
- cmdb导出实例数据，当导出的字段包含用户字段，且用户字段有值时，导出非常慢
### 修复的问题：
- 提高cmdb导出实例数据速度
### 注意事项
- 依赖的用户管理后台版本>1.5

close issue #5425