### PR TITLE
optimize: excel导出用户管理中不存在的用户时，导出中英文时保留原用户名并提示用户不存在

### DIFF
--- a/resources/language/default/web.json
+++ b/resources/language/default/web.json
@@ -17,5 +17,6 @@
     "both_hostid_exportcond_empty": "excel导出条件参数bk_host_id和export_condition不能同时为空",
     "host_id_len_err": "excel导出条件参数bk_host_id的主机数量范围是1～%d",
     "export_page_limit_err": "excel导出条件参数page.limit的范围是1～%d",
+    "nonexistent_user": "用户不存在",
     "": ""
 }

--- a/resources/language/default/web.json
+++ b/resources/language/default/web.json
@@ -17,6 +17,6 @@
     "both_hostid_exportcond_empty": "excel导出条件参数bk_host_id和export_condition不能同时为空",
     "host_id_len_err": "excel导出条件参数bk_host_id的主机数量范围是1～%d",
     "export_page_limit_err": "excel导出条件参数page.limit的范围是1～%d",
-    "nonexistent_user": "用户不存在",
+    "nonexistent_user": "用户已经不存在",
     "": ""
 }

--- a/resources/language/en/web.json
+++ b/resources/language/en/web.json
@@ -17,5 +17,6 @@
     "both_hostid_exportcond_empty": "excel export condition param bk_host_id and export_condition can't be empty at the same time",
     "host_id_len_err": "the count of hostids in excel export condition param bk_host_id must be 1～%d",
     "export_page_limit_err": "excel export condition param page.limit must be 1～%d",
+    "nonexistent_user": "nonexistent user",
     "": ""
 }

--- a/resources/language/en/web.json
+++ b/resources/language/en/web.json
@@ -17,6 +17,6 @@
     "both_hostid_exportcond_empty": "excel export condition param bk_host_id and export_condition can't be empty at the same time",
     "host_id_len_err": "the count of hostids in excel export condition param bk_host_id must be 1～%d",
     "export_page_limit_err": "excel export condition param page.limit must be 1～%d",
-    "nonexistent_user": "nonexistent user",
+    "nonexistent_user": "user already does not exist",
     "": ""
 }

--- a/src/web_server/logics/excel.go
+++ b/src/web_server/logics/excel.go
@@ -66,7 +66,7 @@ func (lgc *Logics) BuildExcelFromData(ctx context.Context, objID string, fields 
 			return ccErr.Errorf(common.CCErrCommInstFieldNotFound, "instIDKey", objID)
 		}
 		// 使用中英文用户名重新构造用户列表(用户列表实际为逗号分隔的string型)
-		rowMap, err = replaceEnName(rid, rowMap, usernameMap, propertyList)
+		rowMap, err = replaceEnName(rid, rowMap, usernameMap, propertyList, ccLang)
 		if err != nil {
 			blog.Errorf("rebuild user list field, rid: %s", rid)
 			return err
@@ -164,7 +164,7 @@ func (lgc *Logics) BuildHostExcelFromData(ctx context.Context, objID string, fie
 		}
 
 		// 使用中英文用户名重新构造用户列表(用户列表实际为逗号分隔的string型)
-		rowMap, err = replaceEnName(rid, rowMap, usernameMap, propertyList)
+		rowMap, err = replaceEnName(rid, rowMap, usernameMap, propertyList, ccLang)
 		if err != nil {
 			blog.Errorf("rebuild user list field, rid: %s", rid)
 			return err

--- a/src/web_server/logics/util.go
+++ b/src/web_server/logics/util.go
@@ -18,6 +18,7 @@ import (
 
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
+	"configcenter/src/common/language"
 	"configcenter/src/common/mapstr"
 	"github.com/rentiansheng/xlsx"
 )
@@ -175,7 +176,8 @@ func addExtFields(fields map[string]Property, extFields map[string]string) map[s
 	return fields
 }
 
-func replaceEnName(rid string, rowMap mapstr.MapStr, usernameMap map[string]string, propertyList []string) (mapstr.MapStr, error) {
+func replaceEnName(rid string, rowMap mapstr.MapStr, usernameMap map[string]string, propertyList []string,
+	defLang language.DefaultCCLanguageIf) (mapstr.MapStr, error) {
 	// propertyList是用户自定义的objuser型的attr名列表
 	for _, property := range propertyList {
 		if rowMap[property] == nil {
@@ -189,7 +191,12 @@ func replaceEnName(rid string, rowMap mapstr.MapStr, usernameMap map[string]stri
 		}
 		enNameList := strings.Split(userListString, ",")
 		for _, item := range enNameList {
-			newUserList = append(newUserList, usernameMap[item])
+			username := usernameMap[item]
+			if username == "" {
+				// return the original user name and remind that the user is nonexistent in '()'
+				username = fmt.Sprintf("%s(%s)", item, defLang.Language("nonexistent_user"))
+			}
+			newUserList = append(newUserList, username)
 		}
 		rowMap[property] = strings.Join(newUserList, ",")
 	}


### PR DESCRIPTION
### 优化的功能:
- excel导出用户管理中不存在的用户时，导出中英文时保留原用户名并提示用户不存在
close issue https://github.com/Tencent/bk-cmdb/issues/5491