### PR TITLE
使用get_all_users接口获取全量用户

### DIFF
--- a/src/common/metadata/webserver.go
+++ b/src/common/metadata/webserver.go
@@ -58,6 +58,7 @@ type LoginUserPluginParams struct {
 type LoginUserPluginInerface interface {
 	LoginUser(c *gin.Context, config map[string]string, isMultiOwner bool) (user *LoginUserInfo, loginSucc bool)
 	GetUserList(c *gin.Context, config map[string]string) ([]*LoginSystemUserInfo, error)
+	GetUserListForFront(c *gin.Context, config map[string]string) ([]*LoginSystemUserInfo, error)
 	GetLoginUrl(c *gin.Context, config map[string]string, input *LogoutRequestParams) string
 }
 

--- a/src/web_server/middleware/user/plugins/method/self/userinfo.go
+++ b/src/web_server/middleware/user/plugins/method/self/userinfo.go
@@ -172,7 +172,6 @@ func (m *user) getEsbClient(config map[string]string) (esbserver.EsbClientInterf
 // GetUserList get user list from paas
 func (m *user) GetUserList(c *gin.Context, config map[string]string) ([]*metadata.LoginSystemUserInfo, error) {
 	rid := commonutil.GetHTTPCCRequestID(c.Request.Header)
-	accountURL, ok := config["site.bk_account_url"]
 	query := c.Request.URL.Query()
 	params := make(map[string]string)
 	for key, values := range query {
@@ -185,6 +184,7 @@ func (m *user) GetUserList(c *gin.Context, config map[string]string) ([]*metadat
 		}
 	}
 
+	accountURL, ok := config["site.bk_account_url"]
 	if !ok {
 		// try to use esb user list api
 		esbClient, err := m.getEsbClient(config)
@@ -223,19 +223,19 @@ func (m *user) GetUserList(c *gin.Context, config map[string]string) ([]*metadat
 	}
 
 	token := session.Get(common.HTTPCookieBKToken)
-	getURL := fmt.Sprintf(accountURL, token)
+	getUserListURL := fmt.Sprintf(accountURL, token)
 	httpClient := httpclient.NewHttpClient()
 
 	if err := httpClient.SetTlsNoVerity(); err != nil {
 		blog.Warnf("httpClient.SetTlsNoVerity failed, err: %s, rid: %s", err.Error(), rid)
 	}
-	reply, err := httpClient.GET(getURL, nil, nil)
+	reply, err := httpClient.GET(getUserListURL, nil, nil)
 
 	if nil != err {
 		blog.Errorf("get user list error：%v, rid: %s", err, rid)
 		return nil, fmt.Errorf("http do error:%s", err.Error())
 	}
-	blog.V(5).Infof("get user list url: %s, return：%s, rid: %s", getURL, reply, rid)
+	blog.V(5).Infof("get user list url: %s, return：%s, rid: %s", getUserListURL, reply, rid)
 	var result userListResult
 	err = json.Unmarshal([]byte(reply), &result)
 	if nil != err || false == result.Result {
@@ -298,18 +298,18 @@ func (m *user) GetUserListForFront(c *gin.Context, config map[string]string) ([]
 	}
 
 	token := session.Get(common.HTTPCookieBKToken)
-	getURL := fmt.Sprintf(accountURL, token)
+	getUserListURL := fmt.Sprintf(accountURL, token)
 	httpClient := httpclient.NewHttpClient()
 
 	if err := httpClient.SetTlsNoVerity(); err != nil {
 		blog.Warnf("httpClient.SetTlsNoVerity failed, err: %s, rid: %s", err.Error(), rid)
 	}
-	reply, err := httpClient.GET(getURL, nil, nil)
+	reply, err := httpClient.GET(getUserListURL, nil, nil)
 	if nil != err {
 		blog.Errorf("get user list error：%v, rid: %s", err, rid)
 		return nil, fmt.Errorf("http do error:%s", err.Error())
 	}
-	blog.V(5).Infof("get user list url: %s, return：%s, rid: %s", getURL, reply, rid)
+	blog.V(5).Infof("get user list url: %s, return：%s, rid: %s", getUserListURL, reply, rid)
 	var result userListResult
 	err = json.Unmarshal([]byte(reply), &result)
 	if nil != err || false == result.Result {

--- a/src/web_server/middleware/user/plugins/method/self/userinfo.go
+++ b/src/web_server/middleware/user/plugins/method/self/userinfo.go
@@ -260,7 +260,6 @@ func (m *user) GetUserList(c *gin.Context, config map[string]string) ([]*metadat
 func (m *user) GetUserListForFront(c *gin.Context, config map[string]string) ([]*metadata.LoginSystemUserInfo, error) {
 	rid := commonutil.GetHTTPCCRequestID(c.Request.Header)
 	accountURL, ok := config["site.bk_account_url"]
-
 	if !ok {
 		// try to use esb user list api
 		esbClient, err := m.getEsbClient(config)
@@ -306,7 +305,6 @@ func (m *user) GetUserListForFront(c *gin.Context, config map[string]string) ([]
 		blog.Warnf("httpClient.SetTlsNoVerity failed, err: %s, rid: %s", err.Error(), rid)
 	}
 	reply, err := httpClient.GET(getURL, nil, nil)
-
 	if nil != err {
 		blog.Errorf("get user list error：%v, rid: %s", err, rid)
 		return nil, fmt.Errorf("http do error:%s", err.Error())

--- a/src/web_server/middleware/user/public.go
+++ b/src/web_server/middleware/user/public.go
@@ -113,7 +113,7 @@ func (m *publicUser) GetUserList(c *gin.Context) (int, interface{}) {
 	httpStatus := http.StatusOK
 	if nil == m.loginPlg {
 		user := plugins.CurrentPlugin(c, m.config.LoginVersion)
-		userList, err = user.GetUserList(c, m.config.ConfigMap)
+		userList, err = user.GetUserListForFront(c, m.config.ConfigMap)
 	} else {
 		getUserListFunc, err := m.loginPlg.Lookup("GetUserList")
 		if nil != err {


### PR DESCRIPTION
### 修复的问题：
- 前端获取用户，后端依旧使用原来的get_all_users用户管理接口来获取，虽然慢，但是不会超时


<!--  **重要提醒**: 这些关键信息会辅助我们快速定位问题。 -->

请提供以下信息:

 - [x] bk-cmdb   版本: v3.5.x