### PR TITLE
optimize: excel导出用户管理中不存在的用户时，导出中英文名时保留原用户名并提示用户不存在

### DIFF
--- a/resources/language/default/web.json
+++ b/resources/language/default/web.json
@@ -13,5 +13,6 @@
     "web_excel_sheet_not_found": "文件内容不能为空,工作簿内容不存在",
     "web_get_object_field_failure": "查询对象属性失败，错误:%s",
     "web_ext_field_topo":"业务拓扑",
+    "nonexistent_user": "用户不存在",
     "": ""
 }

--- a/resources/language/default/web.json
+++ b/resources/language/default/web.json
@@ -13,6 +13,6 @@
     "web_excel_sheet_not_found": "文件内容不能为空,工作簿内容不存在",
     "web_get_object_field_failure": "查询对象属性失败，错误:%s",
     "web_ext_field_topo":"业务拓扑",
-    "nonexistent_user": "用户不存在",
+    "nonexistent_user": "用户已经不存在",
     "": ""
 }

--- a/resources/language/en/web.json
+++ b/resources/language/en/web.json
@@ -13,5 +13,6 @@
     "web_excel_sheet_not_found": "The content of the file cannot be empty, the workbook content does not exist",
     "web_get_object_field_failure": "Query fields fail, error:%s",
     "web_ext_field_topo":"business topology",
+    "nonexistent_user": "nonexistent user",
     "": ""
 }

--- a/resources/language/en/web.json
+++ b/resources/language/en/web.json
@@ -13,6 +13,6 @@
     "web_excel_sheet_not_found": "The content of the file cannot be empty, the workbook content does not exist",
     "web_get_object_field_failure": "Query fields fail, error:%s",
     "web_ext_field_topo":"business topology",
-    "nonexistent_user": "nonexistent user",
+    "nonexistent_user": "user already does not exist",
     "": ""
 }

--- a/src/web_server/logics/excel.go
+++ b/src/web_server/logics/excel.go
@@ -66,7 +66,11 @@ func (lgc *Logics) BuildExcelFromData(ctx context.Context, objID string, fields 
 		}
 
 		// 使用中英文用户名重新构造用户列表(用户列表实际为逗号分隔的string型)
-		rowMap = replaceEnName(rowMap, usernameMap, propertyList)
+		rowMap, err = replaceEnName(rid, rowMap, usernameMap, propertyList, ccLang)
+		if err != nil {
+			blog.Errorf("rebuild user list field, err: %s, rid: %s", err, rid)
+			return err
+		}
 
 		primaryKeyArr := setExcelRowDataByIndex(rowMap, sheet, rowIndex, fields)
 
@@ -127,7 +131,11 @@ func (lgc *Logics) BuildHostExcelFromData(ctx context.Context, objID string, fie
 		}
 
 		// 使用中英文用户名重新构造用户列表(用户列表实际为逗号分隔的string型)
-		rowMap = replaceEnName(rowMap, usernameMap, propertyList)
+		rowMap, err = replaceEnName(rid, rowMap, usernameMap, propertyList, ccLang)
+		if err != nil {
+			blog.Errorf("rebuild user list field, err: %s, rid: %s", err, rid)
+			return err
+		}
 
 		primaryKeyArr := setExcelRowDataByIndex(rowMap, sheet, rowIndex, fields)
 		instPrimaryKeyValMap[instID] = primaryKeyArr

--- a/src/web_server/logics/util.go
+++ b/src/web_server/logics/util.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 
 	"configcenter/src/common"
+	"configcenter/src/common/blog"
+	"configcenter/src/common/language"
 	"configcenter/src/common/mapstr"
 
 	"github.com/rentiansheng/xlsx"
@@ -175,24 +177,33 @@ func addExtFields(fields map[string]Property, extFields map[string]string) map[s
 	return fields
 }
 
-func replaceEnName(rowMap mapstr.MapStr, usernameMap map[string]string, propertyList []string) mapstr.MapStr {
+func replaceEnName(rid string, rowMap mapstr.MapStr, usernameMap map[string]string, propertyList []string,
+	defLang language.DefaultCCLanguageIf) (mapstr.MapStr, error) {
 	// propertyList是用户自定义的objuser型的attr名列表
 	for _, property := range propertyList {
 		if rowMap[property] == nil {
 			continue
 		}
+
 		newUserList := []string{}
-		// usernameMap是依照英文名对照中英文名的对照字典
-		for enName, enCnName := range usernameMap {
-			// rowMap包含了即将写入excel的信息,我们要替换其中的objuser类型的attr内容
-			enNameList := strings.Split(rowMap[property].(string), ",")
-			for _, enNameSingle := range enNameList {
-				if enNameSingle == enName {
-					newUserList = append(newUserList, enCnName)
-				}
+		userListString, ok := rowMap[property].(string)
+		if !ok {
+			blog.Errorf("convert variable rowMap[%s] type to string field , rowMap: %v, rowMap type: %T, rid: %s",
+				property, rowMap[property], rowMap[property], rid)
+			return nil, fmt.Errorf("convert variable rowMap[%s] type to string field", property)
+		}
+		enNameList := strings.Split(userListString, ",")
+
+		for _, item := range enNameList {
+			username := usernameMap[item]
+			if username == "" {
+				// return the original user name and remind that the user is nonexistent in '()'
+				username = fmt.Sprintf("%s(%s)", item, defLang.Language("nonexistent_user"))
 			}
+			newUserList = append(newUserList, username)
 		}
 		rowMap[property] = strings.Join(newUserList, ",")
 	}
-	return rowMap
+
+	return rowMap, nil
 }


### PR DESCRIPTION
### 优化的功能:
- excel导出用户管理中不存在的用户时，导出中英文名时保留原用户名并提示用户不存在
close issue  https://github.com/Tencent/bk-cmdb/issues/5491