### PR TITLE
默认使用服务实例ID排序

### DIFF
--- a/src/source_controller/coreservice/core/process/service_instance.go
+++ b/src/source_controller/coreservice/core/process/service_instance.go
@@ -426,6 +426,8 @@ func (p *processOperation) ListServiceInstanceDetail(kit *rest.Kit, option metad
 	query := mongodb.Client().Table(common.BKTableNameServiceInstance).Find(filter).Start(start).Limit(limit)
 	if len(option.Page.Sort) > 0 {
 		query = query.Sort(option.Page.Sort)
+	}else {
+		query = query.Sort(common.BKFieldID)
 	}
 	if err := query.All(kit.Ctx, &serviceInstances); nil != err {
 		blog.Errorf("ListServiceInstance failed, mongodb failed, table: %s, filter: %+v, err: %+v, rid: %s", common.BKTableNameServiceInstance, filter, err, kit.Rid)

--- a/src/source_controller/coreservice/core/process/service_instance.go
+++ b/src/source_controller/coreservice/core/process/service_instance.go
@@ -426,7 +426,7 @@ func (p *processOperation) ListServiceInstanceDetail(kit *rest.Kit, option metad
 	query := mongodb.Client().Table(common.BKTableNameServiceInstance).Find(filter).Start(start).Limit(limit)
 	if len(option.Page.Sort) > 0 {
 		query = query.Sort(option.Page.Sort)
-	}else {
+	} else {
 		query = query.Sort(common.BKFieldID)
 	}
 	if err := query.All(kit.Ctx, &serviceInstances); nil != err {


### PR DESCRIPTION
### 修复的问题：
- 获取实例数据时，前端没有传递排序字段时，默认使用实例ID进行排序
