### PR TITLE
fix: 首页主机高级搜索跳转到资源主机全部列表页

### DIFF
--- a/src/ui/src/views/index/children/host-search.vue
+++ b/src/ui/src/views/index/children/host-search.vue
@@ -192,7 +192,10 @@
       handleClickAdvancedSearch() {
         this.$routerActions.redirect({
           name: MENU_RESOURCE_HOST,
-          query: { adv: 1 },
+          query: {
+            adv: 1,
+            scope: 'all'
+          },
           history: false
         })
       }


### PR DESCRIPTION
### 优化的功能:
- 首页主机高级搜索跳转到资源主机全部列表页