### PR TITLE
锁定webpack版本为5.47.x

### DIFF
--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -102,7 +102,7 @@
     "vue-loader": "^15.9.6",
     "vue-style-loader": "^4.1.3",
     "vue-template-compiler": "2.6.14",
-    "webpack": "^5.33.2",
+    "webpack": "~5.47.0",
     "webpack-bundle-analyzer": "^4.4.1",
     "webpack-dev-server": "^3.11.2",
     "webpack-merge": "^5.7.3"


### PR DESCRIPTION
### 修复的问题：
- 锁定webpack版本为5.47.x，防止npm依赖报错
