### PR TITLE
修复新建实例自关联的关联关系时对该实例获取两次锁导致失败的问题

### DIFF
--- a/src/source_controller/coreservice/core/association/instance.go
+++ b/src/source_controller/coreservice/core/association/instance.go
@@ -153,9 +153,16 @@ func (m *associationInstance) CreateOneInstanceAssociation(kit *rest.Kit, inputP
 	switch mappingType {
 	case metadata.OneToOneMapping:
 		mlocker := lock.NewMLocker(driverRedis.Client())
-		instkey := genAssoInstLockKey(inputParam.Data.InstID, inputParam.Data.ObjectAsstID)
-		asstInstkey := genAssoInstLockKey(inputParam.Data.AsstInstID, inputParam.Data.ObjectAsstID)
-		locked, err := mlocker.MLock(kit.Rid, 10, time.Minute, lock.StrFormat(instkey), lock.StrFormat(asstInstkey))
+
+		// if one instance is associated with itself, then lock this instance, or else lock both instance
+		instkey := lock.StrFormat(genAssoInstLockKey(inputParam.Data.InstID, inputParam.Data.ObjectAsstID))
+		lockKeys := []lock.StrFormat{instkey}
+		if inputParam.Data.InstID != inputParam.Data.AsstInstID {
+			asstInstkey := lock.StrFormat(genAssoInstLockKey(inputParam.Data.AsstInstID, inputParam.Data.ObjectAsstID))
+			lockKeys = append(lockKeys, asstInstkey)
+		}
+
+		locked, err := mlocker.MLock(kit.Rid, 10, time.Minute, lockKeys...)
 		if err != nil {
 			blog.Errorf("obtain lock failed. err: %v, rid: %s", err, kit.Rid)
 			return nil, kit.CCError.CCErrorf(common.CCERrrCoreServiceConcurrent)


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
