### PR TITLE
修改下载模板枚举值长度限制

### DIFF
--- a/vendor/github.com/rentiansheng/xlsx/datavalidation.go
+++ b/vendor/github.com/rentiansheng/xlsx/datavalidation.go
@@ -23,9 +23,9 @@ const (
 
 const (
 	// dataValidationFormulaStrLen 255 characters+ 2 quotes
-	dataValidationFormulaStrLen = 257
+	dataValidationFormulaStrLen = 2000
 	// dataValidationFormulaStrLenErr
-	dataValidationFormulaStrLenErr = "data validation must be 0-255 characters"
+	dataValidationFormulaStrLenErr = "data validation must be 0-2000 characters"
 )
 
 type DataValidationErrorStyle int

--- a/vendor/github.com/rentiansheng/xlsx/datavalidation.go
+++ b/vendor/github.com/rentiansheng/xlsx/datavalidation.go
@@ -22,7 +22,7 @@ const (
 )
 
 const (
-	// dataValidationFormulaStrLen 255 characters+ 2 quotes
+	// dataValidationFormulaStrLen 2000 characters
 	dataValidationFormulaStrLen = 2000
 	// dataValidationFormulaStrLenErr
 	dataValidationFormulaStrLenErr = "data validation must be 0-2000 characters"


### PR DESCRIPTION
### 修复的问题：
- 下载批量导入模板时，枚举值过多，无法显示枚举值。修改限制枚举值的长度。
