### PR TITLE
修复使用主机/服务实例数量统计接口引起的topo创建问题

### DIFF
--- a/src/common/metadata/association.go
+++ b/src/common/metadata/association.go
@@ -405,8 +405,6 @@ type TopoInst struct {
 	ObjID                string `json:"bk_obj_id"`
 	ObjName              string `json:"bk_obj_name"`
 	Default              int    `json:"default"`
-	HostCount            int64  `json:"host_count"`
-	ServiceInstanceCount int64  `json:"service_instance_count,omitempty"`
 	ServiceTemplateID    int64  `json:"service_template_id,omitempty"`
 	SetTemplateID        int64  `json:"set_template_id,omitempty"`
 	HostApplyEnabled     *bool  `json:"host_apply_enabled,omitempty"`

--- a/src/scene_server/topo_server/core/operation/association_mainline_inst.go
+++ b/src/scene_server/topo_server/core/operation/association_mainline_inst.go
@@ -874,63 +874,8 @@ func (assoc *association) getSetRelationModule(kit *rest.Kit, setIDs []int64) (m
 	return setRelModuleMap, nil
 }
 
-func (assoc *association) fillStatistics(kit *rest.Kit, bizID int64, moduleIDs []int64, topoInsts []*metadata.TopoInstRst) errors.CCError {
-	// get service instance count
-	option := &metadata.ListServiceInstanceOption{
-		BusinessID: bizID,
-		Page: metadata.BasePage{
-			Limit: common.BKNoLimit,
-		},
-	}
-	serviceInstances, err := assoc.clientSet.CoreService().Process().ListServiceInstance(kit.Ctx, kit.Header, option)
-	if err != nil {
-		blog.Errorf("fillStatistics failed, list service instances failed, option: %+v, err: %s, rid: %s", option, err.Error(), kit.Rid)
-		return err
-	}
-	moduleServiceInstanceCount := make(map[int64]int64)
-	for _, serviceInstance := range serviceInstances.Info {
-		moduleServiceInstanceCount[serviceInstance.ModuleID]++
-	}
-
-	// get host count
-	listHostOption := &metadata.HostModuleRelationRequest{
-		ApplicationID: bizID,
-		Fields:        []string{common.BKAppIDField, common.BKSetIDField, common.BKModuleIDField, common.BKHostIDField},
-	}
-	hostModules, e := assoc.clientSet.CoreService().Host().GetHostModuleRelation(kit.Ctx, kit.Header, listHostOption)
-	if e != nil {
-		blog.Errorf("fillStatistics failed, list host modules failed, option: %+v, err: %s, rid: %s", listHostOption, e.Error(), kit.Rid)
-		return e
-	}
-	// topoObjectID -> topoInstanceID -> []hostIDs
-	customLevel := "custom_level"
-	hostCount := make(map[string]map[int64][]int64)
-	hostCount[common.BKInnerObjIDApp] = make(map[int64][]int64)
-	hostCount[common.BKInnerObjIDSet] = make(map[int64][]int64)
-	hostCount[common.BKInnerObjIDModule] = make(map[int64][]int64)
-	hostCount[customLevel] = make(map[int64][]int64)
-	for _, hostModule := range hostModules.Data.Info {
-		if _, exist := hostCount[common.BKInnerObjIDModule][hostModule.ModuleID]; exist == false {
-			hostCount[common.BKInnerObjIDModule][hostModule.ModuleID] = make([]int64, 0)
-		}
-		hostCount[common.BKInnerObjIDModule][hostModule.ModuleID] = append(hostCount[common.BKInnerObjIDModule][hostModule.ModuleID], hostModule.HostID)
-
-		if _, exist := hostCount[common.BKInnerObjIDSet][hostModule.SetID]; exist == false {
-			hostCount[common.BKInnerObjIDSet][hostModule.SetID] = make([]int64, 0)
-		}
-		hostCount[common.BKInnerObjIDSet][hostModule.SetID] = append(hostCount[common.BKInnerObjIDSet][hostModule.SetID], hostModule.HostID)
-
-		if _, exist := hostCount[common.BKInnerObjIDApp][hostModule.AppID]; exist == false {
-			hostCount[common.BKInnerObjIDApp][hostModule.AppID] = make([]int64, 0)
-		}
-		hostCount[common.BKInnerObjIDApp][hostModule.AppID] = append(hostCount[common.BKInnerObjIDApp][hostModule.AppID], hostModule.HostID)
-	}
-	for _, objectID := range []string{common.BKInnerObjIDApp, common.BKInnerObjIDSet, common.BKInnerObjIDModule} {
-		for key := range hostCount[objectID] {
-			hostCount[objectID][key] = util.IntArrayUnique(hostCount[objectID][key])
-		}
-	}
-
+func (assoc *association) fillStatistics(kit *rest.Kit, bizID int64, moduleIDs []int64,
+	topoInsts []*metadata.TopoInstRst) errors.CCError {
 	// get host apply rule count
 	listApplyRuleOption := metadata.ListHostApplyRuleOption{
 		ModuleIDs: moduleIDs,
@@ -938,9 +883,11 @@ func (assoc *association) fillStatistics(kit *rest.Kit, bizID int64, moduleIDs [
 			Limit: common.BKNoLimit,
 		},
 	}
-	hostApplyRules, err := assoc.clientSet.CoreService().HostApplyRule().ListHostApplyRule(kit.Ctx, kit.Header, bizID, listApplyRuleOption)
+	hostApplyRules, err := assoc.clientSet.CoreService().HostApplyRule().ListHostApplyRule(kit.Ctx, kit.Header,
+		bizID, listApplyRuleOption)
 	if err != nil {
-		blog.ErrorJSON("fillStatistics failed, ListHostApplyRule failed, bizID: %s, option: %s, err: %s, rid: %s", bizID, listApplyRuleOption, err, kit.Rid)
+		blog.Errorf("fillStatistics failed, list host apply rule failed, bizID: %s, option: %s, err: %s, rid: %s",
+			bizID, listApplyRuleOption, err, kit.Rid)
 		return err
 	}
 	moduleRuleCount := make(map[int64]int64)
@@ -948,51 +895,17 @@ func (assoc *association) fillStatistics(kit *rest.Kit, bizID int64, moduleIDs [
 		moduleRuleCount[item.ModuleID]++
 	}
 
-	exactNodes := []string{common.BKInnerObjIDApp, common.BKInnerObjIDSet, common.BKInnerObjIDModule}
 	// fill hosts
 	for _, tir := range topoInsts {
 		tir.DeepFirstTraverse(func(node *metadata.TopoInstRst) {
-			// calculate service instance count
-			subTreeSvcInstCount := int64(0)
-			for _, child := range node.Child {
-				subTreeSvcInstCount += child.ServiceInstanceCount
-			}
-			node.ServiceInstanceCount = subTreeSvcInstCount
 			if node.ObjID == common.BKInnerObjIDModule {
-				if _, exist := moduleServiceInstanceCount[node.InstID]; exist == true {
-					node.ServiceInstanceCount = moduleServiceInstanceCount[node.InstID]
-				}
 				node.HostApplyRuleCount = new(int64)
 				*node.HostApplyRuleCount, _ = moduleRuleCount[node.InstID]
 			}
 
-			if util.InStrArr(exactNodes, node.ObjID) {
-				if _, exist := hostCount[node.ObjID][node.InstID]; exist == true {
-					node.HostCount = int64(len(hostCount[node.ObjID][node.InstID]))
-				}
-				return
-			}
 			if len(node.Child) == 0 {
 				return
 			}
-
-			// calculate host count
-			subTreeHosts := make([]int64, 0)
-			for _, child := range node.Child {
-				childHosts := make([]int64, 0)
-				if util.InStrArr(exactNodes, child.ObjID) {
-					if _, exist := hostCount[child.ObjID][child.InstID]; exist == true {
-						childHosts = hostCount[child.ObjID][child.InstID]
-					}
-				} else {
-					if _, exist := hostCount[customLevel][child.InstID]; exist == true {
-						childHosts = hostCount[customLevel][child.InstID]
-					}
-				}
-				subTreeHosts = append(subTreeHosts, childHosts...)
-			}
-			hostCount[customLevel][node.InstID] = util.IntArrayUnique(subTreeHosts)
-			node.HostCount = int64(len(hostCount[customLevel][node.InstID]))
 		})
 	}
 	return nil

--- a/src/scene_server/topo_server/service/association.go
+++ b/src/scene_server/topo_server/service/association.go
@@ -123,7 +123,7 @@ func (s *Service) SearchObjectByClassificationID(ctx *rest.Contexts) {
 
 // SearchBusinessTopoWithStatistics calculate how many service instances on each topo instance node
 func (s *Service) SearchBusinessTopoWithStatistics(ctx *rest.Contexts) {
-	resp, err := s.searchBusinessTopo(ctx, false, true)
+	resp, err := s.searchBusinessTopo(ctx, true, true)
 	if nil != err {
 		ctx.RespAutoError(err)
 		return

--- a/src/scene_server/topo_server/service/inst_business.go
+++ b/src/scene_server/topo_server/service/inst_business.go
@@ -605,7 +605,7 @@ func (s *Service) GetInternalModuleWithStatistics(ctx *rest.Contexts) {
 		return
 	}
 	if innerAppTopo == nil {
-		blog.ErrorJSON("GetInternalModuleWithStatistics failed, GetInternalModule return unexpected type: %s, rid: %s", innerAppTopo, ctx.Kit.Rid)
+		blog.ErrorJSON("get internal module with statistics failed, type: %s, rid: %s", innerAppTopo, ctx.Kit.Rid)
 		ctx.RespAutoError(err)
 		return
 	}
@@ -621,9 +621,11 @@ func (s *Service) GetInternalModuleWithStatistics(ctx *rest.Contexts) {
 			Limit: common.BKNoLimit,
 		},
 	}
-	hostApplyRules, err := s.Engine.CoreAPI.CoreService().HostApplyRule().ListHostApplyRule(ctx.Kit.Ctx, ctx.Kit.Header, bizID, listApplyRuleOption)
+	hostApplyRules, err := s.Engine.CoreAPI.CoreService().HostApplyRule().ListHostApplyRule(ctx.Kit.Ctx,
+		ctx.Kit.Header, bizID, listApplyRuleOption)
 	if err != nil {
-		blog.Errorf("fillStatistics failed, ListHostApplyRule failed, bizID: %d, option: %+v, err: %+v, rid: %s", bizID, listApplyRuleOption, err, ctx.Kit.Rid)
+		blog.Errorf("fillStatistics failed, ListHostApplyRule failed, bizID: %d, option: %+v, err: %+v, rid: %s",
+			bizID, listApplyRuleOption, err, ctx.Kit.Rid)
 		ctx.RespAutoError(err)
 		return
 	}
@@ -635,40 +637,10 @@ func (s *Service) GetInternalModuleWithStatistics(ctx *rest.Contexts) {
 		moduleRuleCount[item.ModuleID] += 1
 	}
 
-	// count hosts
-	listHostOption := &metadata.HostModuleRelationRequest{
-		ApplicationID: bizID,
-		SetIDArr:      []int64{innerAppTopo.SetID},
-		ModuleIDArr:   moduleIDArr,
-		Page: metadata.BasePage{
-			Limit: common.BKNoLimit,
-		},
-		Fields: []string{common.BKModuleIDField, common.BKHostIDField},
-	}
-	hostModuleRelations, e := s.Engine.CoreAPI.CoreService().Host().GetHostModuleRelation(ctx.Kit.Ctx, ctx.Kit.Header, listHostOption)
-	if e != nil {
-		blog.Errorf("GetInternalModuleWithStatistics failed, list host modules failed, option: %+v, err: %s, rid: %s", listHostOption, e.Error(), ctx.Kit.Rid)
-		ctx.RespAutoError(e)
-		return
-	}
-	setHostIDs := make([]int64, 0)
-	moduleHostIDs := make(map[int64][]int64, 0)
-	for _, relation := range hostModuleRelations.Data.Info {
-		setHostIDs = append(setHostIDs, relation.HostID)
-		if _, ok := moduleHostIDs[relation.ModuleID]; ok == false {
-			moduleHostIDs[relation.ModuleID] = make([]int64, 0)
-		}
-		moduleHostIDs[relation.ModuleID] = append(moduleHostIDs[relation.ModuleID], relation.HostID)
-	}
 	set := mapstr.NewFromStruct(innerAppTopo, "field")
-	set["host_count"] = len(util.IntArrayUnique(setHostIDs))
 	modules := make([]mapstr.MapStr, 0)
 	for _, module := range innerAppTopo.Module {
 		moduleItem := mapstr.NewFromStruct(module, "field")
-		moduleItem["host_count"] = 0
-		if hostIDs, ok := moduleHostIDs[module.ModuleID]; ok == true {
-			moduleItem["host_count"] = len(util.IntArrayUnique(hostIDs))
-		}
 		moduleItem["host_apply_rule_count"] = 0
 		if ruleCount, ok := moduleRuleCount[module.ModuleID]; ok == true {
 			moduleItem["host_apply_rule_count"] = ruleCount


### PR DESCRIPTION
### 修复的问题：
- 修复使用主机/服务实例数量统计接口引起的topo创建问题。
