### PR TITLE
fix:大量ip链接起来的长度大于1024的场景下只取前256长度，防止由于mongo index长度限制写入失败

### DIFF
--- a/src/source_controller/coreservice/core/auditlog/audit.go
+++ b/src/source_controller/coreservice/core/auditlog/audit.go
@@ -54,6 +54,11 @@ func (m *auditManager) CreateAuditLog(kit *rest.Kit, logs ...metadata.AuditLog) 
 		if log.OperateFrom == "" {
 			log.OperateFrom = metadata.FromUser
 		}
+		// ResourceName is assigned mongo index ,length must be less than  1024,so resourceName only save
+		// NameFieldMaxLength.
+		if len(log.ResourceName) > common.NameFieldMaxLength {
+			log.ResourceName = log.ResourceName[:common.NameFieldMaxLength]
+		}
 		log.SupplierAccount = kit.SupplierAccount
 		log.User = kit.User
 		if appCode := kit.Header.Get(common.BKHTTPRequestAppCode); len(appCode) > 0 {

--- a/src/source_controller/coreservice/core/auditlog/audit.go
+++ b/src/source_controller/coreservice/core/auditlog/audit.go
@@ -54,8 +54,7 @@ func (m *auditManager) CreateAuditLog(kit *rest.Kit, logs ...metadata.AuditLog) 
 		if log.OperateFrom == "" {
 			log.OperateFrom = metadata.FromUser
 		}
-		// ResourceName is assigned mongo index ,length must be less than  1024,so resourceName only save
-		// NameFieldMaxLength.
+		// ResourceName is assigned index, length must be less than 1024, so resourceName only save NameFieldMaxLength.
 		if len(log.ResourceName) > common.NameFieldMaxLength {
 			log.ResourceName = log.ResourceName[:common.NameFieldMaxLength]
 		}


### PR DESCRIPTION

### 修复的问题：
- 大量ip链接起来的长度大于1024的场景下只取前256长度，防止由于mongo index长度限制写入失败
