### PR TITLE
新增清理审计日志接口

### DIFF
--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -38,6 +38,12 @@ const (
 	// max limit of a page
 	BKMaxPageSize = 1000
 
+	// BKMaxDelPageSize max limit of delete operation
+	BKMaxDelBatchLimit = 200
+
+	// BKMaxDelDocPageLimit maximum number of documents deleted consecutively quantity
+	BKMaxDelDocPageLimit = 10000
+
 	// max limit of instance count
 	BKMaxInstanceLimit = 500
 
@@ -73,7 +79,6 @@ const (
 
 	// BKTopoBusinessLevelDefault the mainline topo level default level
 	BKTopoBusinessLevelDefault = 7
-
 )
 
 const (
@@ -266,6 +271,9 @@ const (
 
 	// TimeTransferModel the time transferModel field
 	TimeTransferModel = "2006-01-02 15:04:05"
+
+	// TimeDayTransferModel the time transferModel field
+	TimeDayTransferModel = "2006-01-02"
 
 	// BKCloudTaskID the cloud sync task id
 	BKCloudTaskID = "bk_task_id"

--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -38,12 +38,6 @@ const (
 	// max limit of a page
 	BKMaxPageSize = 1000
 
-	// BKMaxDelPageSize max limit of delete operation
-	BKMaxDelBatchLimit = 200
-
-	// BKMaxDelDocPageLimit maximum number of documents deleted consecutively quantity
-	BKMaxDelDocPageLimit = 10000
-
 	// max limit of instance count
 	BKMaxInstanceLimit = 500
 

--- a/src/common/util/time.go
+++ b/src/common/util/time.go
@@ -37,6 +37,12 @@ func GetCurrentTimePtr() *time.Time {
 	return &now
 }
 
+// TimeStrToUnixSecondDefault convert timeStr to timestamp
+func TimeStrToUnixSecondDefault(str string) int64 {
+	parseTime, _ := time.ParseInLocation(common.TimeDayTransferModel, str, time.Local)
+	return parseTime.Unix()
+}
+
 func ConvParamsTime(data interface{}) interface{} {
 	conds, ok := data.(map[string]interface{})
 	if true != ok && nil != conds {

--- a/src/scene_server/admin_server/service/database.go
+++ b/src/scene_server/admin_server/service/database.go
@@ -31,14 +31,14 @@ type metaId struct {
 }
 
 const (
-	// BKMaxDelPageSize max limit of delete operation
+	// BKMaxDelPageSize max limit of delete operation.
 	maxDelBatchLimit = 200
-	// BKMaxDelDocPageLimit maximum number of documents deleted consecutively quantity
+	// BKMaxDelDocPageLimit maximum number of documents deleted consecutively quantity.
 	maxDelDocPageLimit = 10000
 )
 
 type deleteAuditLogReq struct {
-	// delete logs before this day
+	// delete logs before this day,the date format like '2021-08-19'.
 	BeforeDay string `json:"beforeDay"`
 }
 type deleteAuditLogRsp struct {
@@ -70,14 +70,14 @@ func (s *Service) getMinObjIDAndMinDay(baseDay int64, rid string) (primitive.Obj
 			break
 		}
 	}
-	blog.V(5).Infof("getMinObjIDAndMinDay,the min day is: %s,rid: %s", baseDay, rid)
+	blog.Infof("getMinObjIDAndMinDay,the min day is: %s,rid: %s", baseDay, rid)
 
 	return objId, baseDay, nil
 }
 
 // DeleteAuditLog delete user specified audit logs.
 // 删除策略: 1、首先找到最早一天的审计日志，从前向后一天一天的删除审计日志。
-//          2、每次批量删除200条日志。为了防止删除导致的cpu和磁盘io过高，每删除10000条日志需要sleep 5秒钟
+//          2、每次批量删除200条日志。为了防止删除导致的cpu和磁盘io过高，每删除10000条日志需要sleep 5秒钟。
 func (s *Service) DeleteAuditLog(req *restful.Request, resp *restful.Response) {
 
 	rHeader := req.Request.Header
@@ -92,7 +92,7 @@ func (s *Service) DeleteAuditLog(req *restful.Request, resp *restful.Response) {
 		_ = resp.WriteError(http.StatusBadRequest, &errInfo)
 		return
 	}
-	blog.V(5).Infof("deleteAuditLog,the user specified date is: %s,rid: %s", param.BeforeDay, rid)
+	blog.Infof("deleteAuditLog,the user specified date is: %s,rid: %s", param.BeforeDay, rid)
 
 	// convert string format to timestamp.
 	baseDay := util.TimeStrToUnixSecondDefault(param.BeforeDay)
@@ -155,11 +155,11 @@ func (s *Service) DeleteAuditLog(req *restful.Request, resp *restful.Response) {
 			t := time.Unix(minDay, 0)
 			dateStr := t.Format("2006-01-02")
 
-			blog.V(9).Infof("the delete date is: %s,the number of deleted items is: %d,rid: %s",
+			blog.Infof("the delete date is: %s,the number of deleted items is: %d,rid: %s",
 				dateStr, total, rid)
 		}
 	}
-	blog.V(5).Infof(" delete all completed audit logs,the num: %d,rid: %s", total, rid)
+	blog.Infof(" delete all completed audit logs,the num: %d,rid: %s", total, rid)
 
 	response.Num = total
 	_ = resp.WriteEntity(metadata.NewSuccessResp(response))

--- a/src/scene_server/admin_server/service/database.go
+++ b/src/scene_server/admin_server/service/database.go
@@ -1,0 +1,151 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"configcenter/src/common"
+	"configcenter/src/common/blog"
+	"configcenter/src/common/metadata"
+	"configcenter/src/common/util"
+
+	"github.com/emicklei/go-restful"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type metaId struct {
+	MongoID primitive.ObjectID `bson:"_id"`
+}
+
+// eg: "2021-08-18"
+type deleteAuditLogReq struct {
+	Day string `json:"day"`
+}
+type deleteAuditLogRsp struct {
+	Num int `json:"num"`
+}
+
+// getMinObjIDAndMinDay 获取需要删除的最小日期和对应生成的objId
+func (s *Service) getMinObjIDAndMinDay(baseDay int64) (primitive.ObjectID, int64, error) {
+
+	// 根据指定删除的时间点(注意时间点是当天的0点，例如如果指定的是2021-08-19，指的是8月19日的0点)生成 objectId. 后续流程会将小于此
+	// 时间戳的数据全部删掉.
+	objId := primitive.NewObjectIDFromTimestamp(time.Unix(baseDay, 0))
+
+	for {
+		cond := map[string]interface{}{
+			"_id": map[string]interface{}{
+				common.BKDBLT: objId,
+			},
+		}
+		count, err := s.db.Table(common.BKTableNameAuditLog).Find(cond).Count(s.ctx)
+		if err != nil {
+			return primitive.ObjectID{}, 0, err
+		}
+		if count > 0 {
+			baseDay -= 24 * 60 * 60
+			dayAgo := time.Unix(baseDay, 0)
+			objId = primitive.NewObjectIDFromTimestamp(dayAgo)
+		} else {
+			break
+		}
+	}
+
+	return objId, baseDay, nil
+}
+
+// DeleteAuditLog delete user specified audit logs.
+func (s *Service) DeleteAuditLog(req *restful.Request, resp *restful.Response) {
+
+	rHeader := req.Request.Header
+	rid := util.GetHTTPCCRequestID(rHeader)
+	defErr := s.CCErr.CreateDefaultCCErrorIf(util.GetLanguage(rHeader))
+	param := new(deleteAuditLogReq)
+	response := new(deleteAuditLogRsp)
+
+	if err := json.NewDecoder(req.Request.Body).Decode(&param); err != nil {
+		blog.Errorf("deleteAuditLog, decode body failed, err: %+v,rid: %s", err, rid)
+		errInfo := metadata.RespError{
+			Msg: defErr.CCError(common.CCErrCommJSONUnmarshalFailed),
+		}
+		_ = resp.WriteError(http.StatusBadRequest, &errInfo)
+		return
+	}
+
+	// convert string format to timestamp.
+	baseDay := util.TimeStrToUnixSecondDefault(param.Day)
+	objId, minDay, err := s.getMinObjIDAndMinDay(baseDay)
+	if err != nil {
+		blog.Errorf("get the earliest date to delete failed, err: %+v, rid: %s", err, rid)
+		_ = resp.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+	var cnt, total int
+
+	for {
+		// delete the data before the time point specified by the user.
+		if minDay > baseDay {
+			break
+		}
+		cond := map[string]interface{}{
+			"_id": map[string]interface{}{
+				common.BKDBLT: objId,
+			},
+		}
+		metaIdList := make([]metaId, 0)
+
+		// find docs for the specified date.
+		err := s.db.Table(common.BKTableNameAuditLog).Find(cond).Fields("_id").
+			Limit(uint64(common.BKMaxDelBatchLimit)).All(s.ctx, &metaIdList)
+		if err != nil {
+			blog.Errorf("search auditLog failed, err: %+v, rid: %s", err, rid)
+			_ = resp.WriteError(http.StatusInternalServerError, err)
+			return
+		}
+		// the document of the specified date has been deleted，Find the content of the next day.
+		if len(metaIdList) <= 0 {
+			// convert time from day to seconds.
+			minDay += 24 * 60 * 60
+			dayAgo := time.Unix(minDay, 0)
+			objId = primitive.NewObjectIDFromTimestamp(dayAgo)
+			continue
+		}
+
+		mongoIDs := make([]primitive.ObjectID, len(metaIdList))
+		for index, data := range metaIdList {
+			mongoIDs[index] = data.MongoID
+		}
+		delCond := map[string]interface{}{"_id": map[string]interface{}{common.BKDBIN: mongoIDs}}
+
+		if err := s.db.Table(common.BKTableNameAuditLog).Delete(s.ctx, delCond); err != nil {
+			blog.Errorf("search auditLog failed, objIds: %v,err: %+v, rid: %s", mongoIDs, err, rid)
+			errInfo := metadata.RespError{Msg: err}
+			_ = resp.WriteError(http.StatusBadRequest, &errInfo)
+			return
+		}
+
+		cnt += len(metaIdList)
+		total += len(metaIdList)
+		if cnt >= common.BKMaxDelDocPageLimit {
+			time.Sleep(5 * time.Second)
+			cnt = 0
+		}
+	}
+
+	response.Num = total
+	_ = resp.WriteEntity(metadata.NewSuccessResp(response))
+	return
+}

--- a/src/scene_server/admin_server/service/service.go
+++ b/src/scene_server/admin_server/service/service.go
@@ -86,6 +86,7 @@ func (s *Service) WebService() *restful.Container {
 	api.Route(api.POST("/migrate/specify/version/{distribution}/{ownerID}").To(s.migrateSpecifyVersion))
 	api.Route(api.POST("/migrate/config/refresh").To(s.refreshConfig))
 	api.Route(api.POST("/migrate/dataid").To(s.migrateDataID))
+	api.Route(api.POST("/delete/auditlog").To(s.DeleteAuditLog))
 
 	container.Add(api)
 


### PR DESCRIPTION
### 新加的功能:
- adminserver 新增清理审计日志接口，用户输入"2021-08-19"指定清理日期之后，会将此日期之前的日志清理掉。#5603
- 示例如下:
`curl -d '{"day":"2021-08-19"}' -X POST -H 'Content-Type:application/json' -H 'BK_USER:migrate' -H 'HTTP_BLUEKING_SUPPLIER_ID:0' http://127.0.01:60002/migrate/v3/delete/auditlog`
注意:
1、此操作属于高危操作，在清理日志之前需要确定清理的可行性，如果需要必须事先备份好审计日志，防止误操作之后日志丢失。
2、删除操作属于cpu和磁盘io密集型操作，为了防止此操作造成cpu或者磁盘io过高，实现上做了处理，根据测试如果删除100万数据，需要的时间大概10分钟。
3、建议此操作在业务低峰期进行操作。并且日志量过大，分时间段进行操作。您想删除半年之前数据，可以分别指定删除3年前数据、2年前数据、1年前数据、半年前数据。