### PR TITLE
fix:  The process number in start.sh

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-proc_num=12
+# Get the number of directories starting with "cmdb_" in the current directory
+proc_num=`ls -l | grep "^d" | grep cmdb_ | grep -v cmdb_synchronizeserver | wc -l`
 withSynchronizeServer=false 
 
 


### PR DESCRIPTION
### 新加的功能:
- 无
### 优化的功能:
- 无
### 修复的问题：

- 部署启动时 ，展示的的进程数不是12，目前不包括cmdb_synchronizeserver是14，如下图：

![image](https://user-images.githubusercontent.com/2959046/132280367-71b4cbc5-87c4-4a80-8aa0-4e896cca484f.png)

已修复为，动态获取当前目录下的不包含cmdb_synchronizeserver，以cmdb_开头的目录数量

验证如下：
![image](https://user-images.githubusercontent.com/2959046/132280438-222cd95d-d6d0-4124-b2ed-49c0bb6d953c.png)
