### PR TITLE
动态分组，组织字段值支持string和int

### DIFF
--- a/src/common/metadata/dynamic_grouping.go
+++ b/src/common/metadata/dynamic_grouping.go
@@ -146,10 +146,8 @@ func (c *DynamicGroupCondition) Validate(attributeMap map[string]string) error {
 func validAttributeValueType(attrType string, value interface{}) error {
 	switch attrType {
 	case stringType:
-		switch value.(type) {
-		case string, int:
-		default:
-			return fmt.Errorf("attribute only support string value, and int value, %+v", value)
+		if _, ok := value.(string); !ok {
+			return fmt.Errorf("attribute only support string value, not support value, %+v", value)
 		}
 	case numericType:
 		if !util.IsNumeric(value) {
@@ -173,9 +171,9 @@ const (
 func getAttributeType(attributeType string) (string, error) {
 	switch attributeType {
 	case common.FieldTypeSingleChar, common.FieldTypeLongChar, common.FieldTypeEnum, common.FieldTypeDate, common.FieldTypeTime,
-		common.FieldTypeTimeZone, common.FieldTypeUser, common.FieldTypeList, common.FieldTypeOrganization:
+		common.FieldTypeTimeZone, common.FieldTypeUser, common.FieldTypeList:
 		return stringType, nil
-	case common.FieldTypeInt, common.FieldTypeFloat:
+	case common.FieldTypeInt, common.FieldTypeFloat, common.FieldTypeOrganization:
 		return numericType, nil
 	case common.FieldTypeBool:
 		return boolType, nil

--- a/src/common/metadata/dynamic_grouping.go
+++ b/src/common/metadata/dynamic_grouping.go
@@ -146,8 +146,10 @@ func (c *DynamicGroupCondition) Validate(attributeMap map[string]string) error {
 func validAttributeValueType(attrType string, value interface{}) error {
 	switch attrType {
 	case stringType:
-		if _, ok := value.(string); !ok {
-			return fmt.Errorf("attribute only support string value, not support value, %+v", value)
+		switch value.(type) {
+		case string, int:
+		default:
+			return fmt.Errorf("attribute only support string value, and value, %+v", value)
 		}
 	case numericType:
 		if !util.IsNumeric(value) {

--- a/src/common/metadata/dynamic_grouping.go
+++ b/src/common/metadata/dynamic_grouping.go
@@ -149,7 +149,7 @@ func validAttributeValueType(attrType string, value interface{}) error {
 		switch value.(type) {
 		case string, int:
 		default:
-			return fmt.Errorf("attribute only support string value, and value, %+v", value)
+			return fmt.Errorf("attribute only support string value, and int value, %+v", value)
 		}
 	case numericType:
 		if !util.IsNumeric(value) {


### PR DESCRIPTION
### 修复的问题：
- 动态分组选择组织字段时，attrType类型为string时，如果传递int array则不支持。修改后兼容int array和string array
