### PR TITLE
将组织字段类型调整为numeric type

### DIFF
--- a/src/common/metadata/dynamic_grouping.go
+++ b/src/common/metadata/dynamic_grouping.go
@@ -171,9 +171,9 @@ const (
 func getAttributeType(attributeType string) (string, error) {
 	switch attributeType {
 	case common.FieldTypeSingleChar, common.FieldTypeLongChar, common.FieldTypeEnum, common.FieldTypeDate, common.FieldTypeTime,
-		common.FieldTypeTimeZone, common.FieldTypeUser, common.FieldTypeList, common.FieldTypeOrganization:
+		common.FieldTypeTimeZone, common.FieldTypeUser, common.FieldTypeList:
 		return stringType, nil
-	case common.FieldTypeInt, common.FieldTypeFloat:
+	case common.FieldTypeInt, common.FieldTypeFloat, common.FieldTypeOrganization:
 		return numericType, nil
 	case common.FieldTypeBool:
 		return boolType, nil


### PR DESCRIPTION
### 修复的问题：
- 处理动态分组，字段类型为组织时，attrType为organization， value值当成numeric进行校验
