### PR TITLE
主机身份事件监听在watch token里添加id和cursor信息，防止用户用过期的最后一个cursor请求时报错

### DIFF
--- a/src/source_controller/cacheservice/event/identifier/handler.go
+++ b/src/source_controller/cacheservice/event/identifier/handler.go
@@ -59,6 +59,16 @@ func (f *identityHandler) setLastWatchToken(ctx context.Context, data map[string
 	tokenInfo := mapstr.MapStr{
 		f.key.Collection(): data,
 	}
+
+	// update id and cursor field if set, to compensate for the scenario of searching with an outdated but latest cursor
+	if id, exists := data[common.BKFieldID]; exists {
+		tokenInfo[common.BKFieldID] = id
+	}
+
+	if cursor, exists := data[common.BKCursorField]; exists {
+		tokenInfo[common.BKCursorField] = cursor
+	}
+
 	if err := f.watchDB.Table(common.BKTableNameWatchToken).Update(ctx, filter, tokenInfo); err != nil {
 		blog.Errorf("set host identity %s last watch token failed, err: %v, data: %+v", f.key.Collection(),
 			err, tokenInfo)


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
