### PR TITLE
调整mongodb的连接池连接空闲超时时间为25分钟

### DIFF
--- a/src/storage/dal/mongo/local/mongo.go
+++ b/src/storage/dal/mongo/local/mongo.go
@@ -66,16 +66,20 @@ func NewMgo(config MongoConf, timeout time.Duration) (*Mongo, error) {
 		return nil, fmt.Errorf("mongodb rsName not set")
 	}
 	socketTimeout := time.Second * time.Duration(config.SocketTimeout)
+	maxConnIdleTime := 25 * time.Minute
+	appName := common.GetIdentification()
 	// do not change this, our transaction plan need it to false.
 	// it's related with the transaction number(eg txnNumber) in a transaction session.
 	disableWriteRetry := false
 	conOpt := options.ClientOptions{
-		MaxPoolSize:    &config.MaxOpenConns,
-		MinPoolSize:    &config.MaxIdleConns,
-		ConnectTimeout: &timeout,
-		SocketTimeout:  &socketTimeout,
-		ReplicaSet:     &config.RsName,
-		RetryWrites:    &disableWriteRetry,
+		MaxPoolSize:     &config.MaxOpenConns,
+		MinPoolSize:     &config.MaxIdleConns,
+		ConnectTimeout:  &timeout,
+		SocketTimeout:   &socketTimeout,
+		ReplicaSet:      &config.RsName,
+		RetryWrites:     &disableWriteRetry,
+		MaxConnIdleTime: &maxConnIdleTime,
+		AppName:         &appName,
 	}
 
 	client, err := mongo.NewClient(options.Client().ApplyURI(config.URI), &conOpt)


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
