### PR TITLE
当云资源权限为空的时候不能返回错误而是应该返回空

### DIFF
--- a/src/scene_server/cloud_server/logics/synctask.go
+++ b/src/scene_server/cloud_server/logics/synctask.go
@@ -13,7 +13,6 @@
 package logics
 
 import (
-	"errors"
 	"fmt"
 
 	"configcenter/src/ac/meta"
@@ -171,8 +170,7 @@ func (lgc *Logics) SearchSyncTask(kit *rest.Kit, option *metadata.SearchSyncTask
 		if !isAny {
 
 			if len(list) == 0 {
-				blog.Errorf("get authIds failed, rid: %s, option:%+v", kit.Rid, option)
-				return nil, errors.New("get authIds failed")
+				return &metadata.MultipleCloudSyncTask{}, nil
 			}
 
 			if len(option.Condition) == 0 {


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
