### PR TITLE
bugfix 添加判断防止导入关联关系时获取对应单元格数据数组越界

### DIFF
--- a/src/web_server/logics/excel.go
+++ b/src/web_server/logics/excel.go
@@ -451,14 +451,21 @@ func GetRawExcelData(ctx context.Context, sheet *xlsx.Sheet, defFields common.Kv
 
 }
 
+// GetAssociationExcelData read sheet of association data from excel
 func GetAssociationExcelData(sheet *xlsx.Sheet, firstRow int) map[int]metadata.ExcelAssociation {
 
 	rowCnt := len(sheet.Rows)
 	index := firstRow
 
-	asstInfoArr := make(map[int]metadata.ExcelAssociation, 0)
+	asstInfoArr := make(map[int]metadata.ExcelAssociation)
 	for ; index < rowCnt; index++ {
 		row := sheet.Rows[index]
+
+		// 防止数组越界
+		if len(row.Cells) <= assciationDstInstIndex {
+			continue
+		}
+
 		op := row.Cells[associationOPColIndex].String()
 		if op == "" {
 			continue

--- a/src/web_server/logics/excel_util.go
+++ b/src/web_server/logics/excel_util.go
@@ -505,7 +505,8 @@ func handleFields(handleFieldParam HandleFieldParam) {
 }
 
 // ProductExcelHeader Excel文件头部，
-func productExcelAssociationHeader(ctx context.Context, sheet *xlsx.Sheet, defLang lang.DefaultCCLanguageIf, instNum int, asstList []*metadata.Association) {
+func productExcelAssociationHeader(ctx context.Context, sheet *xlsx.Sheet, defLang lang.DefaultCCLanguageIf,
+	instNum int, asstList []*metadata.Association) {
 	rid := util.ExtractRequestIDFromContext(ctx)
 
 	//第一列(指标说明，橙色)

--- a/src/web_server/logics/host.go
+++ b/src/web_server/logics/host.go
@@ -172,114 +172,84 @@ func (lgc *Logics) ImportHosts(ctx context.Context, f *xlsx.File, header http.He
 
 	rid := util.ExtractRequestIDFromContext(ctx)
 	defErr := lgc.CCErr.CreateDefaultCCErrorIf(util.GetLanguage(header))
+	resp := &metadata.ResponseDataMapStr{Data: mapstr.New()}
 
 	hosts, errMsg, err := lgc.GetImportHosts(f, header, defLang, modelBizID)
-	if nil != err {
-		blog.Errorf("ImportHosts failed, GetImportHosts error:%s, rid: %s", err.Error(), rid)
-		return &metadata.ResponseDataMapStr{
-			BaseResp: metadata.BaseResp{
-				Result: false,
-				Code:   common.CCErrWebFileContentFail,
-				ErrMsg: defErr.Errorf(common.CCErrWebFileContentFail, err.Error()).Error(),
-			},
-			Data: nil,
-		}
+	if err != nil {
+		blog.Errorf("get import hosts failed, err: %v, rid: %s", err, rid)
+		resp.Code = common.CCErrWebFileContentFail
+		resp.ErrMsg = defErr.Errorf(common.CCErrWebFileContentFail, err.Error()).Error()
+		return resp
 	}
 	if len(errMsg) > 0 {
-		return &metadata.ResponseDataMapStr{
-			BaseResp: metadata.BaseResp{
-				Result: false,
-				Code:   common.CCErrWebFileContentFail,
-				ErrMsg: defErr.Errorf(common.CCErrWebFileContentFail, "").Error(),
-			},
-			Data: map[string]interface{}{
-				"error": errMsg,
-			},
-		}
+		resp.Code = common.CCErrWebFileContentFail
+		resp.ErrMsg = defErr.Errorf(common.CCErrWebFileContentFail, "").Error()
+		resp.Data.Set("error", errMsg)
+		return resp
 	}
 
 	errMsg, err = lgc.CheckHostsAdded(ctx, header, hosts)
-	if nil != err {
-		blog.Errorf("ImportHosts failed,  CheckHostsAdded error:%s, rid: %s", err.Error(), rid)
-		return &metadata.ResponseDataMapStr{
-			BaseResp: metadata.BaseResp{
-				Result: false,
-				Code:   common.CCErrWebHostCheckFail,
-				ErrMsg: defErr.Errorf(common.CCErrWebHostCheckFail, err.Error()).Error(),
-			},
-			Data: nil,
-		}
+	if err != nil {
+		blog.Errorf("check host added failed, err: %v, rid: %s", err, rid)
+		resp.Code = common.CCErrWebHostCheckFail
+		resp.ErrMsg = defErr.Errorf(common.CCErrWebHostCheckFail, err.Error()).Error()
+		return resp
 	}
 	if len(errMsg) > 0 {
-		return &metadata.ResponseDataMapStr{
-			BaseResp: metadata.BaseResp{
-				Result: false,
-				Code:   common.CCErrWebHostCheckFail,
-				ErrMsg: defErr.Errorf(common.CCErrWebHostCheckFail, "").Error(),
-			},
-			Data: map[string]interface{}{
-				"error": errMsg,
-			},
-		}
+		resp.Code = common.CCErrWebHostCheckFail
+		resp.ErrMsg = defErr.Errorf(common.CCErrWebHostCheckFail, "").Error()
+		resp.Data.Set("error", errMsg)
+		return resp
 	}
 
-	var resultErr error
-	result := &metadata.ResponseDataMapStr{}
-	result.BaseResp.Result = true
-	result.Data = mapstr.New()
 	if len(hosts) > 0 {
 		params := map[string]interface{}{
 			"host_info":            hosts,
 			"input_type":           common.InputTypeExcel,
 			common.BKModuleIDField: moduleID,
 		}
-		result, resultErr = lgc.CoreAPI.ApiServer().AddHostByExcel(context.Background(), header, params)
-		if nil != resultErr {
-			blog.Errorf("ImportHosts add host info  http request  error:%s, rid:%s", resultErr.Error(), util.GetHTTPCCRequestID(header))
-			return &metadata.ResponseDataMapStr{
-				BaseResp: metadata.BaseResp{
-					Result: false,
-					Code:   common.CCErrCommHTTPDoRequestFailed,
-					ErrMsg: defErr.Error(common.CCErrCommHTTPDoRequestFailed).Error(),
-				},
-				Data: nil,
-			}
+		result, resultErr := lgc.CoreAPI.ApiServer().AddHostByExcel(context.Background(), header, params)
+		if resultErr != nil {
+			blog.Errorf("add host info failed, err: %v, rid: %s", resultErr, rid)
+			resp.Code = common.CCErrCommHTTPDoRequestFailed
+			resp.ErrMsg = defErr.Errorf(common.CCErrCommHTTPDoRequestFailed).Error()
+			return resp
 		}
+
+		resp = result
 	}
 
 	if len(f.Sheets) < 2 {
-		return result
+		resp.Result = true
+		return resp
 	}
 
 	// if len(f.Sheets) >= 2, the second sheet is association data to be import
-	asstInfoMap := GetAssociationExcelData(f.Sheets[1], common.HostAddMethodExcelAssociationIndexOffset)
-	if len(asstInfoMap) == 0 {
-		return result
-	}
+	asstInfoMap, assoErrMsg := GetAssociationExcelData(f.Sheets[1], common.HostAddMethodExcelAssociationIndexOffset,
+		defLang)
 
-	asstInfoMapInput := &metadata.RequestImportAssociation{
-		AssociationInfoMap: asstInfoMap,
-	}
-	asstResult, asstResultErr := lgc.CoreAPI.ApiServer().ImportAssociation(ctx, header, common.BKInnerObjIDHost, asstInfoMapInput)
-	if nil != asstResultErr {
-		blog.Errorf("ImportHosts logics http request import association error:%s, rid:%s", asstResultErr.Error(), util.GetHTTPCCRequestID(header))
-		return &metadata.ResponseDataMapStr{
-			BaseResp: metadata.BaseResp{
-				Result: false,
-				Code:   common.CCErrCommHTTPDoRequestFailed,
-				ErrMsg: defErr.Error(common.CCErrCommHTTPDoRequestFailed).Error(),
-			},
-			Data: nil,
+	if len(asstInfoMap) > 0 {
+		asstInfoMapInput := &metadata.RequestImportAssociation{
+			AssociationInfoMap: asstInfoMap,
+		}
+		asstResult, asstResultErr := lgc.CoreAPI.ApiServer().ImportAssociation(ctx, header, common.BKInnerObjIDHost,
+			asstInfoMapInput)
+		if asstResultErr != nil {
+			blog.Errorf("import host association failed, err: %v, rid: %s", asstResultErr, rid)
+			resp.Code = common.CCErrCommHTTPDoRequestFailed
+			resp.ErrMsg = defErr.Errorf(common.CCErrCommHTTPDoRequestFailed).Error()
+			return resp
+		}
+
+		assoErrMsg = append(assoErrMsg, asstResult.Data.ErrMsgMap...)
+		if resp.Result && !asstResult.Result {
+			resp.BaseResp = asstResult.BaseResp
 		}
 	}
 
-	result.Data.Set("asst_error", asstResult.Data.ErrMsgMap)
+	resp.Data.Set("asst_error", assoErrMsg)
 
-	if result.Result && !asstResult.Result {
-		result.BaseResp = asstResult.BaseResp
-	}
-
-	return result
+	return resp
 }
 
 // UpdateHosts update excel import hosts


### PR DESCRIPTION
### 修复的问题：
- 添加判断防止导入关联关系时获取对应单元格数据数组越界

issue #5747 