### PR TITLE
3.10迁移校验小工具添加校验和清理无进程关系的进程的功能

### DIFF
--- a/src/scene_server/admin_server/upgrader/y3.10.202109181134/migrate_svc_inst_id_to_proc.go
+++ b/src/scene_server/admin_server/upgrader/y3.10.202109181134/migrate_svc_inst_id_to_proc.go
@@ -14,6 +14,7 @@ package y3_10_202109181134
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"configcenter/src/common"
@@ -144,6 +145,11 @@ func migrateSvcInstIDToProc(ctx context.Context, db dal.RDB, conf *upgrader.Conf
 			common.BKProcessIDField, common.BKServiceInstanceIDField).All(ctx, &procRelations); err != nil {
 			blog.Errorf("get process relations failed, err: %v", err)
 			return err
+		}
+
+		if len(procRelations) != len(processes) {
+			blog.Errorf("process count differs with relation count, process ids: %+v", procIDs)
+			return fmt.Errorf("process count differs with relation count")
 		}
 
 		// set service instance id to corresponding process


### PR DESCRIPTION
### 新加的功能:
- 3.10迁移校验小工具添加校验和清理无进程关系的进程的功能，使用方式：
1. 校验全部，包括唯一索引和进程：./tool_ctl migrate-check --check-all=true
2. 单独校验唯一索引：./tool_ctl migrate-check unique
3. 单独校验进程：./tool_ctl migrate-check process
4. 清除无进程关系的进程：./tool_ctl migrate-check process --clear-proc=true
