### PR TITLE
fix: 修复动态分组预览初始页码错误导致无法正确获取数据的问题

### DIFF
--- a/src/ui/src/utils/tools.js
+++ b/src/ui/src/utils/tools.js
@@ -329,12 +329,12 @@ export function transformHostSearchParams(params) {
 const defaultPaginationConfig = window.innerHeight > 750
   ? { limit: 20, 'limit-list': [20, 50, 100, 500] }
   : { limit: 10, 'limit-list': [10, 50, 100, 500] }
-export function getDefaultPaginationConfig(customConfig = {}) {
+export function getDefaultPaginationConfig(customConfig = {}, useQuery = true) {
   const RouterQuery = require('@/router/query').default
   const config = {
     count: 0,
-    current: parseInt(RouterQuery.get('page', 1), 10),
-    limit: parseInt(RouterQuery.get('limit', defaultPaginationConfig.limit), 10),
+    current: useQuery ? parseInt(RouterQuery.get('page', 1), 10) : 1,
+    limit: useQuery ? parseInt(RouterQuery.get('limit', defaultPaginationConfig.limit), 10) : defaultPaginationConfig.limit,
     'limit-list': customConfig['limit-list'] || defaultPaginationConfig['limit-list']
   }
   return config

--- a/src/ui/src/views/dynamic-group/preview/preview.vue
+++ b/src/ui/src/views/dynamic-group/preview/preview.vue
@@ -50,7 +50,7 @@
         properties: [],
         previewProperties: [],
         table: {
-          pagination: this.$tools.getDefaultPaginationConfig(),
+          pagination: this.$tools.getDefaultPaginationConfig({}, false),
           sort: '-create_time',
           list: []
         },


### PR DESCRIPTION
### 修复的问题：
- 修复动态分组预览初始页码错误导致无法正确获取数据的问题
