### PR TITLE
datacollection主机静态数据上报支持kafka

### DIFF
--- a/scripts/init.py
+++ b/scripts/init.py
@@ -339,6 +339,8 @@ cloudServer:
 #datacollection专属配置
 datacollection:
   hostsnap:
+    # 主机静态数据采集模式，将数据导入kafka或者redis，可选值是 kafka、redis，默认值为redis（仅用于新插件bkmonitorbeat）
+    reportMode: redis
     # 当主机快照数据属性,如cpu,bk_cpu_mhz,bk_disk,bk_mem这些数值型数据变动的范围大于该配置的值时，进行db数据的更新，默认值为10%，最小值为5%，以百分比为单位
     changeRangePercent: 10
     # 用于设置主机快照key在redis中的过期时间，该时间会有上下50%的波动，当key存在时，同一id的主机数据不会更新，默认值为10分钟，最小值为5分钟，以分钟为单位
@@ -429,6 +431,19 @@ gse:
     certFile:
     keyFile:
     caFile:
+    password:
+
+# 当主机静态数据采集模式为kafka时，datacollection处理插件bkmonitorbeat采集上来的主机静态数据，选择kafka作为数据导入组件时的相关配置
+# 此配置与migrate.yaml文件中的reportMode相关联
+kafka:
+  snap:
+    brokers:
+    # groupID为固定值，请勿随便修改，修改后会导致重复消费过去的数据
+    groupID: bk_cmdb_snapshot_group
+    # partition数量固定为1，保证消息的顺序性
+    partition: 1
+    # 安全协议SASL_PLAINTEXT，SASL机制SCRAM-SHA-512的账号、密码信息
+    user:
     password:
     '''
 

--- a/src/scene_server/admin_server/app/options/options.go
+++ b/src/scene_server/admin_server/app/options/options.go
@@ -16,6 +16,7 @@ import (
 	"configcenter/src/ac/iam"
 	"configcenter/src/common/auth"
 	"configcenter/src/common/core/cc/config"
+	"configcenter/src/storage/dal/kafka"
 	"configcenter/src/storage/dal/mongo"
 	"configcenter/src/storage/dal/redis"
 
@@ -45,17 +46,19 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 }
 
 type Config struct {
-	MongoDB       mongo.Config
-	WatchDB       mongo.Config
-	Errors        ErrorConfig
-	Language      LanguageConfig
-	Configures    ConfConfig
-	Register      RegisterConfig
-	Redis         redis.Config
-	SnapRedis     redis.Config
-	IAM           iam.AuthConfig
-	SnapDataID    int64
-	ShardingTable ShardingTableConfig
+	MongoDB        mongo.Config
+	WatchDB        mongo.Config
+	Errors         ErrorConfig
+	Language       LanguageConfig
+	Configures     ConfConfig
+	Register       RegisterConfig
+	Redis          redis.Config
+	SnapRedis      redis.Config
+	SnapKafka      kafka.Config
+	IAM            iam.AuthConfig
+	SnapDataID     int64
+	SnapReportMode string
+	ShardingTable  ShardingTableConfig
 	// SyncIAMPeriodMinutes the period for sync IAM resources
 	SyncIAMPeriodMinutes int
 }

--- a/src/scene_server/admin_server/app/server.go
+++ b/src/scene_server/admin_server/app/server.go
@@ -57,9 +57,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	process.Config.Register.Address, _ = cc.String("registerServer.addrs")
 	snapDataID, _ := cc.Int("hostsnap.dataID")
 	process.Config.SnapDataID = int64(snapDataID)
-	process.Config.SnapReportMode, _ = cc.String("hostsnap.reportMode")
 	process.Config.SyncIAMPeriodMinutes, _ = cc.Int("adminServer.syncIAMPeriodMinutes")
-	process.Config.SnapKafka, _ = cc.Kafka("kafka.snap")
 
 	// load mongodb, redis and common config from configure directory
 	mongodbPath := process.Config.Configures.Dir + "/" + types.CCConfigureMongo
@@ -76,6 +74,9 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	if err := cc.SetCommonFromFile(commonPath); err != nil {
 		return fmt.Errorf("parse common config from file[%s] failed, err: %v", commonPath, err)
 	}
+
+	process.Config.SnapReportMode, _ = cc.String("datacollection.hostsnap.reportMode")
+	process.Config.SnapKafka, _ = cc.Kafka("kafka.snap")
 
 	if err := monitor.InitMonitor(); err != nil {
 		return fmt.Errorf("init monitor failed, err: %v", err)

--- a/src/scene_server/admin_server/app/server.go
+++ b/src/scene_server/admin_server/app/server.go
@@ -57,7 +57,9 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	process.Config.Register.Address, _ = cc.String("registerServer.addrs")
 	snapDataID, _ := cc.Int("hostsnap.dataID")
 	process.Config.SnapDataID = int64(snapDataID)
+	process.Config.SnapReportMode, _ = cc.String("hostsnap.reportMode")
 	process.Config.SyncIAMPeriodMinutes, _ = cc.Int("adminServer.syncIAMPeriodMinutes")
+	process.Config.SnapKafka, _ = cc.Kafka("kafka.snap")
 
 	// load mongodb, redis and common config from configure directory
 	mongodbPath := process.Config.Configures.Dir + "/" + types.CCConfigureMongo
@@ -229,8 +231,8 @@ func parseShardingTableConfig(process *MigrateServer) error {
 			return fmt.Errorf("config shardingTable.indexInterval parse error. err: %s", err)
 		}
 		if val < 30 || val > 720 {
-			blog.Errorf("config shardingTable.indexInterval value illegal. must be in 20-720(minute), but now val is %d",
-				val)
+			blog.Errorf("config shardingTable.indexInterval value illegal. must be in 20-720(minute), "+
+				"but now val is %d", val)
 			return fmt.Errorf("config shardingTable.indexInterval parse error. err: %s", err)
 		}
 		process.Config.ShardingTable.IndexesInterval = val
@@ -248,7 +250,8 @@ func parseShardingTableConfig(process *MigrateServer) error {
 			return fmt.Errorf("config shardingTable.tableInterval parse error. err: %s", err)
 		}
 		if val < 30 || val > 720 {
-			blog.Errorf("config shardingTable.tableInterval value illegal. must be in 60-1800(second), but now val is %d", val)
+			blog.Errorf("config shardingTable.tableInterval value illegal. must be in 60-1800(second), "+
+				"but now val is %d", val)
 			return fmt.Errorf("config shardingTable.tableInterval parse error. err: %s", err)
 		}
 		process.Config.ShardingTable.TableInterval = val

--- a/src/scene_server/admin_server/service/dataid.go
+++ b/src/scene_server/admin_server/service/dataid.go
@@ -205,43 +205,82 @@ func (s *Service) migrateOldVersionDataID(header http.Header, user string, defEr
 }
 
 // generateGseConfigStreamTo generate host snap stream to config by snap redis config
-func (s *Service) generateGseConfigStreamTo(header http.Header, user string, defErr errors.DefaultCCErrorIf, rid string) (
-	*metadata.GseConfigStreamTo, error) {
+func (s *Service) generateGseConfigStreamTo(header http.Header, user string, defErr errors.DefaultCCErrorIf,
+	rid string) (*metadata.GseConfigStreamTo, error) {
 
 	if snapStreamTo != nil {
 		return snapStreamTo, nil
 	}
+	snapStreamTo = &metadata.GseConfigStreamTo{
+		Name: snapStreamToName,
+	}
+	if s.Config.SnapReportMode == "" || s.Config.SnapReportMode == "kafka" {
+		snapStreamTo.ReportMode = metadata.GseConfigReportModeKafka
+		kafkaStreamToAddresses := make([]metadata.GseConfigStorageAddress, 0)
+		for _, addr := range s.Config.SnapKafka.Brokers {
+			ipPort := strings.Split(addr, ":")
+			if len(ipPort) != 2 {
+				blog.Errorf("host snap kafka address is invalid, addr: %s, rid: %s", addr, rid)
+				return nil, &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommParamsInvalid,
+					"snap kafka")}
+			}
 
-	redisStreamToAddresses := make([]metadata.GseConfigStorageAddress, 0)
-	snapRedisAddresses := strings.Split(s.Config.SnapRedis.Address, ",")
-	for _, addr := range snapRedisAddresses {
-		ipPort := strings.Split(addr, ":")
-		if len(ipPort) != 2 {
-			blog.Errorf("host snap redis address is invalid, addr: %s, rid: %s", addr, rid)
-			return nil, &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommParamsInvalid, "snap redis")}
+			port, err := strconv.ParseInt(ipPort[1], 10, 64)
+			if err != nil {
+				blog.Errorf("parse snap kafka address port failed, err: %v, port: %s, rid: %s",
+					err, ipPort[1], rid)
+				return nil, &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommParamsInvalid,
+					"snap kafka")}
+			}
+
+			kafkaStreamToAddresses = append(kafkaStreamToAddresses, metadata.GseConfigStorageAddress{
+				IP:   ipPort[0],
+				Port: port,
+			})
 		}
-
-		port, err := strconv.ParseInt(ipPort[1], 10, 64)
-		if err != nil {
-			blog.Errorf("parse snap redis address port failed, err: %v, port: %s, rid: %s", err, ipPort[1], rid)
-			return nil, &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommParamsInvalid, "snap redis")}
+		snapStreamTo.Kafka = &metadata.GseConfigStreamToKafka{
+			StorageAddresses: kafkaStreamToAddresses,
 		}
-
-		redisStreamToAddresses = append(redisStreamToAddresses, metadata.GseConfigStorageAddress{
-			IP:   ipPort[0],
-			Port: port,
-		})
+		if s.Config.SnapKafka.User != "" && s.Config.SnapKafka.Password != "" {
+			snapStreamTo.Kafka.SaslUsername = s.Config.SnapKafka.User
+			snapStreamTo.Kafka.SaslPassword = s.Config.SnapKafka.Password
+			snapStreamTo.Kafka.SaslMechanisms = "SCRAM-SHA-512"
+			snapStreamTo.Kafka.SecurityProtocol = "SASL_PLAINTEXT"
+		}
 	}
 
-	snapStreamTo = &metadata.GseConfigStreamTo{
-		Name:       snapStreamToName,
-		ReportMode: metadata.GseConfigReportModeRedis,
-		Redis: &metadata.GseConfigStreamToRedis{
+	if s.Config.SnapReportMode == "redis" {
+		snapStreamTo.ReportMode = metadata.GseConfigReportModeRedis
+		redisStreamToAddresses := make([]metadata.GseConfigStorageAddress, 0)
+		snapRedisAddresses := strings.Split(s.Config.SnapRedis.Address, ",")
+		for _, addr := range snapRedisAddresses {
+			ipPort := strings.Split(addr, ":")
+			if len(ipPort) != 2 {
+				blog.Errorf("host snap redis address is invalid, addr: %s, rid: %s", addr, rid)
+				return nil, &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommParamsInvalid,
+					"snap redis")}
+			}
+
+			port, err := strconv.ParseInt(ipPort[1], 10, 64)
+			if err != nil {
+				blog.Errorf("parse snap redis address port failed, err: %v, port: %s, rid: %s",
+					err, ipPort[1], rid)
+				return nil, &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommParamsInvalid,
+					"snap redis")}
+			}
+
+			redisStreamToAddresses = append(redisStreamToAddresses, metadata.GseConfigStorageAddress{
+				IP:   ipPort[0],
+				Port: port,
+			})
+		}
+		snapStreamTo.Redis = &metadata.GseConfigStreamToRedis{
 			StorageAddresses: redisStreamToAddresses,
 			Password:         s.Config.SnapRedis.Password,
 			MasterName:       s.Config.SnapRedis.MasterName,
-		},
+		}
 	}
+
 	return snapStreamTo, nil
 }
 
@@ -279,7 +318,8 @@ func (s *Service) gseConfigQueryStreamTo(header http.Header, user string, defErr
 	streamTos, err := esb.EsbClient().GseSrv().ConfigQueryStreamTo(s.ctx, header, params)
 	if err != nil {
 		blog.ErrorJSON("query stream to from gse failed, err: %s, params: %s, rid: %s", err, params, rid)
-		return streamToID.HostSnap, nil, &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommMigrateFailed, err.Error())}
+		return streamToID.HostSnap, nil, &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommMigrateFailed,
+			err.Error())}
 	}
 
 	return streamToID.HostSnap, streamTos, nil
@@ -311,7 +351,8 @@ func (s *Service) gseConfigAddStreamTo(streamTo *metadata.GseConfigStreamTo, hea
 	}
 
 	if err := s.db.Table(common.BKTableNameSystem).Upsert(s.ctx, cond, &streamToID); err != nil {
-		blog.Errorf("upsert stream to id %d to db failed, err: %v, rid: %s", addStreamResult.StreamToID, err, rid)
+		blog.Errorf("upsert stream to id %d to db failed, err: %v, rid: %s",
+			addStreamResult.StreamToID, err, rid)
 		return addStreamResult.StreamToID, &metadata.RespError{Msg: defErr.Error(common.CCErrCommDBSelectFailed)}
 	}
 
@@ -392,14 +433,25 @@ func (s *Service) generateGseConfigChannel(streamToID, dataID int64, rid string)
 			Name: snapRouteName,
 			StreamTo: metadata.GseConfigRouteStreamTo{
 				StreamToID: streamToID,
-				Redis: &metadata.GseConfigRouteRedis{
-					ChannelName: fmt.Sprintf("snapshot%d", bizID),
-					// compatible for the older version of gse that uses DataSet+BizID as channel name
-					DataSet: "snapshot",
-					BizID:   bizID,
-				},
 			},
 		}},
+	}
+	if s.Config.SnapReportMode == "" || s.Config.SnapReportMode == "kafka" {
+		snapChannel.Route[0].StreamTo.Kafka = &metadata.GseConfigRouteKafka{
+			TopicName: fmt.Sprintf("snapshot%d", bizID),
+			// compatible for the older version of gse that uses DataSet+BizID as channel name
+			DataSet:   "snapshot",
+			BizID:     bizID,
+			Partition: s.Config.SnapKafka.Partition,
+		}
+	}
+	if s.Config.SnapReportMode == "redis" {
+		snapChannel.Route[0].StreamTo.Redis = &metadata.GseConfigRouteRedis{
+			ChannelName: fmt.Sprintf("snapshot%d", bizID),
+			// compatible for the older version of gse that uses DataSet+BizID as channel name
+			DataSet: "snapshot",
+			BizID:   bizID,
+		}
 	}
 	return snapChannel, nil
 }

--- a/src/scene_server/datacollection/app/server.go
+++ b/src/scene_server/datacollection/app/server.go
@@ -37,12 +37,14 @@ import (
 	"configcenter/src/scene_server/datacollection/collections/netcollect"
 	svc "configcenter/src/scene_server/datacollection/service"
 	"configcenter/src/storage/dal"
+	"configcenter/src/storage/dal/kafka"
 	"configcenter/src/storage/dal/mongo"
 	"configcenter/src/storage/dal/mongo/local"
 	"configcenter/src/storage/dal/redis"
 	"configcenter/src/thirdparty/esbserver"
 	"configcenter/src/thirdparty/esbserver/esbutil"
 
+	"github.com/Shopify/sarama"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -86,6 +88,9 @@ type DataCollectionConfig struct {
 	// NetCollectRedis net collection redis configs.
 	NetCollectRedis redis.Config
 
+	// SnapKafka snap kafka configs.
+	SnapKafka kafka.Config
+
 	// ESB blueking ESB configs.
 	Esb esbutil.EsbConfig
 
@@ -119,14 +124,17 @@ type DataCollection struct {
 	// redisCli is cc main cache redis client.
 	redisCli redis.Client
 
-	// snapCli is snap redis client.
-	snapCli redis.Client
+	// snapRedisCli is snap redis client.
+	snapRedisCli redis.Client
 
-	// disCli is discover redis client.
-	disCli redis.Client
+	// disRedisCli is discover redis client.
+	disRedisCli redis.Client
 
-	// netCli is net collect redis client.
-	netCli redis.Client
+	// netRedisCli is net collect redis client.
+	netRedisCli redis.Client
+
+	// snapConsumerGroup is snap kafka consumer group client.
+	snapConsumerGroup sarama.ConsumerGroup
 
 	// authManager is auth manager.
 	authManager *extensions.AuthManager
@@ -216,7 +224,8 @@ func (c *DataCollection) initConfigs() error {
 		if c.config == nil {
 			c.hostConfigUpdateMu.Unlock()
 
-			blog.Info("DataCollection| can't find configs to run the new datacollection server, try again later!")
+			blog.Info("DataCollection| can't find configs to run the new datacollection server, " +
+				"try again later!")
 			time.Sleep(defaultInitWaitDuration)
 			continue
 		}
@@ -264,6 +273,8 @@ func (c *DataCollection) initConfigs() error {
 		return fmt.Errorf("init netcollect redis configs, %+v", err)
 	}
 
+	c.config.SnapKafka, _ = cc.Kafka("kafka.snap")
+
 	c.config.Auth, err = iam.ParseConfigFromKV("authServer", nil)
 	if err != nil {
 		blog.Warnf("parse auth center config failed: %v", err)
@@ -309,7 +320,7 @@ func (c *DataCollection) initModules() error {
 		if err != nil {
 			return fmt.Errorf("connect to snap redis, %+v", err)
 		}
-		c.snapCli = snapCli
+		c.snapRedisCli = snapCli
 		c.service.SetSnapCli(snapCli)
 		blog.Infof("DataCollection| init modules, connected to snap redis, %+v", c.config.SnapRedis)
 	}
@@ -320,7 +331,7 @@ func (c *DataCollection) initModules() error {
 		if nil != err {
 			return fmt.Errorf("connect to discover redis, %+v", err)
 		}
-		c.disCli = disCli
+		c.disRedisCli = disCli
 		c.service.SetDiscoverCli(disCli)
 		blog.Infof("DataCollection| init modules, connected to discover redis, %+v", c.config.DiscoverRedis)
 	}
@@ -331,9 +342,33 @@ func (c *DataCollection) initModules() error {
 		if nil != err {
 			return fmt.Errorf("connect to netcollect redis, %+v", err)
 		}
-		c.netCli = netCli
+		c.netRedisCli = netCli
 		c.service.SetNetCollectCli(netCli)
 		blog.Infof("DataCollection| init modules, connected to netcollect redis, %+v", c.config.NetCollectRedis)
+	}
+
+	// connect to snap kafka.
+	if c.config.SnapKafka.Brokers != nil {
+		config := sarama.NewConfig()
+		config.Consumer.Return.Errors = false
+		config.Consumer.Offsets.AutoCommit.Enable = false // 禁用自动提交，改为手动
+		config.Consumer.Offsets.Initial = sarama.OffsetOldest
+		if c.config.SnapKafka.User != "" && c.config.SnapKafka.Password != "" {
+			config.Net.SASL.Enable = true
+			config.Net.SASL.User = c.config.SnapKafka.User
+			config.Net.SASL.Password = c.config.SnapKafka.Password
+			config.Net.SASL.Handshake = true
+			config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
+				return &kafka.XDGSCRAMClient{HashGeneratorFcn: kafka.SHA512}
+			}
+			config.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA512
+		}
+		var err error
+		c.snapConsumerGroup, err =
+			sarama.NewConsumerGroup(c.config.SnapKafka.Brokers, c.config.SnapKafka.GroupID, config)
+		if err != nil {
+			return err
+		}
 	}
 
 	iamCli := new(iam.IAM)
@@ -369,7 +404,8 @@ func (c *DataCollection) getDefaultAppID() (string, error) {
 
 	id, err := util.GetInt64ByInterface(results[0][common.BKAppIDField])
 	if err != nil {
-		return "", fmt.Errorf("can't query default appid, unkonw id type, %+v", reflect.TypeOf(results[0][common.BKAppIDField]))
+		return "", fmt.Errorf("can't query default appid, unkonw id type, %+v",
+			reflect.TypeOf(results[0][common.BKAppIDField]))
 	}
 	defaultAppID := strconv.FormatInt(id, 10)
 
@@ -415,38 +451,55 @@ func (c *DataCollection) runCollectPorters() {
 			break
 		}
 
-		blog.Errorf("DataCollection| get default appid failed: %+v, init database first and it would try again in %+v seconds later",
-			err, defaultAppInitWaitDuration)
+		blog.Errorf("DataCollection| get default appid failed: %+v, init database first and it would "+
+			"try again in %+v seconds later", err, defaultAppInitWaitDuration)
 		time.Sleep(defaultAppInitWaitDuration)
 	}
 	blog.Info("DataCollection| get default appid id success[%s]", c.defaultAppID)
 
 	// create and add new porters.
-	if c.snapCli != nil {
+	if c.config.SnapKafka.Brokers != nil {
 		topic := c.snapMessageTopic(c.defaultAppID)
 		analyzer := hostsnap.NewHostSnap(c.ctx, c.redisCli, c.db, c.engine, c.authManager)
 
-		porter := collections.NewSimplePorter(snapPorterName, c.engine, c.hash, analyzer, c.snapCli, topic, c.registry)
-		c.porterManager.AddPorter(porter)
-		blog.Info("DataCollection| create hostsnap analyzer with target porter[%s] on topic[%s] success", snapPorterName, topic)
+		kafkaPorter := collections.NewKafkaPorter(snapPorterName, c.engine, c.ctx, analyzer, c.snapConsumerGroup,
+			topic, c.registry)
+		c.porterManager.AddPorter(kafkaPorter)
+		blog.Info("DataCollection| create kafka hostsnap analyzer with target porter[%s] on topic[%s] success",
+			snapPorterName, topic)
 	}
 
-	if c.disCli != nil {
+	if c.snapRedisCli != nil {
+		topic := c.snapMessageTopic(c.defaultAppID)
+		analyzer := hostsnap.NewHostSnap(c.ctx, c.redisCli, c.db, c.engine, c.authManager)
+
+		porter := collections.NewSimplePorter(snapPorterName, c.engine, c.hash, analyzer, c.snapRedisCli, topic,
+			c.registry)
+		c.porterManager.AddPorter(porter)
+		blog.Info("DataCollection| create redis hostsnap analyzer with target porter[%s] on topic[%s] success",
+			snapPorterName, topic)
+	}
+
+	if c.disRedisCli != nil {
 		topic := c.discoverMessageTopic(c.defaultAppID)
 		analyzer := middleware.NewDiscover(c.ctx, c.redisCli, c.engine, c.authManager)
 
-		porter := collections.NewSimplePorter(middlewarePorterName, c.engine, c.hash, analyzer, c.disCli, topic, c.registry)
+		porter := collections.NewSimplePorter(middlewarePorterName, c.engine, c.hash, analyzer, c.disRedisCli, topic,
+			c.registry)
 		c.porterManager.AddPorter(porter)
-		blog.Info("DataCollection| create discover analyzer with target porter[%s] on topic[%s] success", middlewarePorterName, topic)
+		blog.Info("DataCollection| create kafka discover analyzer with target porter[%s] on topic[%s] success",
+			middlewarePorterName, topic)
 	}
 
-	if c.netCli != nil {
+	if c.netRedisCli != nil {
 		topic := c.netcollectMessageTopic(c.defaultAppID)
 		analyzer := netcollect.NewNetCollect(c.ctx, c.db, c.authManager)
 
-		porter := collections.NewSimplePorter(netCollectPorterName, c.engine, c.hash, analyzer, c.netCli, topic, c.registry)
+		porter := collections.NewSimplePorter(netCollectPorterName, c.engine, c.hash, analyzer, c.netRedisCli, topic,
+			c.registry)
 		c.porterManager.AddPorter(porter)
-		blog.Info("DataCollection| create netcollect analyzer with target porter[%s] on topic[%s] success", netCollectPorterName, topic)
+		blog.Info("DataCollection| create redis netcollect analyzer with target porter[%s] on topic[%s] success",
+			netCollectPorterName, topic)
 	}
 }
 
@@ -515,7 +568,8 @@ func (c *DataCollection) setSnapshotBizName() error {
 	}
 
 	if c.snapshotBizName == "" {
-		blog.Errorf("setSnapshotBizName failed, SnapshotBizName is empty, check the coreservice and the value in table cc_System")
+		blog.Errorf("setSnapshotBizName failed, SnapshotBizName is empty, check the coreservice and the value " +
+			"in table cc_System")
 		return fmt.Errorf("setSnapshotBizName failed")
 	}
 

--- a/src/scene_server/datacollection/collections/hostsnap/hostsnap.go
+++ b/src/scene_server/datacollection/collections/hostsnap/hostsnap.go
@@ -252,11 +252,16 @@ func (h *HostSnap) Analyze(msg *string) error {
 		return nil
 	}
 
-	// limit the number of requests
-	if !h.rateLimit.TryAccept() {
+	// limit request from the old collection plug-in
+	if !val.Get("data.apiVer").Exists() && !h.rateLimit.TryAccept() {
 		blog.Warnf("skip host snapshot data update due to request limit, host id: %d, ip: %s, cloud id: %d, "+
 			"rid: %s", hostID, innerIP, cloudID, rid)
 		return nil
+	}
+
+	// limit the request from the new collection plug-in
+	if val.Get("data.apiVer").Exists() {
+		h.rateLimit.Accept()
 	}
 
 	blog.V(5).Infof("snapshot for host changed, need update, host id: %d, ip: %s, cloud id: %d, from %s "+

--- a/src/scene_server/datacollection/collections/hostsnap/hostsnap.go
+++ b/src/scene_server/datacollection/collections/hostsnap/hostsnap.go
@@ -50,6 +50,8 @@ const (
 	defaultRateLimiterQPS = 40
 	// defaultRateLimiterBurst is the default value of rateLimiter burst
 	defaultRateLimiterBurst = 100
+	// redisConsumptionCheckPrefix redis consumption check prefix
+	redisConsumptionCheckPrefix = "consumptionCheck:"
 )
 
 var (
@@ -71,9 +73,12 @@ type HostSnap struct {
 	ctx       context.Context
 	db        dal.RDB
 	window    *Window
+	success   bool
 }
 
-func NewHostSnap(ctx context.Context, redisCli redis.Client, db dal.RDB, engine *backbone.Engine, authManager *extensions.AuthManager) *HostSnap {
+// NewHostSnap new hostsnap
+func NewHostSnap(ctx context.Context, redisCli redis.Client, db dal.RDB, engine *backbone.Engine,
+	authManager *extensions.AuthManager) *HostSnap {
 	qps, burst := getRateLimiterConfig()
 	h := &HostSnap{
 		redisCli:    redisCli,
@@ -84,19 +89,32 @@ func NewHostSnap(ctx context.Context, redisCli redis.Client, db dal.RDB, engine 
 		Engine:      engine,
 		filter:      newFilter(),
 		window:      newWindow(),
+		success:     true,
 	}
 	return h
+}
+
+// IsSuccess judge failed due to network problems etc.
+func (h *HostSnap) IsSuccess() bool {
+	return h.success
+}
+
+// SetSuccessFlag set success flag
+func (h *HostSnap) SetSuccessFlag(success bool) {
+	h.success = success
 }
 
 func getRateLimiterConfig() (int, int) {
 	qps, err := cc.Int("datacollection.hostsnap.rateLimiter.qps")
 	if err != nil {
-		blog.Errorf("can't find the value of datacollection.hostsnap.rateLimiter.qps settings, set the default value: %s", defaultRateLimiterQPS)
+		blog.Errorf("can't find the value of datacollection.hostsnap.rateLimiter.qps settings, "+
+			"set the default value: %d", defaultRateLimiterQPS)
 		qps = defaultRateLimiterQPS
 	}
 	burst, err := cc.Int("datacollection.hostsnap.rateLimiter.burst")
 	if err != nil {
-		blog.Errorf("can't find the value of datacollection.hostsnap.rateLimiter.burst setting,set the default value: %s", defaultRateLimiterBurst)
+		blog.Errorf("can't find the value of datacollection.hostsnap.rateLimiter.burst setting, "+
+			"set the default value: %d", defaultRateLimiterBurst)
 		burst = defaultRateLimiterBurst
 	}
 	return qps, burst
@@ -184,7 +202,6 @@ func (h *HostSnap) Analyze(msg *string) error {
 	outerIP := elements[2].String()
 
 	// save host snapshot in redis
-
 	if !val.Get("data.apiVer").Exists() {
 		h.saveHostsnap(header, &val, hostID)
 	}
@@ -192,11 +209,43 @@ func (h *HostSnap) Analyze(msg *string) error {
 	// window restriction on request when no apiVer information reported
 	if !val.Get("data.apiVer").Exists() && !h.window.canPassWindow() {
 		if blog.V(4) {
-			blog.Infof("not within the time window that can pass, skip host snapshot data update, host id: %d, "+
-				"ip: %s, cloud id: %d, rid: %s", hostID, innerIP, cloudID, rid)
+			blog.Infof("not within the time window that can pass, skip host snapshot data update, "+
+				"host id: %d, ip: %s, cloud id: %d, rid: %s", hostID, innerIP, cloudID, rid)
 		}
 		return nil
 	}
+
+	// verify the timestamp to determine whether the host sequence is correct
+	if val.Get("data.apiVer").Exists() {
+		key := redisConsumptionCheckPrefix + innerIP + ":" + strconv.FormatInt(cloudID, 10)
+		timestamp, err := h.redisCli.Get(context.Background(), key).Result()
+		if err != nil && !redis.IsNilErr(err) {
+			blog.Errorf("get key: %s from redis err: %v, rid: %s", key, err, rid)
+		}
+
+		var oldTimestamp int64
+		if timestamp != "" {
+			oldTimestamp, err = strconv.ParseInt(timestamp, 10, 64)
+			if err != nil {
+				blog.Errorf("parseInt timestamp %s error, key: %s to redis err: %v, rid: %s",
+					timestamp, key, err, rid)
+			}
+		}
+
+		newTimestamp := val.Get("data.timestamp").Int()
+		if err == nil && oldTimestamp != 0 && oldTimestamp > newTimestamp {
+			blog.Warnf("skip host snapshot data update due to it is old data, host id: %d, ip: %s, "+
+				"cloud id: %d, timestamp: %d, rid: %s", hostID, innerIP, cloudID, newTimestamp, rid)
+			return nil
+		}
+
+		randTime := util.RandInt64WithRange(int64(5), int64(10))
+		err = h.redisCli.Set(context.Background(), key, newTimestamp, time.Minute*time.Duration(randTime)).Err()
+		if err != nil {
+			blog.Errorf("set key: %s to redis err: %v, rid: %s", key, err, rid)
+		}
+	}
+
 	setter, raw := parseSetter(&val, innerIP, outerIP)
 	// no need to update
 	if !needToUpdate(raw, host) {
@@ -205,13 +254,13 @@ func (h *HostSnap) Analyze(msg *string) error {
 
 	// limit the number of requests
 	if !h.rateLimit.TryAccept() {
-		blog.Warnf("skip host snapshot data update due to request limit, host id: %d, ip: %s, cloud id: %d, rid: %s",
-			hostID, innerIP, cloudID, rid)
+		blog.Warnf("skip host snapshot data update due to request limit, host id: %d, ip: %s, cloud id: %d, "+
+			"rid: %s", hostID, innerIP, cloudID, rid)
 		return nil
 	}
 
-	blog.V(5).Infof("snapshot for host changed, need update, host id: %d, ip: %s, cloud id: %d, from %s to %s, "+
-		"rid: %s", hostID, innerIP, cloudID, host, raw, rid)
+	blog.V(5).Infof("snapshot for host changed, need update, host id: %d, ip: %s, cloud id: %d, from %s "+
+		"to %s, rid: %s", hostID, innerIP, cloudID, host, raw, rid)
 
 	// get audit interface of host.
 	audit := auditlog.NewHostAudit(h.CoreAPI.CoreService())
@@ -236,8 +285,9 @@ func (h *HostSnap) Analyze(msg *string) error {
 		WithOperateFrom(metadata.FromDataCollection).WithUpdateFields(setter)
 	auditLog, err := audit.GenerateAuditLog(generateAuditParameter, 0, []mapstr.MapStr{hostData})
 	if err != nil {
-		blog.Errorf("generate host snap audit log failed before update host, host: %d/%s, err: %v, rid: %s", hostID,
-			innerIP, err, rid)
+		h.success = false
+		blog.Errorf("generate host snap audit log failed before update host, host: %d/%s, err: %v, rid: %s",
+			hostID, innerIP, err, rid)
 		return err
 	}
 
@@ -256,17 +306,18 @@ func (h *HostSnap) Analyze(msg *string) error {
 
 	_, err = h.CoreAPI.CoreService().Instance().UpdateInstance(h.ctx, header, common.BKInnerObjIDHost, opt)
 	if err != nil {
-		blog.Errorf("snapshot changed, update host %d/%s snapshot failed, err: %v, rid: %s", hostID, innerIP, err, rid)
+		h.success = false
+		blog.Errorf("snapshot changed, update host %d/%s snapshot failed, err: %v, rid: %s",
+			hostID, innerIP, err, rid)
 		return err
 	}
-
 	// save audit log.
 	if err := audit.SaveAuditLog(kit, auditLog...); err != nil {
+		h.success = false
 		blog.Errorf("save host snap audit log failed after update host, host %d/%s, err: %v, rid: %s", hostID,
 			innerIP, err, rid)
 		return err
 	}
-
 	blog.V(5).Infof("snapshot for host changed, update success, host id: %d, ip: %s, cloud id: %d, rid: %s",
 		hostID, innerIP, cloudID, rid)
 
@@ -275,7 +326,8 @@ func (h *HostSnap) Analyze(msg *string) error {
 
 func needToUpdate(src, toCompare string) bool {
 	// get data fluctuation limit
-	changeRangePercent := getLimitConfig("datacollection.hostsnap.changeRangePercent", defaultChangeRangePercent, minChangeRangePercent)
+	changeRangePercent := getLimitConfig("datacollection.hostsnap.changeRangePercent",
+		defaultChangeRangePercent, minChangeRangePercent)
 	srcElements := gjson.GetMany(src, compareFields...)
 	compareElements := gjson.GetMany(toCompare, compareFields...)
 	for idx, field := range compareFields {
@@ -713,9 +765,11 @@ func (h *HostSnap) getHostByVal(header http.Header, cloudID int64, ips []string,
 			Fields:  reqireFields,
 		}
 
-		host, err := h.Engine.CoreAPI.CacheService().Cache().Host().SearchHostWithInnerIP(context.Background(), header, opt)
+		host, err := h.Engine.CoreAPI.CacheService().Cache().Host().SearchHostWithInnerIP(context.Background(),
+			header, opt)
 		if err != nil {
-			blog.Errorf("get host info with ip: %s, cloud id: %d failed, err: %v, rid: %s", ip, cloudID, err, rid)
+			blog.Errorf("get host info with ip: %s, cloud id: %d failed, err: %v, rid: %s", ip, cloudID,
+				err, rid)
 			if ccErr, ok := err.(ccErr.CCErrorCoder); ok {
 				if ccErr.GetCode() == common.CCErrCommDBSelectFailed {
 					h.filter.Set(ip, cloudID)
@@ -802,4 +856,73 @@ func newHeaderWithRid() (http.Header, string) {
 	return header, rid
 }
 
-const MockMessage = "{\"localTime\": \"2017-09-19 16:57:00\", \"data\": \"{\\\"ip\\\":\\\"192.168.1.7\\\",\\\"bizid\\\":0,\\\"cloudid\\\":0,\\\"data\\\":{\\\"timezone\\\":8,\\\"datetime\\\":\\\"2017-09-19 16:57:07\\\",\\\"utctime\\\":\\\"2017-09-19 08:57:07\\\",\\\"country\\\":\\\"Asia\\\",\\\"city\\\":\\\"Shanghai\\\",\\\"cpu\\\":{\\\"cpuinfo\\\":[{\\\"cpu\\\":0,\\\"vendorID\\\":\\\"GenuineIntel\\\",\\\"family\\\":\\\"6\\\",\\\"model\\\":\\\"63\\\",\\\"stepping\\\":2,\\\"physicalID\\\":\\\"0\\\",\\\"coreID\\\":\\\"0\\\",\\\"cores\\\":1,\\\"modelName\\\":\\\"Intel(R) Xeon(R) CPU E5-26xx v3\\\",\\\"mhz\\\":2294.01,\\\"cacheSize\\\":4096,\\\"flags\\\":[\\\"fpu\\\",\\\"vme\\\",\\\"de\\\",\\\"pse\\\",\\\"tsc\\\",\\\"msr\\\",\\\"pae\\\",\\\"mce\\\",\\\"cx8\\\",\\\"apic\\\",\\\"sep\\\",\\\"mtrr\\\",\\\"pge\\\",\\\"mca\\\",\\\"cmov\\\",\\\"pat\\\",\\\"pse36\\\",\\\"clflush\\\",\\\"mmx\\\",\\\"fxsr\\\",\\\"sse\\\",\\\"sse2\\\",\\\"ss\\\",\\\"ht\\\",\\\"syscall\\\",\\\"nx\\\",\\\"lm\\\",\\\"constant_tsc\\\",\\\"up\\\",\\\"rep_good\\\",\\\"unfair_spinlock\\\",\\\"pni\\\",\\\"pclmulqdq\\\",\\\"ssse3\\\",\\\"fma\\\",\\\"cx16\\\",\\\"pcid\\\",\\\"sse4_1\\\",\\\"sse4_2\\\",\\\"x2apic\\\",\\\"movbe\\\",\\\"popcnt\\\",\\\"tsc_deadline_timer\\\",\\\"aes\\\",\\\"xsave\\\",\\\"avx\\\",\\\"f16c\\\",\\\"rdrand\\\",\\\"hypervisor\\\",\\\"lahf_lm\\\",\\\"abm\\\",\\\"xsaveopt\\\",\\\"bmi1\\\",\\\"avx2\\\",\\\"bmi2\\\"],\\\"microcode\\\":\\\"1\\\"}],\\\"per_usage\\\":[3.0232169701043103],\\\"total_usage\\\":3.0232169701043103,\\\"per_stat\\\":[{\\\"cpu\\\":\\\"cpu0\\\",\\\"user\\\":5206.09,\\\"system\\\":6107.04,\\\"idle\\\":337100.84,\\\"nice\\\":6.68,\\\"iowait\\\":528.24,\\\"irq\\\":0.02,\\\"softirq\\\":13.48,\\\"steal\\\":0,\\\"guest\\\":0,\\\"guestNice\\\":0,\\\"stolen\\\":0}],\\\"total_stat\\\":{\\\"cpu\\\":\\\"cpu-total\\\",\\\"user\\\":5206.09,\\\"system\\\":6107.04,\\\"idle\\\":337100.84,\\\"nice\\\":6.68,\\\"iowait\\\":528.24,\\\"irq\\\":0.02,\\\"softirq\\\":13.48,\\\"steal\\\":0,\\\"guest\\\":0,\\\"guestNice\\\":0,\\\"stolen\\\":0}},\\\"env\\\":{\\\"crontab\\\":[{\\\"user\\\":\\\"root\\\",\\\"content\\\":\\\"#secu-tcs-agent monitor, install at Fri Sep 15 16:12:02 CST 2017\\\\n* * * * * /usr/local/sa/agent/secu-tcs-agent-mon-safe.sh /usr/local/sa/agent \\\\u003e /dev/null 2\\\\u003e\\\\u00261\\\\n*/1 * * * * /usr/local/qcloud/stargate/admin/start.sh \\\\u003e /dev/null 2\\\\u003e\\\\u00261 \\\\u0026\\\\n*/20 * * * * /usr/sbin/ntpdate ntpupdate.tencentyun.com \\\\u003e/dev/null \\\\u0026\\\\n*/1 * * * * cd /usr/local/gse/gseagent; ./cron_agent.sh 1\\\\u003e/dev/null 2\\\\u003e\\\\u00261\\\\n\\\"}],\\\"host\\\":\\\"127.0.0.1  localhost  localhost.localdomain  VM_0_31_centos\\\\n::1         localhost localhost.localdomain localhost6 localhost6.localdomain6\\\\n\\\",\\\"route\\\":\\\"Kernel IP routing table\\\\nDestination     Gateway         Genmask         Flags Metric Ref    Use Iface\\\\n10.0.0.0        0.0.0.0         255.255.255.0   U     0      0        0 eth0\\\\n169.254.0.0     0.0.0.0         255.255.0.0     U     1002   0        0 eth0\\\\n0.0.0.0         10.0.0.1        0.0.0.0         UG    0      0        0 eth0\\\\n\\\"},\\\"disk\\\":{\\\"diskstat\\\":{\\\"vda1\\\":{\\\"major\\\":252,\\\"minor\\\":1,\\\"readCount\\\":24347,\\\"mergedReadCount\\\":570,\\\"writeCount\\\":696357,\\\"mergedWriteCount\\\":4684783,\\\"readBytes\\\":783955968,\\\"writeBytes\\\":22041231360,\\\"readSectors\\\":1531164,\\\"writeSectors\\\":43049280,\\\"readTime\\\":80626,\\\"writeTime\\\":12704736,\\\"iopsInProgress\\\":0,\\\"ioTime\\\":822057,\\\"weightedIoTime\\\":12785026,\\\"name\\\":\\\"vda1\\\",\\\"serialNumber\\\":\\\"\\\",\\\"speedIORead\\\":0,\\\"speedByteRead\\\":0,\\\"speedIOWrite\\\":2.9,\\\"speedByteWrite\\\":171144.53333333333,\\\"util\\\":0.0025666666666666667,\\\"avgrq_sz\\\":115.26436781609195,\\\"avgqu_sz\\\":0.06568333333333334,\\\"await\\\":22.649425287356323,\\\"svctm\\\":0.8850574712643678}},\\\"partition\\\":[{\\\"device\\\":\\\"/dev/vda1\\\",\\\"mountpoint\\\":\\\"/\\\",\\\"fstype\\\":\\\"ext3\\\",\\\"opts\\\":\\\"rw,noatime,acl,user_xattr\\\"}],\\\"usage\\\":[{\\\"path\\\":\\\"/\\\",\\\"fstype\\\":\\\"ext2/ext3\\\",\\\"total\\\":52843638784,\\\"free\\\":47807447040,\\\"used\\\":2351915008,\\\"usedPercent\\\":4.4507060113962345,\\\"inodesTotal\\\":3276800,\\\"inodesUsed\\\":29554,\\\"inodesFree\\\":3247246,\\\"inodesUsedPercent\\\":0.9019165039062501}]},\\\"load\\\":{\\\"load_avg\\\":{\\\"load1\\\":0,\\\"load5\\\":0,\\\"load15\\\":0}},\\\"mem\\\":{\\\"meminfo\\\":{\\\"total\\\":1044832256,\\\"available\\\":805912576,\\\"used\\\":238919680,\\\"usedPercent\\\":22.866797864249705,\\\"free\\\":92041216,\\\"active\\\":521183232,\\\"inactive\\\":352964608,\\\"wired\\\":0,\\\"buffers\\\":110895104,\\\"cached\\\":602976256,\\\"writeback\\\":0,\\\"dirty\\\":151552,\\\"writebacktmp\\\":0},\\\"vmstat\\\":{\\\"total\\\":0,\\\"used\\\":0,\\\"free\\\":0,\\\"usedPercent\\\":0,\\\"sin\\\":0,\\\"sout\\\":0}},\\\"net\\\":{\\\"interface\\\":[{\\\"mtu\\\":65536,\\\"name\\\":\\\"lo\\\",\\\"hardwareaddr\\\":\\\"28:31:52:1d:c6:0a\\\",\\\"flags\\\":[\\\"up\\\",\\\"loopback\\\"],\\\"addrs\\\":[{\\\"addr\\\":\\\"127.0.0.1/8\\\"}]},{\\\"mtu\\\":1500,\\\"name\\\":\\\"eth0\\\",\\\"hardwareaddr\\\":\\\"52:54:00:19:2e:e8\\\",\\\"flags\\\":[\\\"up\\\",\\\"broadcast\\\",\\\"multicast\\\"],\\\"addrs\\\":[{\\\"addr\\\":\\\"127.0.0.1/24\\\"}]}],\\\"dev\\\":[{\\\"name\\\":\\\"lo\\\",\\\"speedSent\\\":0,\\\"speedRecv\\\":0,\\\"speedPacketsSent\\\":0,\\\"speedPacketsRecv\\\":0,\\\"bytesSent\\\":604,\\\"bytesRecv\\\":604,\\\"packetsSent\\\":2,\\\"packetsRecv\\\":2,\\\"errin\\\":0,\\\"errout\\\":0,\\\"dropin\\\":0,\\\"dropout\\\":0,\\\"fifoin\\\":0,\\\"fifoout\\\":0},{\\\"name\\\":\\\"eth0\\\",\\\"speedSent\\\":574,\\\"speedRecv\\\":214,\\\"speedPacketsSent\\\":3,\\\"speedPacketsRecv\\\":2,\\\"bytesSent\\\":161709123,\\\"bytesRecv\\\":285910298,\\\"packetsSent\\\":1116625,\\\"packetsRecv\\\":1167796,\\\"errin\\\":0,\\\"errout\\\":0,\\\"dropin\\\":0,\\\"dropout\\\":0,\\\"fifoin\\\":0,\\\"fifoout\\\":0}],\\\"netstat\\\":{\\\"established\\\":2,\\\"syncSent\\\":1,\\\"synRecv\\\":0,\\\"finWait1\\\":0,\\\"finWait2\\\":0,\\\"timeWait\\\":0,\\\"close\\\":0,\\\"closeWait\\\":0,\\\"lastAck\\\":0,\\\"listen\\\":2,\\\"closing\\\":0},\\\"protocolstat\\\":[{\\\"protocol\\\":\\\"udp\\\",\\\"stats\\\":{\\\"inDatagrams\\\":176253,\\\"inErrors\\\":0,\\\"noPorts\\\":1,\\\"outDatagrams\\\":199569,\\\"rcvbufErrors\\\":0,\\\"sndbufErrors\\\":0}}]},\\\"system\\\":{\\\"info\\\":{\\\"hostname\\\":\\\"VM_0_31_centos\\\",\\\"uptime\\\":348315,\\\"bootTime\\\":1505463112,\\\"procs\\\":142,\\\"os\\\":\\\"linux\\\",\\\"platform\\\":\\\"centos\\\",\\\"platformFamily\\\":\\\"rhel\\\",\\\"platformVersion\\\":\\\"6.2\\\",\\\"kernelVersion\\\":\\\"2.6.32-504.30.3.el6.x86_64\\\",\\\"virtualizationSystem\\\":\\\"\\\",\\\"virtualizationRole\\\":\\\"\\\",\\\"hostid\\\":\\\"96D0F4CA-2157-40E6-BF22-6A7CD9B6EB8C\\\",\\\"systemtype\\\":\\\"64-bit\\\"}}}}\", \"timestamp\": 1505811427, \"dtEventTime\": \"2017-09-19 16:57:07\", \"dtEventTimeStamp\": 1505811427000}"
+const MockMessage = "{\"localTime\": \"2017-09-19 16:57:00\", \"data\": \"{\\\"ip\\\":\\\"192.168.1.7\\\"," +
+	"\\\"bizid\\\":0,\\\"cloudid\\\":0,\\\"data\\\":{\\\"timezone\\\":8,\\\"datetime\\\":\\\"2017-09-19 16:57:07\\\"," +
+	"\\\"utctime\\\":\\\"2017-09-19 08:57:07\\\",\\\"country\\\":\\\"Asia\\\",\\\"city\\\":\\\"Shanghai\\\"," +
+	"\\\"cpu\\\":{\\\"cpuinfo\\\":[{\\\"cpu\\\":0,\\\"vendorID\\\":\\\"GenuineIntel\\\",\\\"family\\\":\\\"6\\\"," +
+	"\\\"model\\\":\\\"63\\\",\\\"stepping\\\":2,\\\"physicalID\\\":\\\"0\\\",\\\"coreID\\\":\\\"0\\\"," +
+	"\\\"cores\\\":1,\\\"modelName\\\":\\\"Intel(R) Xeon(R) CPU E5-26xx v3\\\",\\\"mhz\\\":2294.01," +
+	"\\\"cacheSize\\\":4096,\\\"flags\\\":[\\\"fpu\\\",\\\"vme\\\",\\\"de\\\",\\\"pse\\\",\\\"tsc\\\"," +
+	"\\\"msr\\\",\\\"pae\\\",\\\"mce\\\",\\\"cx8\\\",\\\"apic\\\",\\\"sep\\\",\\\"mtrr\\\",\\\"pge\\\"," +
+	"\\\"mca\\\",\\\"cmov\\\",\\\"pat\\\",\\\"pse36\\\",\\\"clflush\\\",\\\"mmx\\\",\\\"fxsr\\\"," +
+	"\\\"sse\\\",\\\"sse2\\\",\\\"ss\\\",\\\"ht\\\",\\\"syscall\\\",\\\"nx\\\",\\\"lm\\\",\\\"constant_tsc\\\"," +
+	"\\\"up\\\",\\\"rep_good\\\",\\\"unfair_spinlock\\\",\\\"pni\\\",\\\"pclmulqdq\\\",\\\"ssse3\\\",\\\"fma\\\"," +
+	"\\\"cx16\\\",\\\"pcid\\\",\\\"sse4_1\\\",\\\"sse4_2\\\",\\\"x2apic\\\",\\\"movbe\\\",\\\"popcnt\\\"," +
+	"\\\"tsc_deadline_timer\\\",\\\"aes\\\",\\\"xsave\\\",\\\"avx\\\",\\\"f16c\\\",\\\"rdrand\\\",\\\"hypervisor\\\"," +
+	"\\\"lahf_lm\\\",\\\"abm\\\",\\\"xsaveopt\\\",\\\"bmi1\\\",\\\"avx2\\\",\\\"bmi2\\\"],\\\"microcode\\\":" +
+	"\\\"1\\\"}],\\\"per_usage\\\":[3.0232169701043103],\\\"total_usage\\\":3.0232169701043103,\\\"per_stat\\\"" +
+	":[{\\\"cpu\\\":\\\"cpu0\\\",\\\"user\\\":5206.09,\\\"system\\\":6107.04,\\\"idle\\\":337100.84,\\\"nice\\\"" +
+	":6.68,\\\"iowait\\\":528.24,\\\"irq\\\":0.02,\\\"softirq\\\":13.48,\\\"steal\\\":0,\\\"guest\\\":0," +
+	"\\\"guestNice\\\":0,\\\"stolen\\\":0}],\\\"total_stat\\\":{\\\"cpu\\\":\\\"cpu-total\\\",\\\"user\\\"" +
+	":5206.09,\\\"system\\\":6107.04,\\\"idle\\\":337100.84,\\\"nice\\\":6.68,\\\"iowait\\\":528.24,\\\"irq\\\"" +
+	":0.02,\\\"softirq\\\":13.48,\\\"steal\\\":0,\\\"guest\\\":0,\\\"guestNice\\\":0,\\\"stolen\\\":0}}," +
+	"\\\"env\\\":{\\\"crontab\\\":[{\\\"user\\\":\\\"root\\\",\\\"content\\\":\\\"#secu-tcs-agent monitor, " +
+	"install at Fri Sep 15 16:12:02 CST 2017\\\\n* * * * * /usr/local/sa/agent/secu-tcs-agent-mon-safe.sh " +
+	"/usr/local/sa/agent \\\\u003e /dev/null 2\\\\u003e\\\\u00261\\\\n*/1 * * * * /usr/local/qcloud/stargate" +
+	"/admin/start.sh \\\\u003e /dev/null 2\\\\u003e\\\\u00261 \\\\u0026\\\\n*/20 * * * * /usr/sbin/ntpdate " +
+	"ntpupdate.tencentyun.com \\\\u003e/dev/null \\\\u0026\\\\n*/1 * * * * cd /usr/local/gse/gseagent; " +
+	"./cron_agent.sh 1\\\\u003e/dev/null 2\\\\u003e\\\\u00261\\\\n\\\"}],\\\"host\\\":\\\"127.0.0.1  localhost" +
+	"  localhost.localdomain  VM_0_31_centos\\\\n::1         localhost localhost.localdomain localhost6 " +
+	"localhost6.localdomain6\\\\n\\\",\\\"route\\\":\\\"Kernel IP routing table\\\\nDestination     " +
+	"Gateway         Genmask         Flags Metric Ref    Use Iface\\\\n10.0.0.0        0.0.0.0     " +
+	"    255.255.255.0   U     0      0        0 eth0\\\\n169.254.0.0     0.0.0.0         255.255.0.0  " +
+	"   U     1002   0        0 eth0\\\\n0.0.0.0         10.0.0.1        0.0.0.0         UG    0      0    " +
+	"    0 eth0\\\\n\\\"},\\\"disk\\\":{\\\"diskstat\\\":{\\\"vda1\\\":{\\\"major\\\":252,\\\"minor\\\"" +
+	":1,\\\"readCount\\\":24347,\\\"mergedReadCount\\\":570,\\\"writeCount\\\":696357,\\\"mergedWriteCount\\\"" +
+	":4684783,\\\"readBytes\\\":783955968,\\\"writeBytes\\\":22041231360,\\\"readSectors\\\":1531164,\\\"" +
+	"writeSectors\\\":43049280,\\\"readTime\\\":80626,\\\"writeTime\\\":12704736,\\\"iopsInProgress\\\":0," +
+	"\\\"ioTime\\\":822057,\\\"weightedIoTime\\\":12785026,\\\"name\\\":\\\"vda1\\\",\\\"serialNumber\\\"" +
+	":\\\"\\\",\\\"speedIORead\\\":0,\\\"speedByteRead\\\":0,\\\"speedIOWrite\\\":2.9,\\\"speedByteWrite\\\"" +
+	":171144.53333333333,\\\"util\\\":0.0025666666666666667,\\\"avgrq_sz\\\":115.26436781609195,\\\"avgqu_sz\\\"" +
+	":0.06568333333333334,\\\"await\\\":22.649425287356323,\\\"svctm\\\":0.8850574712643678}},\\\"" +
+	"partition\\\":[{\\\"device\\\":\\\"/dev/vda1\\\",\\\"mountpoint\\\":\\\"/\\\",\\\"fstype\\\":\\\"ext3\\\"," +
+	"\\\"opts\\\":\\\"rw,noatime,acl,user_xattr\\\"}],\\\"usage\\\":[{\\\"path\\\":\\\"/\\\",\\\"fstype\\\":" +
+	"\\\"ext2/ext3\\\",\\\"total\\\":52843638784,\\\"free\\\":47807447040,\\\"used\\\":2351915008," +
+	"\\\"usedPercent\\\":4.4507060113962345,\\\"inodesTotal\\\":3276800,\\\"inodesUsed\\\":29554,\\\"inodesFree" +
+	"\\\":3247246,\\\"inodesUsedPercent\\\":0.9019165039062501}]},\\\"load\\\":{\\\"load_avg\\\":{\\\"load1\\\"" +
+	":0,\\\"load5\\\":0,\\\"load15\\\":0}},\\\"mem\\\":{\\\"meminfo\\\":{\\\"total\\\":1044832256,\\\"available" +
+	"\\\":805912576,\\\"used\\\":238919680,\\\"usedPercent\\\":22.866797864249705,\\\"free\\\":92041216," +
+	"\\\"active\\\":521183232,\\\"inactive\\\":352964608,\\\"wired\\\":0,\\\"buffers\\\":110895104,\\\"cached" +
+	"\\\":602976256,\\\"writeback\\\":0,\\\"dirty\\\":151552,\\\"writebacktmp\\\":0},\\\"vmstat\\\":" +
+	"{\\\"total\\\":0,\\\"used\\\":0,\\\"free\\\":0,\\\"usedPercent\\\":0,\\\"sin\\\":0,\\\"sout\\\":0}}," +
+	"\\\"net\\\":{\\\"interface\\\":[{\\\"mtu\\\":65536,\\\"name\\\":\\\"lo\\\",\\\"hardwareaddr\\\":\\\"" +
+	"28:31:52:1d:c6:0a\\\",\\\"flags\\\":[\\\"up\\\",\\\"loopback\\\"],\\\"addrs\\\":[{\\\"addr\\\":\\\"" +
+	"127.0.0.1/8\\\"}]},{\\\"mtu\\\":1500,\\\"name\\\":\\\"eth0\\\",\\\"hardwareaddr\\\":\\\"52:54:00:19:" +
+	"2e:e8\\\",\\\"flags\\\":[\\\"up\\\",\\\"broadcast\\\",\\\"multicast\\\"],\\\"addrs\\\":[{\\\"addr\\\":\\" +
+	"\"127.0.0.1/24\\\"}]}],\\\"dev\\\":[{\\\"name\\\":\\\"lo\\\",\\\"speedSent\\\":0,\\\"speedRecv\\\":0,\\\"" +
+	"speedPacketsSent\\\":0,\\\"speedPacketsRecv\\\":0,\\\"bytesSent\\\":604,\\\"bytesRecv\\\":604,\\\"packet" +
+	"sSent\\\":2,\\\"packetsRecv\\\":2,\\\"errin\\\":0,\\\"errout\\\":0,\\\"dropin\\\":0,\\\"dropout\\\":0,\\\"" +
+	"fifoin\\\":0,\\\"fifoout\\\":0},{\\\"name\\\":\\\"eth0\\\",\\\"speedSent\\\":574,\\\"speedRecv\\\":214,\\" +
+	"\"speedPacketsSent\\\":3,\\\"speedPacketsRecv\\\":2,\\\"bytesSent\\\":161709123,\\\"bytesRecv\\\":285910" +
+	"298,\\\"packetsSent\\\":1116625,\\\"packetsRecv\\\":1167796,\\\"errin\\\":0,\\\"errout\\\":0,\\\"dropin\\" +
+	"\":0,\\\"dropout\\\":0,\\\"fifoin\\\":0,\\\"fifoout\\\":0}],\\\"netstat\\\":{\\\"established\\\":2,\\\"syn" +
+	"cSent\\\":1,\\\"synRecv\\\":0,\\\"finWait1\\\":0,\\\"finWait2\\\":0,\\\"timeWait\\\":0,\\\"close\\\":0,\\\"" +
+	"closeWait\\\":0,\\\"lastAck\\\":0,\\\"listen\\\":2,\\\"closing\\\":0},\\\"protocolstat\\\":[{\\\"protocol\\\"" +
+	":\\\"udp\\\",\\\"stats\\\":{\\\"inDatagrams\\\":176253,\\\"inErrors\\\":0,\\\"noPorts\\\":1,\\\"outDatagrams" +
+	"\\\":199569,\\\"rcvbufErrors\\\":0,\\\"sndbufErrors\\\":0}}]},\\\"system\\\":{\\\"info\\\":{\\\"hostname\\\"" +
+	":\\\"VM_0_31_centos\\\",\\\"uptime\\\":348315,\\\"bootTime\\\":1505463112,\\\"procs\\\":142,\\\"os\\\":\\" +
+	"\"linux\\\",\\\"platform\\\":\\\"centos\\\",\\\"platformFamily\\\":\\\"rhel\\\",\\\"platformVersion\\\":" +
+	"\\\"6.2\\\",\\\"kernelVersion\\\":\\\"2.6.32-504.30.3.el6.x86_64\\\",\\\"virtualizationSystem\\\":\\\"\\\"" +
+	",\\\"virtualizationRole\\\":\\\"\\\",\\\"hostid\\\":\\\"96D0F4CA-2157-40E6-BF22-6A7CD9B6EB8C\\\",\\\"syst" +
+	"emtype\\\":\\\"64-bit\\\"}}}}\", \"timestamp\": 1505811427, \"dtEventTime\": \"2017-09-19 16:57:07\", \"" +
+	"dtEventTimeStamp\": 1505811427000}"

--- a/src/scene_server/datacollection/collections/kafkaporter.go
+++ b/src/scene_server/datacollection/collections/kafkaporter.go
@@ -1,0 +1,290 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package collections
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"configcenter/src/common/backbone"
+	"configcenter/src/common/blog"
+
+	"github.com/Shopify/sarama"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	msgCount = 100
+)
+
+type consumerGroupHandler struct {
+	// name of this porter.
+	name string
+
+	// analyzer analyzes message from collectors.
+	analyzer Analyzer
+
+	// collectors message channels kafka topics.
+	topics []string
+
+	// metrics.
+	// receiveTotal is message received total stat.
+	receiveTotal prometheus.Counter
+
+	// receiveInvalidTotal is message received but it's not valid data total stat.
+	receiveInvalidTotal prometheus.Counter
+
+	// analyzeTotal is message analyzed total stat with target labels.
+	analyzeTotal *prometheus.CounterVec
+
+	// analyzeDuration is analyze cost duration stat.
+	analyzeDuration prometheus.Histogram
+
+	// registry is prometheus register.
+	registry prometheus.Registerer
+}
+
+// init inits a new consumerGroupHandler.
+func (c *consumerGroupHandler) init() {
+	// register metrics.
+	c.registerMetrics()
+	blog.Infof("KafkaPorter[%s]| init metrics success!", c.name)
+}
+
+// registerMetrics registers prometheus metrics.
+func (c *consumerGroupHandler) registerMetrics() {
+	c.receiveTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: fmt.Sprintf("%s_%s_receive_total", metricsNamespacePrefix, c.name),
+			Help: "total number of received message.",
+		},
+	)
+	c.registry.MustRegister(c.receiveTotal)
+
+	c.receiveInvalidTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: fmt.Sprintf("%s_%s_receive_invalid_total", metricsNamespacePrefix, c.name),
+			Help: "total number of received invalid message.",
+		},
+	)
+	c.registry.MustRegister(c.receiveInvalidTotal)
+
+	c.analyzeTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: fmt.Sprintf("%s_%s_analyze_total", metricsNamespacePrefix, c.name),
+			Help: "total number of analyzed message.",
+		},
+		[]string{"status"},
+	)
+	c.registry.MustRegister(c.analyzeTotal)
+
+	c.analyzeDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name: fmt.Sprintf("%s_%s_analyze_duration", metricsNamespacePrefix, c.name),
+			Help: "analyze duration of each batch message.",
+		},
+	)
+	c.registry.MustRegister(c.analyzeDuration)
+}
+
+// Setup is run at the beginning of a new session, before ConsumeClaim
+func (c *consumerGroupHandler) Setup(sarama.ConsumerGroupSession) error {
+	return nil
+}
+
+// Cleanup is run at the end of a session, once all ConsumeClaim goroutines have exited
+func (c *consumerGroupHandler) Cleanup(sarama.ConsumerGroupSession) error {
+	return nil
+}
+
+// ConsumeClaim consumption logic
+func (c *consumerGroupHandler) ConsumeClaim(sess sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
+	blog.Infof("KafkaPorter[%s]| start a new analyze loop now!", c.name)
+	var msgArray []string
+	// record the last message for commit
+	var lastMessage *sarama.ConsumerMessage
+	for {
+		if c.analyzer.IsSuccess() {
+			msgArray, lastMessage = c.readMessage(claim)
+		}
+
+		c.analyzer.SetSuccessFlag(true)
+
+		// open goroutine to analyse message until consumption is complete
+		var wg sync.WaitGroup
+		for _, msg := range msgArray {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := c.analyzer.Analyze(&msg); err != nil {
+					blog.Errorf("KafkaPorter[%s]| analyze message failed, %v", c.name, err)
+
+					// metrics stats for analyze failed.
+					c.analyzeTotal.WithLabelValues("failed").Inc()
+				} else {
+					// metrics stats for analyze success.
+					c.analyzeTotal.WithLabelValues("success").Inc()
+				}
+			}()
+		}
+		wg.Wait()
+
+		if !c.analyzer.IsSuccess() {
+			continue
+		}
+
+		// metrics stats for analyze duration.
+		c.analyzeDuration.Observe(time.Since(time.Now()).Seconds())
+
+		// commit offset to kafka
+		sess.MarkMessage(lastMessage, "")
+		sess.Commit()
+	}
+	return nil
+}
+
+func (c *consumerGroupHandler) readMessage(claim sarama.ConsumerGroupClaim) ([]string, *sarama.ConsumerMessage) {
+	// record the last message for commit
+	var lastMessage *sarama.ConsumerMessage
+	// the key is unique id for message, the value is message timestamp
+	timeMap := make(map[string]int64)
+	// the key is unique id for message, the value is message
+	msgMap := make(map[string]string)
+
+	startTime := time.Now()
+	// 如果 没有消息 或者 在2秒内读取的消息没超过100条，那么这两种情况会进行消息的读取操作
+	for len(msgMap) == 0 ||
+		(len(msgMap) > 0 && len(msgMap) <= msgCount && time.Now().Sub(startTime) < 2*time.Second) {
+
+		var message *sarama.ConsumerMessage
+		select {
+		case message = <-claim.Messages():
+			break
+		case <-time.After(2 * time.Second):
+			break
+		}
+
+		if message == nil {
+			continue
+		}
+
+		// metrics stats for message receiving.
+		c.receiveTotal.Inc()
+
+		if message.Value == nil {
+			blog.Errorf("KafkaPorter[%s]| receive a message with empty value!", c.name)
+
+			// metrics stats for invalid message.
+			c.receiveInvalidTotal.Inc()
+			continue
+		}
+
+		val := gjson.Parse(string(message.Value))
+		cloudID := val.Get("cloudid").String()
+		ip := val.Get("ip").String()
+		uniqueKey := cloudID + ":" + ip
+		timestamp := val.Get("data.timestamp").Int()
+		oldTimestamp, exist := timeMap[uniqueKey]
+		if exist && oldTimestamp > timestamp {
+			continue
+		}
+
+		delete(msgMap, uniqueKey)
+		msgMap[uniqueKey] = string(message.Value)
+		timeMap[uniqueKey] = timestamp
+
+		lastMessage = message
+	}
+	var msgArray []string
+	for _, msg := range msgMap {
+		msgArray = append(msgArray, msg)
+	}
+	return msgArray, lastMessage
+}
+
+type KafkaPorter struct {
+	engine *backbone.Engine
+
+	// name of this porter.
+	name string
+
+	// collectors message channels kafka topics.
+	topics []string
+
+	// analyzer analyzes message from collectors.
+	analyzer Analyzer
+
+	ctx context.Context
+
+	// consumerGroupHandler consumer group handle
+	consumerGroupHandler sarama.ConsumerGroupHandler
+
+	// consumerGroup consumer group
+	consumerGroup sarama.ConsumerGroup
+}
+
+// NewKafkaPorter new kafka porter
+func NewKafkaPorter(name string, engine *backbone.Engine, ctx context.Context, analyzer Analyzer,
+	consumerGroup sarama.ConsumerGroup, topics []string, registry prometheus.Registerer) *KafkaPorter {
+	consumerGroupHandler := &consumerGroupHandler{
+		name:     name,
+		analyzer: analyzer,
+		topics:   topics,
+		registry: registry,
+	}
+	consumerGroupHandler.init()
+	return &KafkaPorter{
+		name:                 name,
+		engine:               engine,
+		analyzer:             analyzer,
+		topics:               topics,
+		ctx:                  ctx,
+		consumerGroupHandler: consumerGroupHandler,
+		consumerGroup:        consumerGroup,
+	}
+}
+
+// Name porter name
+func (k *KafkaPorter) Name() string {
+	return k.name
+}
+
+// Run run porter
+func (k *KafkaPorter) Run() error {
+	for {
+		// `Consume` should be called inside an infinite loop, when a
+		// server-side rebalance happens, the consumer session will need to be
+		// recreated to get the new claims
+		err := k.consumerGroup.Consume(k.ctx, k.topics, k.consumerGroupHandler)
+		if err != nil {
+			blog.Errorf("KafkaPorter[%s]| have a error, err: %v", k.name, err)
+		}
+		// check if context was cancelled, signaling that the consumer should stop
+		if k.ctx.Err() != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Mock mock analyzer
+func (k *KafkaPorter) Mock() error {
+	mock := k.analyzer.Mock()
+	if err := k.analyzer.Analyze(&mock); err != nil {
+		return fmt.Errorf("mock failed, %+v", err)
+	}
+	return nil
+}

--- a/src/scene_server/datacollection/collections/kafkaporter.go
+++ b/src/scene_server/datacollection/collections/kafkaporter.go
@@ -215,6 +215,7 @@ func (c *consumerGroupHandler) readMessage(claim sarama.ConsumerGroupClaim) ([]s
 	return msgArray, lastMessage
 }
 
+// KafkaPorter is a porter to handle message from kafka.
 type KafkaPorter struct {
 	engine *backbone.Engine
 

--- a/src/scene_server/datacollection/collections/middleware/discover.go
+++ b/src/scene_server/datacollection/collections/middleware/discover.go
@@ -34,7 +34,9 @@ type Discover struct {
 
 var msgHandlerCnt = int64(0)
 
-func NewDiscover(ctx context.Context, redisCli redis.Client, backbone *backbone.Engine, authManager *extensions.AuthManager) *Discover {
+// NewDiscover new discover
+func NewDiscover(ctx context.Context, redisCli redis.Client, backbone *backbone.Engine,
+	authManager *extensions.AuthManager) *Discover {
 	header := http.Header{}
 	header.Add(bkc.BKHTTPOwnerID, bkc.BKDefaultOwnerID)
 	header.Add(bkc.BKHTTPHeaderUser, bkc.CCSystemCollectorUserName)
@@ -47,6 +49,16 @@ func NewDiscover(ctx context.Context, redisCli redis.Client, backbone *backbone.
 	}
 	discover.Engine = backbone
 	return discover
+}
+
+// IsSuccess judge whether the message is processed successfully.
+func (d *Discover) IsSuccess() bool {
+	return false
+}
+
+// SetSuccessFlag set success flag
+func (d *Discover) SetSuccessFlag(success bool) {
+	// todo
 }
 
 // Hash returns hash value base on message.
@@ -68,6 +80,7 @@ func (d *Discover) Mock() string {
 	return MockMessage
 }
 
+// Analyze analyze discover data
 func (d *Discover) Analyze(msg *string) error {
 	err := d.UpdateOrCreateInst(msg)
 	if err != nil {

--- a/src/scene_server/datacollection/collections/middleware/discover.go
+++ b/src/scene_server/datacollection/collections/middleware/discover.go
@@ -51,16 +51,6 @@ func NewDiscover(ctx context.Context, redisCli redis.Client, backbone *backbone.
 	return discover
 }
 
-// IsSuccess judge whether the message is processed successfully.
-func (d *Discover) IsSuccess() bool {
-	return false
-}
-
-// SetSuccessFlag set success flag
-func (d *Discover) SetSuccessFlag(success bool) {
-	// todo
-}
-
 // Hash returns hash value base on message.
 func (d *Discover) Hash(cloudid, ip string) (string, error) {
 	if len(cloudid) == 0 {
@@ -81,12 +71,12 @@ func (d *Discover) Mock() string {
 }
 
 // Analyze analyze discover data
-func (d *Discover) Analyze(msg *string) error {
+func (d *Discover) Analyze(msg *string) (bool, error) {
 	err := d.UpdateOrCreateInst(msg)
 	if err != nil {
-		return fmt.Errorf("create inst err: %v, raw: %s", err, msg)
+		return false, fmt.Errorf("create inst err: %v, raw: %s", err, msg)
 	}
-	return nil
+	return false, nil
 }
 
 var MockMessage = `{

--- a/src/scene_server/datacollection/collections/netcollect/netdevice.go
+++ b/src/scene_server/datacollection/collections/netcollect/netdevice.go
@@ -42,6 +42,16 @@ func NewNetCollect(ctx context.Context, db dal.RDB, authManager *extensions.Auth
 	return h
 }
 
+// IsSuccess judge whether the message is processed successfully.
+func (h *NetCollect) IsSuccess() bool {
+	return false
+}
+
+// SetSuccessFlag set success flag
+func (h *NetCollect) SetSuccessFlag(success bool) {
+	// todo
+}
+
 // Hash returns hash value base on message.
 func (h *NetCollect) Hash(cloudid, ip string) (string, error) {
 	if len(cloudid) == 0 {

--- a/src/scene_server/datacollection/collections/netcollect/netdevice.go
+++ b/src/scene_server/datacollection/collections/netcollect/netdevice.go
@@ -42,16 +42,6 @@ func NewNetCollect(ctx context.Context, db dal.RDB, authManager *extensions.Auth
 	return h
 }
 
-// IsSuccess judge whether the message is processed successfully.
-func (h *NetCollect) IsSuccess() bool {
-	return false
-}
-
-// SetSuccessFlag set success flag
-func (h *NetCollect) SetSuccessFlag(success bool) {
-	// todo
-}
-
 // Hash returns hash value base on message.
 func (h *NetCollect) Hash(cloudid, ip string) (string, error) {
 	if len(cloudid) == 0 {
@@ -72,15 +62,15 @@ func (h *NetCollect) Mock() string {
 }
 
 // Analyze implements the Analyzer interface
-func (h *NetCollect) Analyze(msg *string) error {
+func (h *NetCollect) Analyze(msg *string) (bool, error) {
 	if msg == nil {
-		return fmt.Errorf("message nil")
+		return false, fmt.Errorf("message nil")
 	}
 
 	data := ReportMessage{}
 
 	if err := json.Unmarshal([]byte(*msg), &data); err != nil {
-		return fmt.Errorf("unmarshal message error: %+v", err)
+		return false, fmt.Errorf("unmarshal message error: %+v", err)
 	}
 
 	for _, report := range data.Data {
@@ -89,7 +79,7 @@ func (h *NetCollect) Analyze(msg *string) error {
 		}
 	}
 
-	return nil
+	return false, nil
 }
 
 func (h *NetCollect) handleReport(report *metadata.NetcollectReport) (err error) {

--- a/src/scene_server/datacollection/collections/porter.go
+++ b/src/scene_server/datacollection/collections/porter.go
@@ -239,7 +239,7 @@ func (p *SimplePorter) analyzeLoop() {
 		cost := time.Now()
 
 		// analyze message from collectors.
-		if err := p.analyzer.Analyze(msg); err != nil {
+		if _, err := p.analyzer.Analyze(msg); err != nil {
 			blog.Errorf("SimplePorter[%s]| analyze message failed, %+v", p.name, err)
 
 			// metrics stats for analyze failed.

--- a/src/scene_server/datacollection/collections/types.go
+++ b/src/scene_server/datacollection/collections/types.go
@@ -22,6 +22,12 @@ type Analyzer interface {
 
 	// Mock returns mock message that could be analyzed by the Analyzer.
 	Mock() string
+
+	// IsSuccess judge whether the message is processed successfully.
+	IsSuccess() bool
+
+	// SetSuccessFlag set success flag
+	SetSuccessFlag(success bool)
 }
 
 // Porter is common porter interface. It handles

--- a/src/scene_server/datacollection/collections/types.go
+++ b/src/scene_server/datacollection/collections/types.go
@@ -15,19 +15,13 @@ package collections
 // Analyzer is common collection analyzer interface.
 type Analyzer interface {
 	// Analyze analyzes message from collectors.
-	Analyze(message *string) error
+	Analyze(message *string) (bool, error)
 
 	// Hash returns a hash value of the input message string.
 	Hash(cloudid, ip string) (string, error)
 
 	// Mock returns mock message that could be analyzed by the Analyzer.
 	Mock() string
-
-	// IsSuccess judge whether the message is processed successfully.
-	IsSuccess() bool
-
-	// SetSuccessFlag set success flag
-	SetSuccessFlag(success bool)
 }
 
 // Porter is common porter interface. It handles

--- a/src/storage/dal/kafka/config.go
+++ b/src/storage/dal/kafka/config.go
@@ -12,6 +12,8 @@
 
 package kafka
 
+import "errors"
+
 // Config kafka config
 type Config struct {
 	Brokers   []string
@@ -20,4 +22,20 @@ type Config struct {
 	Partition int64
 	User      string
 	Password  string
+}
+
+// Check check kafka config
+func (c *Config) Check() error {
+	if c.Brokers == nil || len(c.Brokers) == 0 {
+		return errors.New("can not find kafka brokers config")
+	}
+
+	if c.GroupID == "" {
+		return errors.New("can not find kafka groupID config")
+	}
+
+	if c.Partition == 0 {
+		return errors.New("can not find kafka partition config or value cannot be set to 0")
+	}
+	return nil
 }

--- a/src/storage/dal/kafka/config.go
+++ b/src/storage/dal/kafka/config.go
@@ -1,0 +1,23 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka
+
+// Config kafka config
+type Config struct {
+	Brokers   []string
+	GroupID   string
+	Topic     string
+	Partition int64
+	User      string
+	Password  string
+}

--- a/src/storage/dal/kafka/scram.go
+++ b/src/storage/dal/kafka/scram.go
@@ -1,0 +1,51 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"github.com/xdg-go/scram"
+)
+
+var (
+	SHA256 scram.HashGeneratorFcn = sha256.New
+	SHA512 scram.HashGeneratorFcn = sha512.New
+)
+
+type XDGSCRAMClient struct {
+	*scram.Client
+	*scram.ClientConversation
+	scram.HashGeneratorFcn
+}
+
+// Begin
+func (x *XDGSCRAMClient) Begin(userName, password, authzID string) (err error) {
+	x.Client, err = x.HashGeneratorFcn.NewClient(userName, password, authzID)
+	if err != nil {
+		return err
+	}
+	x.ClientConversation = x.Client.NewConversation()
+	return nil
+}
+
+// Step
+func (x *XDGSCRAMClient) Step(challenge string) (response string, err error) {
+	response, err = x.ClientConversation.Step(challenge)
+	return
+}
+
+// Done
+func (x *XDGSCRAMClient) Done() bool {
+	return x.ClientConversation.Done()
+}

--- a/src/storage/dal/kafka/scram.go
+++ b/src/storage/dal/kafka/scram.go
@@ -23,6 +23,7 @@ var (
 	SHA512 scram.HashGeneratorFcn = sha512.New
 )
 
+// XDGSCRAMClient
 type XDGSCRAMClient struct {
 	*scram.Client
 	*scram.ClientConversation

--- a/src/storage/dal/kafka/scram.go
+++ b/src/storage/dal/kafka/scram.go
@@ -13,24 +13,21 @@
 package kafka
 
 import (
-	"crypto/sha256"
 	"crypto/sha512"
+
 	"github.com/xdg-go/scram"
 )
 
-var (
-	SHA256 scram.HashGeneratorFcn = sha256.New
-	SHA512 scram.HashGeneratorFcn = sha512.New
-)
+var SHA512 scram.HashGeneratorFcn = sha512.New
 
-// XDGSCRAMClient
+// XDGSCRAMClient is a SCRAM client.
 type XDGSCRAMClient struct {
 	*scram.Client
 	*scram.ClientConversation
 	scram.HashGeneratorFcn
 }
 
-// Begin
+// Begin prepares the client for the SCRAM exchange with the server with a user name and a password.
 func (x *XDGSCRAMClient) Begin(userName, password, authzID string) (err error) {
 	x.Client, err = x.HashGeneratorFcn.NewClient(userName, password, authzID)
 	if err != nil {
@@ -40,13 +37,13 @@ func (x *XDGSCRAMClient) Begin(userName, password, authzID string) (err error) {
 	return nil
 }
 
-// Step
+// Step steps client through the SCRAM exchange.
 func (x *XDGSCRAMClient) Step(challenge string) (response string, err error) {
 	response, err = x.ClientConversation.Step(challenge)
 	return
 }
 
-// Done
+// Done should return true when the SCRAM conversation is over.
 func (x *XDGSCRAMClient) Done() bool {
 	return x.ClientConversation.Done()
 }


### PR DESCRIPTION
### 新加的功能:
- 对于新插件上报的数据，默认使用kafka，也可选redis，可配置
