### PR TITLE
初始化的snapshot_biz_name必须是蓝鲸

### DIFF
--- a/src/common/metadata/configadmin.go
+++ b/src/common/metadata/configadmin.go
@@ -199,7 +199,7 @@ var InitAdminConfig = `
 {
     "backend":{
         "max_biz_topo_level":7,
-        "snapshot_biz_name":"BlueKing"
+        "snapshot_biz_name":"蓝鲸"
     },
     "site":{
          "name":{


### PR DESCRIPTION

### 修复的问题：
- 修复datacollection启动时读取默认业务失败
