### PR TITLE
bugfix 导入excel数量超限返回正确的报错

### DIFF
--- a/src/web_server/logics/inst.go
+++ b/src/web_server/logics/inst.go
@@ -119,7 +119,7 @@ func (lgc *Logics) importInsts(ctx context.Context, f *xlsx.File, objID string, 
 	insts, errMsg, err := lgc.GetImportInsts(ctx, f, objID, header, 0, true, defLang, modelBizID)
 	if err != nil {
 		blog.Errorf("get %s inst info from excel error, err: %v, rid: %s", objID, err, rid)
-		return
+		return resultData, common.CCErrWebFileContentFail, err
 	}
 	if len(errMsg) != 0 {
 		resultData.Set("err", errMsg)


### PR DESCRIPTION
### 修复的问题：
- 导入excel数量超限返回正确的报错

close #5833 