### PR TITLE
3.10禁止创建bk打头的模型，用于后续创建内置模型，避免冲突

### DIFF
--- a/src/common/util/valid.go
+++ b/src/common/util/valid.go
@@ -314,6 +314,10 @@ func ValidModelIDField(value interface{}, field string, errProxy errors.DefaultC
 	if !match {
 		return errProxy.Errorf(common.CCErrCommParamsIsInvalid, field)
 	}
+
+	if strings.HasPrefix(strValue, "bk") {
+		return errProxy.Errorf(common.CCErrCommParamsIsInvalid, "bk_obj_id value can not start with bk")
+	}
 	return nil
 }
 


### PR DESCRIPTION
### 优化的功能:
- 禁止创建bk打头的模型，用于后续创建内置模型，避免冲突
