### PR TITLE
新增支持更新basereport老版本data id的到gse的接口

### DIFF
--- a/src/scene_server/admin_server/service/dataid.go
+++ b/src/scene_server/admin_server/service/dataid.go
@@ -55,54 +55,27 @@ func (s *Service) migrateDataID(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
-	// get stream to config by db id from gse, if not found, register it, else update it
-	streamTo, err := s.generateGseConfigStreamTo(header, user, defErr, rid)
+	// upsert stream to config to gse
+	streamToID, err := s.UpsertGseConfigStreamTo(header, user, defErr, rid)
 	if err != nil {
 		_ = resp.WriteError(http.StatusOK, err)
 		return
 	}
 
-	streamToID, streamTos, err := s.gseConfigQueryStreamTo(header, user, defErr, rid)
+	// upsert config channel to gse
+	channel, err := s.generateGseConfigChannel(streamToID, s.Config.SnapDataID, rid)
 	if err != nil {
 		_ = resp.WriteError(http.StatusOK, err)
 		return
 	}
 
-	if len(streamTos) == 0 {
-		if streamToID, err = s.gseConfigAddStreamTo(streamTo, header, user, defErr, rid); err != nil {
-			_ = resp.WriteError(http.StatusOK, err)
-			return
-		}
-	} else if len(streamTos) != 1 {
-		blog.ErrorJSON("get multiple stream to(%s), rid: %s", streamTos, rid)
-		result := &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommParamsInvalid, "stream to id")}
-		_ = resp.WriteError(http.StatusOK, result)
-		return
-	} else {
-		if !reflect.DeepEqual(streamTos[0].StreamTo, *streamTo) {
-			if err := s.gseConfigUpdateStreamTo(streamTo, streamToID, header, user, defErr, rid); err != nil {
-				_ = resp.WriteError(http.StatusOK, err)
-				return
-			}
-		}
-	}
-
-	// get already registered channel by host snap data id from gse, if not found, register it, else update it
-	channel, err := s.generateGseConfigChannel(streamToID, header, user, defErr, rid)
+	channels, exists, err := s.gseConfigQueryRoute(header, user, defErr, rid)
 	if err != nil {
-		_ = resp.WriteError(http.StatusOK, err)
-		return
-	}
-
-	channels, err := s.gseConfigQueryRoute(header, user, defErr, rid)
-	if err != nil {
+		// gse returns a common error for not exist case before ee1.7.18/ce3.6.18, so we ignore it for compatibility
 		blog.Errorf("query gse channel failed, ** skip this error for not exist case **, err: %v, rid: %s", err, rid)
-		// TODO clarify this error when gse returns a specified error code
-		// _ = resp.WriteError(http.StatusOK, err)
-		// return
 	}
 
-	if len(channels) == 0 {
+	if !exists {
 		if err := s.gseConfigAddRoute(channel, header, user, defErr, rid); err != nil {
 			_ = resp.WriteError(http.StatusOK, err)
 			return
@@ -122,6 +95,113 @@ func (s *Service) migrateDataID(req *restful.Request, resp *restful.Response) {
 	}
 
 	_ = resp.WriteEntity(metadata.NewSuccessResp(nil))
+}
+
+// migrateOldDataID migrate old version data id, register it when it is not exist
+func (s *Service) migrateOldDataID(req *restful.Request, resp *restful.Response) {
+	header := req.Request.Header
+	rid := util.GetHTTPCCRequestID(header)
+	user := util.GetUser(header)
+	defErr := s.CCErr.CreateDefaultCCErrorIf(util.GetLanguage(header))
+
+	if err := s.migrateOldVersionDataID(header, user, defErr, rid); err != nil {
+		_ = resp.WriteError(http.StatusOK, err)
+		return
+	}
+
+	_ = resp.WriteEntity(metadata.NewSuccessResp(nil))
+}
+
+// migrateOldVersionDataID old version data id is registered using script with gse version < 3.1, but new version of gse
+// only allows registering data id by http interface, and the script can not be used, so we need to compensate by
+// registering it in cc if it is not already registered before by script in the former version
+func (s *Service) migrateOldVersionDataID(header http.Header, user string, defErr errors.DefaultCCErrorIf,
+	rid string) error {
+
+	const oldDataID = 1001
+
+	// get already registered channel by host snap data id from gse, if not found, register it with its stream to
+	commonOperation := metadata.GseConfigOperation{
+		OperatorName: user,
+	}
+	queryParams := &metadata.GseConfigQueryRouteParams{
+		Condition: metadata.GseConfigRouteCondition{
+			ChannelID: oldDataID,
+		},
+		Operation: commonOperation,
+	}
+
+	channels, isDataIDExists, err := esb.EsbClient().GseSrv().ConfigQueryRoute(s.ctx, header, queryParams)
+	if err != nil {
+		// gse returns a common error for not exist case before ee1.7.18/ce3.6.18, so we ignore it for compatibility
+		blog.Errorf("query gse channel failed, ** skip this error for not exist case **, err: %v, rid: %s", err, rid)
+	}
+
+	// if old data id has channels, we need to check if they are registered by cc or by other system like bk-monitor
+	var existsPlatName metadata.GseConfigPlatName
+	if isDataIDExists {
+		bizID, err := s.getSnapBizID(rid)
+		if err != nil {
+			return err
+		}
+
+		// check if channel name is snapshot+snap biz id to confirm if it is registered by cc, skip in this situation
+		for _, channel := range channels {
+			existsPlatName = channel.Metadata.PlatName
+			for _, route := range channel.Route {
+				if route.StreamTo.Redis == nil {
+					continue
+				}
+				if route.StreamTo.Redis.ChannelName == fmt.Sprintf("snapshot%d", bizID) ||
+					(route.StreamTo.Redis.BizID == bizID && route.StreamTo.Redis.DataSet == "snapshot") {
+					blog.Infof("old gse data id is already exist, skip registering it, rid: %s", rid)
+					return nil
+				}
+			}
+		}
+	}
+
+	// old stream to and channel is the same with the new one except for the data id, generate in the same way
+	streamToID, err := s.UpsertGseConfigStreamTo(header, user, defErr, rid)
+	if err != nil {
+		return err
+	}
+
+	oldChannel, err := s.generateGseConfigChannel(streamToID, oldDataID, rid)
+	if err != nil {
+		blog.Errorf("generate gse channel failed, err: %v, stream to id: %d, rid: %s", err, streamToID, rid)
+		return err
+	}
+
+	// update the exist data id's corresponding channel, add the route to it
+	if isDataIDExists {
+		params := &metadata.GseConfigUpdateRouteParams{
+			Condition: metadata.GseConfigRouteCondition{
+				ChannelID: oldDataID,
+				PlatName:  existsPlatName,
+			},
+			Operation: metadata.GseConfigOperation{
+				OperatorName: user,
+			},
+			Specification: metadata.GseConfigUpdateRouteSpecification{
+				Route:         oldChannel.Route,
+				StreamFilters: oldChannel.StreamFilters,
+			},
+		}
+
+		err := esb.EsbClient().GseSrv().ConfigUpdateRoute(s.ctx, header, params)
+		if err != nil {
+			blog.Errorf("update old data id route to gse failed, err: %v, params: %#v, rid: %s", err, params, rid)
+			return &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommMigrateFailed, err.Error())}
+		}
+	} else {
+		if err := s.gseConfigAddRoute(oldChannel, header, user, defErr, rid); err != nil {
+			blog.Errorf("add route to gse failed, err: %v, channel: %v, rid: %s", err, oldChannel, rid)
+			return err
+		}
+	}
+
+	return nil
 }
 
 // generateGseConfigStreamTo generate host snap stream to config by snap redis config
@@ -263,51 +343,60 @@ func (s *Service) gseConfigUpdateStreamTo(streamTo *metadata.GseConfigStreamTo, 
 	return nil
 }
 
-// generateGseConfigStreamTo generate host snap stream to config by snap redis config
-func (s *Service) generateGseConfigChannel(streamToID int64, header http.Header, user string,
-	defErr errors.DefaultCCErrorIf, rid string) (*metadata.GseConfigChannel, error) {
-
-	if snapChannel != nil {
-		return snapChannel, nil
-	}
-
+// getSnapBizID get the biz id that host snap uses
+func (s *Service) getSnapBizID(rid string) (int64, error) {
 	cfgCond := map[string]interface{}{
 		"_id": common.ConfigAdminID,
 	}
 	cfg := make(map[string]string)
 	err := s.db.Table(common.BKTableNameSystem).Find(cfgCond).Fields(common.ConfigAdminValueField).One(s.ctx, &cfg)
 	if nil != err {
-		blog.Errorf("get config admin failed, err: %v", err)
-		return nil, err
+		blog.Errorf("get config admin failed, err: %v, rid: %s", err, rid)
+		return 0, err
 	}
 
 	configAdmin := new(metadata.ConfigAdmin)
 	if err := json.Unmarshal([]byte(cfg[common.ConfigAdminValueField]), configAdmin); err != nil {
-		blog.Errorf("unmarshal config admin failed, err: %v, config: %s", err, cfg[common.ConfigAdminValueField])
-		return nil, err
+		blog.Errorf("unmarshal config admin(%s) failed, err: %v, rid: %s", cfg[common.ConfigAdminValueField], err, rid)
+		return 0, err
 	}
 
 	bizCond := map[string]interface{}{common.BKAppNameField: configAdmin.Backend.SnapshotBizName}
 	biz := new(metadata.BizBasicInfo)
 	if err := s.db.Table(common.BKTableNameBaseApp).Find(bizCond).One(s.ctx, biz); err != nil {
-		blog.Errorf("get snap biz failed, err: %v, biz name: %s", err, configAdmin.Backend.SnapshotBizName)
+		blog.Errorf("get snap biz by name(%s) failed, err: %v, rid: %s", configAdmin.Backend.SnapshotBizName, err, rid)
+		return 0, err
+	}
+
+	return biz.BizID, nil
+}
+
+// generateGseConfigStreamTo generate host snap stream to config by snap redis config
+func (s *Service) generateGseConfigChannel(streamToID, dataID int64, rid string) (*metadata.GseConfigChannel, error) {
+
+	if snapChannel != nil {
+		return snapChannel, nil
+	}
+
+	bizID, err := s.getSnapBizID(rid)
+	if err != nil {
 		return nil, err
 	}
 
 	snapChannel = &metadata.GseConfigChannel{
 		Metadata: metadata.GseConfigAddRouteMetadata{
 			PlatName:  metadata.GseConfigPlatBkmonitor,
-			ChannelID: s.Config.SnapDataID,
+			ChannelID: dataID,
 		},
 		Route: []metadata.GseConfigRoute{{
 			Name: snapRouteName,
 			StreamTo: metadata.GseConfigRouteStreamTo{
 				StreamToID: streamToID,
 				Redis: &metadata.GseConfigRouteRedis{
-					ChannelName: fmt.Sprintf("snapshot%d", biz.BizID),
+					ChannelName: fmt.Sprintf("snapshot%d", bizID),
 					// compatible for the older version of gse that uses DataSet+BizID as channel name
 					DataSet: "snapshot",
-					BizID:   biz.BizID,
+					BizID:   bizID,
 				},
 			},
 		}},
@@ -317,7 +406,7 @@ func (s *Service) generateGseConfigChannel(streamToID int64, header http.Header,
 
 // gseConfigQueryRoute get channel by host snap data id from gse
 func (s *Service) gseConfigQueryRoute(header http.Header, user string, defErr errors.DefaultCCErrorIf, rid string) (
-	[]metadata.GseConfigChannel, error) {
+	[]metadata.GseConfigChannel, bool, error) {
 
 	commonOperation := metadata.GseConfigOperation{
 		OperatorName: user,
@@ -330,13 +419,13 @@ func (s *Service) gseConfigQueryRoute(header http.Header, user string, defErr er
 		Operation: commonOperation,
 	}
 
-	channels, err := esb.EsbClient().GseSrv().ConfigQueryRoute(s.ctx, header, params)
+	channels, exists, err := esb.EsbClient().GseSrv().ConfigQueryRoute(s.ctx, header, params)
 	if err != nil {
 		blog.ErrorJSON("query route from gse failed, err: %s, params: %s, rid: %s", err, params, rid)
-		return nil, &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommMigrateFailed, err.Error())}
+		return nil, false, &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommMigrateFailed, err.Error())}
 	}
 
-	return channels, nil
+	return channels, exists, nil
 }
 
 // gseConfigAddRoute add host snap channel to gse
@@ -383,4 +472,35 @@ func (s *Service) gseConfigUpdateRoute(channel *metadata.GseConfigChannel, heade
 		return &metadata.RespError{Msg: defErr.CCErrorf(common.CCErrCommMigrateFailed, err.Error())}
 	}
 	return nil
+}
+
+// UpsertGseConfigStreamTo get stream to config by db id from gse, if not found, register it, else update it
+func (s *Service) UpsertGseConfigStreamTo(header http.Header, user string, defErr errors.DefaultCCErrorIf,
+	rid string) (int64, error) {
+
+	streamTo, err := s.generateGseConfigStreamTo(header, user, defErr, rid)
+	if err != nil {
+		return 0, err
+	}
+
+	streamToID, streamTos, err := s.gseConfigQueryStreamTo(header, user, defErr, rid)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(streamTos) == 0 {
+		if streamToID, err = s.gseConfigAddStreamTo(streamTo, header, user, defErr, rid); err != nil {
+			return 0, err
+		}
+	} else if len(streamTos) != 1 {
+		blog.ErrorJSON("get multiple stream to(%s), rid: %s", streamTos, rid)
+		return 0, defErr.CCErrorf(common.CCErrCommParamsInvalid, "stream to id")
+	} else {
+		if !reflect.DeepEqual(streamTos[0].StreamTo, *streamTo) {
+			if err := s.gseConfigUpdateStreamTo(streamTo, streamToID, header, user, defErr, rid); err != nil {
+				return 0, err
+			}
+		}
+	}
+	return streamToID, nil
 }

--- a/src/scene_server/admin_server/service/service.go
+++ b/src/scene_server/admin_server/service/service.go
@@ -90,6 +90,7 @@ func (s *Service) WebService() *restful.Container {
 	api.Route(api.POST("/migrate/specify/version/{distribution}/{ownerID}").To(s.migrateSpecifyVersion))
 	api.Route(api.POST("/migrate/config/refresh").To(s.refreshConfig))
 	api.Route(api.POST("/migrate/dataid").To(s.migrateDataID))
+	api.Route(api.POST("/migrate/old/dataid").To(s.migrateOldDataID))
 	api.Route(api.POST("/delete/auditlog").To(s.DeleteAuditLog))
 
 	container.Add(api)

--- a/src/thirdparty/esbserver/gse/api.go
+++ b/src/thirdparty/esbserver/gse/api.go
@@ -296,7 +296,7 @@ func (p *gse) ConfigDeleteRoute(ctx context.Context, h http.Header, data *metada
 }
 
 func (p *gse) ConfigQueryRoute(ctx context.Context, h http.Header, data *metadata.GseConfigQueryRouteParams) (
-	[]metadata.GseConfigChannel, error) {
+	[]metadata.GseConfigChannel, bool, error) {
 
 	resp := new(metadata.GseConfigQueryRouteResp)
 	subPath := "/v2/gse/config_query_route/"
@@ -314,10 +314,16 @@ func (p *gse) ConfigQueryRoute(ctx context.Context, h http.Header, data *metadat
 		Into(resp)
 
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
+
+	// 14001 is a special error code for route not exists
+	if resp.Code == 14001 {
+		return nil, false, nil
+	}
+
 	if !resp.Result || resp.Code != 0 {
-		return nil, fmt.Errorf("gse config query route failed, code: %d, message: %s", resp.Code, resp.Message)
+		return nil, false, fmt.Errorf("gse config query route failed, code: %d, message: %s", resp.Code, resp.Message)
 	}
-	return resp.Data, nil
+	return resp.Data, true, nil
 }

--- a/src/thirdparty/esbserver/gse/esbserv.go
+++ b/src/thirdparty/esbserver/gse/esbserv.go
@@ -37,7 +37,7 @@ type GseClientInterface interface {
 	ConfigUpdateRoute(ctx context.Context, h http.Header, data *metadata.GseConfigUpdateRouteParams) error
 	ConfigDeleteRoute(ctx context.Context, h http.Header, data *metadata.GseConfigDeleteRouteParams) error
 	ConfigQueryRoute(ctx context.Context, h http.Header, data *metadata.GseConfigQueryRouteParams) (
-		[]metadata.GseConfigChannel, error)
+		[]metadata.GseConfigChannel, bool, error)
 }
 
 func NewGsecClientInterface(client rest.ClientInterface, config *esbutil.EsbConfigSrv) GseClientInterface {


### PR DESCRIPTION
3.1版本之后的gse不支持之前的用脚本注册dataid的方式，所以cc添加一段兼容逻辑在没有旧版本的dataid的情况下调用gse接口进行注册

注册旧版本dataID的接口的调用方式：curl -X POST -H 'Content-Type:application/json' -H 'BK_USER:migrate' -H 'HTTP_BLUEKING_SUPPLIER_ID:0' http://环境上的adminserver的ip:port地址/migrate/v3/migrate/old/dataid

**注意：

1. 本次调整了新老dataid判断是否已注册的方式，使用gse的错误码14001进行判断，该错误码在gse的ee1.7.18、 ce3.6.18中支持，合入该PR后的cc向此版本以下的gse注册会失败报错**

2. 要求用户在全新部署cmdbv3.9+时，需要调用该接口注册basereport的data id，否则无法正常采集主机的静态快照数据。
