### PR TITLE
不允许用户创建bk开头的分组id 

### DIFF
--- a/src/source_controller/coreservice/core/model/classification.go
+++ b/src/source_controller/coreservice/core/model/classification.go
@@ -13,6 +13,8 @@
 package model
 
 import (
+	"strings"
+
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/errors"
@@ -32,6 +34,14 @@ func (m *modelClassification) CreateOneModelClassification(kit *rest.Kit, inputP
 	if 0 == len(inputParam.Data.ClassificationID) {
 		blog.Errorf("request(%s): it is failed to create the model classification, because of the classificationID (%#v) is not set", kit.Rid, inputParam.Data)
 		return &metadata.CreateOneDataResult{}, kit.CCError.Errorf(common.CCErrCommParamsNeedSet, metadata.ClassFieldClassificationID)
+	}
+
+	// It is forbidden to create a model group starting with bk or BK, to prevent the subsequent creation of built-in
+	// model group conflicts. Note that the upper topo server has this id check, which is used here as a bottom line to
+	// prevent direct calls to core service without interception.
+	if strings.HasPrefix(strings.ToLower(inputParam.Data.ClassificationID), "bk") {
+		return &metadata.CreateOneDataResult{}, kit.CCError.Errorf(common.CCErrCommParamsIsInvalid,
+			"bk_classification_id can not start with bk or BK")
 	}
 
 	_, exists, err := m.isExists(kit, inputParam.Data.ClassificationID)


### PR DESCRIPTION
### 优化的功能:
- 用户在新建模型分组时，不允许bk开头 close #5956
