### PR TITLE
feature 查询主机对应模块的模板id过滤模板id为0的模块

### DIFF
--- a/src/scene_server/host_server/logics/host.go
+++ b/src/scene_server/host_server/logics/host.go
@@ -1652,6 +1652,9 @@ func (lgc *Logics) ListServiceTemplateHostIDMap(kit *rest.Kit, ids []int64) ([]m
 				fmt.Sprintf("module[%d]'s service_template_id is invalid", item.ModuleID))
 		}
 
+		if moduleSvTmp[item.ModuleID] == 0 {
+			continue
+		}
 		hostSvTmp[item.HostID] = append(hostSvTmp[item.HostID], moduleSvTmp[item.ModuleID])
 	}
 


### PR DESCRIPTION
### 优化的功能:
- 查询主机对应模块的模板id过滤模板id为0的模块
close #5959 #5905
