### PR TITLE
3.10升级调整

### DIFF
--- a/src/source_controller/coreservice/core/model/model.go
+++ b/src/source_controller/coreservice/core/model/model.go
@@ -83,7 +83,9 @@ func (m *modelManager) CreateModel(kit *rest.Kit, inputParam metadata.CreateMode
 		return nil, err
 	}
 
-	if !SatisfyMongoCollLimit(inputParam.Spec.ObjectID) {
+	// 因为模型名称会用于生成实例和实例关联的mongodb表名，所以需要校验模型对应的实例表和实例关联表名均不超过mongodb的长度限制
+	if !SatisfyMongoCollLimit(common.GetObjectInstTableName(inputParam.Spec.ObjectID, kit.SupplierAccount)) ||
+		!SatisfyMongoCollLimit(common.GetObjectInstAsstTableName(inputParam.Spec.ObjectID, kit.SupplierAccount)) {
 		blog.Errorf("inputParam.Spec.ObjectID:%s not SatisfyMongoCollLimit", inputParam.Spec.ObjectID)
 		return nil, kit.CCError.Errorf(common.CCErrCommParamsIsInvalid, metadata.ModelFieldObjectID)
 	}


### PR DESCRIPTION
### 优化的功能:
- 3.10判断模型长度是否超过mongo限制时，按照生成的模型实例和关联的表名进行判断
- 升级时迁移实例权限时跳过cc中没有的模型和实例