### PR TITLE
3.10测试问题修复

### DIFF
--- a/src/ac/iam/iam.go
+++ b/src/ac/iam/iam.go
@@ -323,7 +323,7 @@ func (i IAM) SyncIAMSysInstances(ctx context.Context, objects []metadata.Object)
 	for _, obj := range objects {
 		if obj.ID == 0 || len(obj.ObjectID) == 0 || len(obj.ObjectName) == 0 {
 			blog.Errorf("sync iam system instances but object(%#v) is invalid, rid: %s", obj, rid)
-			return errors.New("object is invalid")
+			return errors.New("sync iam instances, but object is invalid")
 		}
 	}
 

--- a/src/common/index/instance.go
+++ b/src/common/index/instance.go
@@ -97,6 +97,9 @@ func InstanceUniqueIndex() []types.Index {
 			},
 			Background: false,
 			Unique:     true,
+			PartialFilterExpression: map[string]interface{}{
+				common.BKInstNameField: map[string]string{common.BKDBType: "string"},
+			},
 		},
 	}
 }

--- a/src/scene_server/admin_server/app/server.go
+++ b/src/scene_server/admin_server/app/server.go
@@ -202,6 +202,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	errors.SetGlobalCCError(engine.CCErr)
 
 	syncor := iam.NewSyncor()
+	syncor.SetDB(mongodb.Client())
 	syncor.SetSyncIAMPeriod(process.Config.SyncIAMPeriodMinutes)
 	go syncor.SyncIAM(iamCli, service.Logics)
 

--- a/src/scene_server/admin_server/iam/synciam.go
+++ b/src/scene_server/admin_server/iam/synciam.go
@@ -109,12 +109,12 @@ func (s *syncor) SyncIAM(iamCli *iamcli.IAM, lgc *logics.Logics) {
 		dbReady, err = upgrader.DBReady(context.Background(), s.db)
 		if err != nil {
 			blog.Errorf("sync iam, check whether db initialization is complete failed, err: %v, rid: %s", err, rid)
-			time.Sleep(20 * time.Second)
+			time.Sleep(5 * time.Second)
 			continue
 		}
 		if !dbReady {
-			blog.Errorf("sync iam, but db initialization is not complete, rid: %s", rid)
-			time.Sleep(20 * time.Second)
+			blog.Warnf("sync iam, but db initialization is not complete, rid: %s", rid)
+			time.Sleep(5 * time.Second)
 			continue
 		}
 	}

--- a/src/scene_server/admin_server/iam/synciam.go
+++ b/src/scene_server/admin_server/iam/synciam.go
@@ -13,6 +13,7 @@
 package iam
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -24,6 +25,8 @@ import (
 	commonlgc "configcenter/src/common/logics"
 	"configcenter/src/common/util"
 	"configcenter/src/scene_server/admin_server/logics"
+	"configcenter/src/scene_server/admin_server/upgrader"
+	"configcenter/src/storage/dal"
 )
 
 const (
@@ -37,6 +40,8 @@ const (
 type syncor struct {
 	// 同步周期
 	SyncIAMPeriodMinutes int
+	// db mongodb实例连接，用于判断是否数据库初始化已完成，防止和模型实例权限迁移的upgrader冲突
+	db dal.RDB
 }
 
 func NewSyncor() *syncor {
@@ -50,6 +55,11 @@ func (s *syncor) SetSyncIAMPeriod(periodMinutes int) {
 		s.SyncIAMPeriodMinutes = syncIAMPeriodMinutesDefault
 	}
 	blog.Infof("sync iam period is %d minutes", s.SyncIAMPeriodMinutes)
+}
+
+// SetDB set db
+func (s *syncor) SetDB(db dal.RDB) {
+	s.db = db
 }
 
 // newHeader 创建IAM同步需要的header
@@ -91,6 +101,23 @@ func (s *syncor) SyncIAM(iamCli *iamcli.IAM, lgc *logics.Logics) {
 		return
 	}
 	time.Sleep(time.Minute)
+
+	// 等待数据库初始化完成，防止和模型实例权限迁移的upgrader冲突
+	rid := util.GenerateRID()
+	for dbReady := false; !dbReady; {
+		var err error
+		dbReady, err = upgrader.DBReady(context.Background(), s.db)
+		if err != nil {
+			blog.Errorf("sync iam, check whether db initialization is complete failed, err: %v, rid: %s", err, rid)
+			time.Sleep(20 * time.Second)
+			continue
+		}
+		if !dbReady {
+			blog.Errorf("sync iam, but db initialization is not complete, rid: %s", rid)
+			time.Sleep(20 * time.Second)
+			continue
+		}
+	}
 
 	for {
 		// new kit with a different rid, header

--- a/src/scene_server/topo_server/logics/model/attribute.go
+++ b/src/scene_server/topo_server/logics/model/attribute.go
@@ -249,14 +249,12 @@ func (a *attribute) CreateObjectAttribute(kit *rest.Kit, data *metadata.Attribut
 	}
 
 	if len(resp.Repeated) > 0 {
-		blog.Errorf("create model attrs failed, the attr is duplicated, ObjectID: %s, input: %s, rid: %s",
-			data.ObjectID, input, kit.Rid)
+		blog.Errorf("create model(%s) attr but it is duplicated, input: %#v, rid: %s", data.ObjectID, input, kit.Rid)
 		return nil, kit.CCError.CCError(common.CCErrorAttributeNameDuplicated)
 	}
 
 	if len(resp.Created) != 1 {
-		blog.Errorf("create model attrs created amount error, ObjectID: %s, input: %s, rid: %s", data.ObjectID,
-			input, kit.Rid)
+		blog.Errorf("created model(%s) attr amount is not one, input: %#v, rid: %s", data.ObjectID, input, kit.Rid)
 		return nil, kit.CCError.CCError(common.CCErrTopoObjectAttributeCreateFailed)
 	}
 
@@ -281,15 +279,13 @@ func (a *attribute) CreateObjectAttribute(kit *rest.Kit, data *metadata.Attribut
 
 	auditLog, err := audit.GenerateAuditLog(generateAuditParameter, data.ID, data)
 	if err != nil {
-		blog.Errorf("create object attribute %s success, but generate audit log failed, err: %v, rid: %s",
-			data.PropertyName, err, kit.Rid)
+		blog.Errorf("gen audit log after creating attr %s failed, err: %v, rid: %s", data.PropertyName, err, kit.Rid)
 		return nil, err
 	}
 
 	// save audit log.
 	if err := audit.SaveAuditLog(kit, *auditLog); err != nil {
-		blog.Errorf("create object attribute %s success, but save audit log failed, err: %v, rid: %s",
-			data.PropertyName, err, kit.Rid)
+		blog.Errorf("save audit log after creating attr %s failed, err: %v, rid: %s", data.PropertyName, err, kit.Rid)
 		return nil, err
 	}
 

--- a/src/scene_server/topo_server/logics/model/classification.go
+++ b/src/scene_server/topo_server/logics/model/classification.go
@@ -65,12 +65,25 @@ func (c *classification) CreateClassification(kit *rest.Kit, data mapstr.MapStr)
 		return nil, err
 	}
 
-	cls.ID = int64(rsp.Created.ID)
+	// get created model classification data by id
+	clsReq := &metadata.QueryCondition{Condition: mapstr.MapStr{metadata.ClassificationFieldID: int64(rsp.Created.ID)}}
+	clsResp, err := c.clientSet.CoreService().Model().ReadModelClassification(kit.Ctx, kit.Header, clsReq)
+	if err != nil {
+		blog.Errorf("get created model classification by id(%d) failed, err: %v, rid: %s", rsp.Created.ID, err, kit.Rid)
+		return nil, err
+	}
+
+	if len(clsResp.Info) != 1 {
+		blog.Errorf("get created model classification by id(%d) returns not one cls, rid: %s", rsp.Created.ID, kit.Rid)
+		return nil, kit.CCError.CCError(common.CCErrCommNotFound)
+	}
+
+	cls = &clsResp.Info[0]
 
 	// generate audit log of object classification.
 	audit := auditlog.NewObjectClsAuditLog(c.clientSet.CoreService())
 	generateAuditParameter := auditlog.NewGenerateAuditCommonParameter(kit, metadata.AuditCreate)
-	auditLog, err := audit.GenerateAuditLog(generateAuditParameter, cls.ID, nil)
+	auditLog, err := audit.GenerateAuditLog(generateAuditParameter, cls.ID, cls)
 	if err != nil {
 		blog.Errorf("create object classification %s success, but generate audit log failed, err: %v, rid: %s",
 			cls.ClassificationName, err, kit.Rid)

--- a/src/scene_server/topo_server/logics/operation/import_association.go
+++ b/src/scene_server/topo_server/logics/operation/import_association.go
@@ -261,7 +261,7 @@ func (ia *importAssociation) importAssociation() {
 			continue
 		}
 
-		err = ia.cli.authManager.AuthorizeByInstanceID(ia.kit.Ctx, ia.kit.Header, meta.Update, ia.objID, srcInstID)
+		err = ia.cli.authManager.AuthorizeByInstanceID(ia.kit.Ctx, ia.kit.Header, meta.Update, asst.ObjectID, srcInstID)
 		if err != nil {
 			ia.parseImportDataErr[idx] = err.Error()
 			continue

--- a/src/source_controller/cacheservice/event/watch/watch.go
+++ b/src/source_controller/cacheservice/event/watch/watch.go
@@ -462,6 +462,19 @@ func (c *Client) WatchWithCursor(kit *rest.Kit, key event.Key, opts *watch.Watch
 					Detail:    nil,
 				}}, nil
 			} else {
+				// 如果最后一个事件存在，则重新拉取匹配watch条件(type和sub resource)的事件，防止最后一个事件正好在超时之后但是
+				// 拉取之前产生的情况下丢失从超时起到最后一个事件之间的事件。如果从起始cursor到最后一个事件之间没有匹配事件的话，
+				// 返回最后一个事件，以免下次拉取时需要从起始cursor再重新拉取一遍不匹配的事件
+				searchOpt.id = nodeID
+				nodes, err = c.searchFollowingEventChainNodesByID(kit, searchOpt)
+				if err != nil {
+					blog.Errorf("watch event from cursor: %s failed, err: %v, rid: %s", opts.Cursor, err, rid)
+					return nil, err
+				}
+				if len(nodes) != 0 {
+					return c.getEventDetailsWithNodes(kit, opts, nodes, key)
+				}
+
 				resp := &watch.WatchEventDetail{
 					Cursor:   lastNode.Cursor,
 					Resource: opts.Resource,

--- a/src/web_server/logics/excel_util.go
+++ b/src/web_server/logics/excel_util.go
@@ -32,14 +32,14 @@ import (
 )
 
 const (
-	userBracketsPattern        = `\([a-zA-Z0-9\@\p{Han} .,_-]*\)`
-	orgnizationBracketsPattern = `\[(\d+)\]([^\s/]+)`
+	userBracketsPattern         = `\([a-zA-Z0-9\@\p{Han} .,_-]*\)`
+	organizationBracketsPattern = `\[(\d+)\]([^\s]+)`
 )
 
 var (
 	headerRow          = common.HostAddMethodExcelIndexOffset
 	userBracketsRegexp = regexp.MustCompile(userBracketsPattern)
-	orgBracketsRegexp  = regexp.MustCompile(orgnizationBracketsPattern)
+	orgBracketsRegexp  = regexp.MustCompile(organizationBracketsPattern)
 )
 
 // getFilterFields 不需要展示字段


### PR DESCRIPTION
### 优化的功能:
- 创建模型时自动添加的bk_inst_name的唯一索引添加partial filter，防止和定时同步时生成的index冲突
- 创建模型分组和属性接口的返回实际创建的数据
- 模型实例权限同步等待db初始化完成后再开始
- 提交事务时若之前没有事务（无db操作的情况下）则跳过提交操作，防止AutoRunTxn里的函数直接返回nil的时候报错txn number不存在
### 修复的问题：
- 修复excel导入反向实例关联和带/的组织名失败的问题
- 修复watch在正好超时的瞬间产生了一个新事件的情况下丢事件的问题