### PR TITLE
bugfix 修复导入时获取excel内容逻辑

### DIFF
--- a/src/web_server/logics/excel.go
+++ b/src/web_server/logics/excel.go
@@ -558,11 +558,11 @@ func GetRawExcelData(ctx context.Context, sheet *xlsx.Sheet, defFields common.Kv
 	for ; index < rowCnt; index++ {
 		row := sheet.Rows[index]
 		host, getErr := getDataFromByExcelRow(ctx, row, index, nil, defFields, nameIndexMap, defLang, department)
-		if nil != getErr {
+		if getErr != nil {
 			errMsg = append(errMsg, getErr...)
 			continue
 		}
-		if len(host) != 0 {
+		if len(host) == 0 {
 			hosts[index+1] = nil
 		} else {
 			hosts[index+1] = host


### PR DESCRIPTION
### 修复的问题：
- 修复导入模型时获取excel内容逻辑
