### PR TITLE
解决当删除服务实例，但模块内的服务实例数不为零场景的同步问题

### DIFF
--- a/src/scene_server/proc_server/service/serviceinstance.go
+++ b/src/scene_server/proc_server/service/serviceinstance.go
@@ -1005,7 +1005,7 @@ func (ps *ProcServer) calculateGeneralDiff(ctx *rest.Contexts, bizID int64, host
 	}
 
 	// 单独处理一下第一次added processTemplate的场景，第一次added时模块下面的主机还没有实例化，模块下的实例数量是0并且主机数量大于0
-	if len(hostMap) > 0 && len(serviceInstances) == 0 {
+	if len(hostMap) != len(serviceInstances) {
 		for templateID, processTemplate := range pTemplateMap {
 			moduleDifference.Added = append(moduleDifference.Added, metadata.ProcessGeneralInfo{
 				Id: templateID, Name: processTemplate.ProcessName})
@@ -1321,7 +1321,7 @@ func (ps *ProcServer) getListDiffServiceInstanceNum(ctx *rest.Contexts, opt *met
 			d.ServiceInsts = append(d.ServiceInsts, metadata.ServiceInstancesInfo{Id: inst.ID, Name: inst.Name})
 		}
 
-		if len(sInsts.Info) == 0 && len(hMap) > 0 {
+		if len(sInsts.Info) != len(hMap) {
 			d.ServiceInsts = ps.handleAddedServiceInsts(module, hMap, hostIDs, hostInst, pTs)
 		}
 

--- a/src/scene_server/topo_server/logics/settemplate/sync_status.go
+++ b/src/scene_server/topo_server/logics/settemplate/sync_status.go
@@ -59,6 +59,9 @@ func (st *setTemplate) GetSets(kit *rest.Kit, setTemplateID int64, setIDs []int6
 	return instResult.Data.Info, nil
 }
 
+// isSyncRequired Note: If the parameter isInterrupt is true, it will return if a state to be synchronized is found.
+// At this time, the rest of the cluster state will be set to synchronized by default. If you need to return all pending
+//synchronization status state setId, you need to set this parameter to false.
 func (st *setTemplate) isSyncRequired(kit *rest.Kit, bizID int64, setTemplateID int64, setIDs []int64,
 	isInterrupt bool) (map[int64]bool, errors.CCErrorCoder) {
 
@@ -276,7 +279,7 @@ func (st *setTemplate) ListSetTemplateSyncStatus(kit *rest.Kit, option *metadata
 	}
 
 	// compare sets with set templates to get their sync status
-	statusMap, err := st.isSyncRequired(kit, option.BizID, option.SetTemplateID, setIDs, true)
+	statusMap, err := st.isSyncRequired(kit, option.BizID, option.SetTemplateID, setIDs, false)
 	if err != nil {
 		blog.Errorf("check if set need sync failed, err: %v, set ids: %+v, rid: %s", err, setIDs, kit.Rid)
 		return nil, err


### PR DESCRIPTION
### 修复的问题：
- 解决当删除服务实例，但模块内的服务实例数不为零场景的同步问题 close #5977.
