### PR TITLE
bugfix 添加初始化指针操作防止调用出现panic

### DIFF
--- a/src/scene_server/auth_server/sdk/auth/count.go
+++ b/src/scene_server/auth_server/sdk/auth/count.go
@@ -143,6 +143,9 @@ func (a *Authorize) countContent(ctx context.Context, op operator.OperType, cont
 	allAttrFieldValue := make([]*operator.FieldValue, 0)
 	allList := make([]types.AuthorizeList, 0)
 
+	// initialize the returned struct to prevent pointer panic
+	idList = new(types.AuthorizeList)
+
 	err = preAnalyzeContent(op, content)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### 修复的问题：
- 修复用户拥有无限制业务权限，创建业务后查询资源池业务报错问题
close #5984