### PR TITLE
修复无法跳转到权限中心申请业务集删除权限的问题

### DIFF
--- a/src/ac/iam/types.go
+++ b/src/ac/iam/types.go
@@ -295,7 +295,7 @@ const (
 
 	CreateBizSet ActionID = "create_business_set"
 	EditBizSet   ActionID = "edit_business_set"
-	DeleteBizSet ActionID = "archive_business_set"
+	DeleteBizSet ActionID = "delete_business_set"
 	ViewBizSet   ActionID = "view_business_set"
 	AccessBizSet ActionID = "access_business_set"
 

--- a/src/scene_server/topo_server/logics/model/mainline_association.go
+++ b/src/scene_server/topo_server/logics/model/mainline_association.go
@@ -76,13 +76,6 @@ func (assoc *association) CreateMainlineAssociation(kit *rest.Kit, data *metadat
 		return nil, err
 	}
 
-	// update the mainline topo inst association
-	if _, err = assoc.instasst.SetMainlineInstAssociation(kit, parentObjID, childObjID, currentObj.ObjectID,
-		currentObj.ObjectName); err != nil {
-		blog.Errorf("failed set the mainline inst association, err: %s, rid: %s", err, kit.Rid)
-		return nil, err
-	}
-
 	if err = assoc.createMainlineObjectAssociation(kit, currentObj.ObjectID, parentObjID); err != nil {
 		blog.Errorf("create mainline object[%s] association related to object[%s] failed, err: %v, rid: %s",
 			currentObj.ObjectID, parentObjID, err, kit.Rid)
@@ -92,6 +85,13 @@ func (assoc *association) CreateMainlineAssociation(kit *rest.Kit, data *metadat
 	if err = assoc.setMainlineParentObject(kit, childObjID, currentObj.ObjectID); err != nil {
 		blog.Errorf("update mainline current object's[%s] child object[%s] association to current failed, "+
 			"err: %v, rid: %s", currentObj.ObjectID, childObjID, err, kit.Rid)
+		return nil, err
+	}
+
+	// update the mainline topo inst association
+	if _, err = assoc.instasst.SetMainlineInstAssociation(kit, parentObjID, childObjID, currentObj.ObjectID,
+		currentObj.ObjectName); err != nil {
+		blog.Errorf("failed set the mainline inst association, err: %s, rid: %s", err, kit.Rid)
 		return nil, err
 	}
 


### PR DESCRIPTION
### 修复的问题：
- 修复无法跳转到权限中心申请业务集删除权限的问题 
close #6016
- 修复创建主线模型时自动为下层节点创建该层级的父节点时审计记录到通用模型实例的问题
