### PR TITLE
去掉go build时的-i参数

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -55,5 +55,5 @@ ifeq ($(PREPARE_CFG),true)
 endif
 	@echo -e "\033[34mbuilding the target: $@... \033[0m"
 	@echo 
-	go build -i $(GOBUILD_FLAGS) -o $(BIN_PATH)/$(TARGET_NAME)/$(TARGET_NAME)
+	go build $(GOBUILD_FLAGS) -o $(BIN_PATH)/$(TARGET_NAME)/$(TARGET_NAME)
 	@chmod +x  $(BIN_PATH)/$(TARGET_NAME)/$(TARGET_NAME)


### PR DESCRIPTION
### 优化的功能:
- 去掉go build时的-i参数，官方已显示 The -i flag is deprecated. Compiled packages are cached automatically.
