### PR TITLE
调整opensource和skip-login登录方式是否调用esb接口的判断方式

### DIFF
--- a/src/web_server/logics/department.go
+++ b/src/web_server/logics/department.go
@@ -88,7 +88,7 @@ func (lgc *Logics) getDepartmentMap(ctx context.Context, header http.Header) (ma
 	}
 
 	if loginVersion == common.BKOpenSourceLoginPluginVersion || loginVersion == common.BKSkipLoginPluginVersion {
-		return nil, nil
+		return map[int64]metadata.DepartmentItem{}, nil
 	}
 
 	result, esbErr := esb.EsbClient().User().GetDepartment(ctx, header, nil)

--- a/src/web_server/logics/department.go
+++ b/src/web_server/logics/department.go
@@ -80,6 +80,7 @@ func (lgc *Logics) getDepartmentMap(ctx context.Context, header http.Header) (ma
 
 	defErr := lgc.CCErr.CreateDefaultCCErrorIf(commonutil.GetLanguage(header))
 	rid := commonutil.GetHTTPCCRequestID(header)
+	dpMap := make(map[int64]metadata.DepartmentItem)
 
 	loginVersion, err := configcenter.String("webServer.login.version")
 	if err != nil {
@@ -88,7 +89,7 @@ func (lgc *Logics) getDepartmentMap(ctx context.Context, header http.Header) (ma
 	}
 
 	if loginVersion == common.BKOpenSourceLoginPluginVersion || loginVersion == common.BKSkipLoginPluginVersion {
-		return map[int64]metadata.DepartmentItem{}, nil
+		return dpMap, nil
 	}
 
 	result, esbErr := esb.EsbClient().User().GetDepartment(ctx, header, nil)
@@ -101,7 +102,6 @@ func (lgc *Logics) getDepartmentMap(ctx context.Context, header http.Header) (ma
 		return nil, errors.NewCCError(result.Code, result.Message)
 	}
 
-	dpMap := make(map[int64]metadata.DepartmentItem)
 	for _, item := range result.Data.Results {
 		dpMap[item.ID] = item
 	}

--- a/src/web_server/logics/department.go
+++ b/src/web_server/logics/department.go
@@ -30,8 +30,8 @@ import (
 
 // GetDepartment get department info from paas
 func (lgc *Logics) GetDepartment(c *gin.Context, config *options.Config) (*metadata.DepartmentData, errors.CCErrorCoder) {
-	// if no esb config, return
-	if !configcenter.IsExist("webServer.esb.addr") {
+	if config.LoginVersion == common.BKOpenSourceLoginPluginVersion ||
+		config.LoginVersion == common.BKSkipLoginPluginVersion {
 		return &metadata.DepartmentData{}, nil
 	}
 
@@ -54,8 +54,8 @@ func (lgc *Logics) GetDepartment(c *gin.Context, config *options.Config) (*metad
 
 // GetDepartmentProfile get department profile from paas
 func (lgc *Logics) GetDepartmentProfile(c *gin.Context, config *options.Config) (*metadata.DepartmentProfileData, errors.CCErrorCoder) {
-	// if no esb config, return
-	if !configcenter.IsExist("webServer.esb.addr") {
+	if config.LoginVersion == common.BKOpenSourceLoginPluginVersion ||
+		config.LoginVersion == common.BKSkipLoginPluginVersion {
 		return &metadata.DepartmentProfileData{}, nil
 	}
 
@@ -77,13 +77,19 @@ func (lgc *Logics) GetDepartmentProfile(c *gin.Context, config *options.Config) 
 
 func (lgc *Logics) getDepartmentMap(ctx context.Context, header http.Header) (map[int64]metadata.DepartmentItem,
 	errors.CCErrorCoder) {
-	// if no esb config, return
-	if !configcenter.IsExist("webServer.esb.addr") {
-		return nil, nil
-	}
 
 	defErr := lgc.CCErr.CreateDefaultCCErrorIf(commonutil.GetLanguage(header))
 	rid := commonutil.GetHTTPCCRequestID(header)
+
+	loginVersion, err := configcenter.String("webServer.login.version")
+	if err != nil {
+		blog.Errorf("get config webServer.login.version failed, err: %v, rid: %s", err, rid)
+		return nil, defErr.CCErrorf(common.CCErrCommConfMissItem, "webServer.login.version")
+	}
+
+	if loginVersion == common.BKOpenSourceLoginPluginVersion || loginVersion == common.BKSkipLoginPluginVersion {
+		return nil, nil
+	}
 
 	result, esbErr := esb.EsbClient().User().GetDepartment(ctx, header, nil)
 	if esbErr != nil {


### PR DESCRIPTION
### 修复的问题：
- skip-login和opensource登录方式，是否调用esb接口的判断方式改为根据登录方式判断，防止上述两种登录方式情况下，配了esb的配置，调用出现问题
