### PR TITLE
bugfix 修复删除模型属性时该模型属性为唯一校验报错未返回问题

### DIFF
--- a/src/scene_server/topo_server/logics/model/attribute.go
+++ b/src/scene_server/topo_server/logics/model/attribute.go
@@ -335,10 +335,15 @@ func (a *attribute) DeleteObjectAttribute(kit *rest.Kit, cond mapstr.MapStr, mod
 				common.BKFieldID: mapstr.MapStr{common.BKDBIN: instIDs},
 			},
 		}
-		_, err = a.clientSet.CoreService().Model().DeleteModelAttr(kit.Ctx, kit.Header, objID, deleteCond)
+		rsp, err := a.clientSet.CoreService().Model().DeleteModelAttr(kit.Ctx, kit.Header, objID, deleteCond)
 		if err != nil {
 			blog.Errorf("delete object attribute failed, err: %v, rid: %s", err, kit.Rid)
 			return err
+		}
+
+		if ccErr := rsp.CCError(); ccErr != nil {
+			blog.Errorf("delete object attribute failed, err: %v, rid: %s", ccErr, kit.Rid)
+			return ccErr
 		}
 	}
 

--- a/src/scene_server/topo_server/service/object_attribute.go
+++ b/src/scene_server/topo_server/service/object_attribute.go
@@ -232,9 +232,8 @@ func (s *Service) DeleteObjectAttribute(ctx *rest.Contexts) {
 	}
 
 	cond := mapstr.MapStr{metadata.AttributeFieldID: id}
-	err = s.Logics.AttributeOperation().DeleteObjectAttribute(ctx.Kit, cond, modelType.BizID)
-	if err != nil {
-		blog.Errorf("delete object attribute failed, params: %+v, err: %+v, rid: %s", ctx.Kit, err, ctx.Kit.Rid)
+	if err = s.Logics.AttributeOperation().DeleteObjectAttribute(ctx.Kit, cond, modelType.BizID); err != nil {
+		blog.Errorf("delete object attribute failed, params: %+v, err: %+v, rid: %s", cond, err, ctx.Kit.Rid)
 		ctx.RespAutoError(err)
 		return
 	}


### PR DESCRIPTION
### 修复的问题：
- 修复删除模型属性时该模型属性为唯一校验报错未返回问题
