### PR TITLE
bugfix

### DIFF
--- a/src/apimachinery/coreservice/transaction/client.go
+++ b/src/apimachinery/coreservice/transaction/client.go
@@ -223,7 +223,7 @@ func (t *transaction) autoRun(ctx context.Context, h http.Header, run func() err
 		// check if context is cancelled because of timeout or else, if so, do not need to abort the transaction.
 		select {
 		case <-ctx.Done():
-			blog.Errorf("run transaction, but context is cancelled, rid: %s", rid)
+			blog.Errorf("run transaction, but context is cancelled, err: %v, rid: %s", ctx.Err(), rid)
 			return false, runErr
 		default:
 		}

--- a/src/apimachinery/coreservice/transaction/client.go
+++ b/src/apimachinery/coreservice/transaction/client.go
@@ -219,6 +219,15 @@ func (t *transaction) autoRun(ctx context.Context, h http.Header, run func() err
 	runErr := run()
 	if runErr != nil {
 		blog.ErrorfDepthf(2, "run transaction, but run() function failed, err: %v, rid: %s", runErr, rid)
+
+		// check if context is cancelled because of timeout or else, if so, do not need to abort the transaction.
+		select {
+		case <-ctx.Done():
+			blog.Errorf("run transaction, but context is cancelled, rid: %s", rid)
+			return false, runErr
+		default:
+		}
+
 		// run() logic failed, then abort the transaction.
 		retry, err := t.AbortTransaction(ctx, h)
 		if err != nil {

--- a/src/apimachinery/taskserver/task/api.go
+++ b/src/apimachinery/taskserver/task/api.go
@@ -24,7 +24,7 @@ import (
 type TaskClientInterface interface {
 	// Create  新加任务， name 任务名，flag:任务标识，留给业务方做识别任务, instID:任务的执行源实例id, data 每一项任务需要的参数
 	Create(ctx context.Context, header http.Header, flag string, instID int64, data []interface{}) (
-		metadata.APITaskDetail, error)
+		metadata.APITaskDetail, errors.CCErrorCoder)
 
 	CreateBatch(c context.Context, h http.Header, tasks []metadata.CreateTaskRequest) ([]metadata.APITaskDetail, error)
 

--- a/src/apimachinery/taskserver/task/task.go
+++ b/src/apimachinery/taskserver/task/task.go
@@ -23,7 +23,7 @@ import (
 
 // Create 新加任务，taskType: 任务标识，留给业务方做识别任务，instID: 任务的执行源实例id，data: 每一项任务需要的参数
 func (t *task) Create(ctx context.Context, header http.Header, taskType string, instID int64, data []interface{}) (
-	metadata.APITaskDetail, error) {
+	metadata.APITaskDetail, errors.CCErrorCoder) {
 
 	resp := new(metadata.CreateTaskResponse)
 	subPath := "/task/create"

--- a/src/scene_server/proc_server/service/serviceinstance.go
+++ b/src/scene_server/proc_server/service/serviceinstance.go
@@ -1154,7 +1154,10 @@ func (ps *ProcServer) getHostAndServiceInsts(ctx *rest.Contexts, option *hostAnd
 		Page: metadata.BasePage{
 			Sort: common.BKFieldID,
 		},
-		ProcessTemplateIDs: []int64{option.ProcTemplateId},
+	}
+
+	if option.ProcTemplateId != 0 {
+		cond.ProcessTemplateIDs = []int64{option.ProcTemplateId}
 	}
 
 	processTemplates, err := ps.CoreAPI.CoreService().Process().ListProcessTemplates(ctx.Kit.Ctx, ctx.Kit.Header, cond)
@@ -1661,17 +1664,20 @@ func (ps *ProcServer) handleAddedServiceInsts(module *metadata.ModuleInst, hostM
 	processTemplates *metadata.MultipleProcessTemplate) []metadata.ServiceInstancesInfo {
 
 	srvInstNameSuffix := ""
-	proc := processTemplates.Info[0].Property
 
-	// 此时模块下的主机均未实例化，所以需要构造实例名字
-	if proc != nil {
-		if proc.ProcessName.Value != nil && len(*proc.ProcessName.Value) > 0 {
-			srvInstNameSuffix += "_" + processTemplates.Info[0].ProcessName
-		}
-		for _, bindInfo := range proc.BindInfo.Value {
-			if bindInfo.Std != nil && bindInfo.Std.Port.Value != nil {
-				srvInstNameSuffix += "_" + *bindInfo.Std.Port.Value
-				break
+	if processTemplates != nil && len(processTemplates.Info) > 0 {
+		proc := processTemplates.Info[0].Property
+
+		// 此时模块下的主机均未实例化，所以需要构造实例名字
+		if proc != nil {
+			if proc.ProcessName.Value != nil && len(*proc.ProcessName.Value) > 0 {
+				srvInstNameSuffix += "_" + processTemplates.Info[0].ProcessName
+			}
+			for _, bindInfo := range proc.BindInfo.Value {
+				if bindInfo.Std != nil && bindInfo.Std.Port.Value != nil {
+					srvInstNameSuffix += "_" + *bindInfo.Std.Port.Value
+					break
+				}
 			}
 		}
 	}

--- a/src/scene_server/topo_server/logics/settemplate/settemplate.go
+++ b/src/scene_server/topo_server/logics/settemplate/settemplate.go
@@ -226,7 +226,7 @@ func (st *setTemplate) DispatchTask4ModuleSync(kit *rest.Kit, taskType string, s
 	createTaskResult, err := st.client.TaskServer().Task().Create(kit.Ctx, kit.Header, taskType, setID, tasksData)
 	if err != nil {
 		blog.ErrorJSON("dispatch synchronize task failed, task: %s, err: %s, rid: %s", tasks, err.Error(), kit.Rid)
-		return taskDetail, errors.CCHttpError
+		return taskDetail, err
 	}
 	blog.InfoJSON("dispatch synchronize task success, task: %s, create result: %s, rid: %s",
 		tasks, createTaskResult, kit.Rid)

--- a/src/storage/dal/redis/client.go
+++ b/src/storage/dal/redis/client.go
@@ -231,3 +231,7 @@ func (c *client) TTL(ctx context.Context, key string) DurationResult {
 func (c *client) BLPop(ctx context.Context, timeout time.Duration, keys ...string) StringSliceResult {
 	return c.cli.BLPop(timeout, keys...)
 }
+
+func (c *client) ZRemRangeByRank(key string, start, stop int64) IntResult {
+	return c.cli.ZRemRangeByRank(key, start, stop)
+}

--- a/src/storage/dal/redis/commands.go
+++ b/src/storage/dal/redis/commands.go
@@ -65,4 +65,5 @@ type Commands interface {
 	TxPipeline(ctx context.Context) Pipeliner
 	Discard(ctx context.Context, pipe Pipeliner) error
 	BLPop(ctx context.Context, timeout time.Duration, keys ...string) StringSliceResult
+	ZRemRangeByRank(key string, start, stop int64) IntResult
 }


### PR DESCRIPTION
### 优化的功能:
- 获取服务实例同步差异时，没有传进程模板ID则对比全部进程模板的差异
- 超时等原因造成context被取消时，不调用取消事务接口，因为此时事务已失败退出
- 调整刷新主机id缓存逻辑