### PR TITLE
服务实例的端口和协议信息校验需要和进程模板中的校验规则保持一致

### DIFF
--- a/src/common/metadata/process.go
+++ b/src/common/metadata/process.go
@@ -873,9 +873,13 @@ func (p ProtocolType) String() string {
 	}
 }
 
-func (p ProtocolType) Validate() error {
+// Validate validate ProtocolType
+func (p *ProtocolType) Validate() error {
+	if p == nil || len(*p) == 0 {
+		return errors.New("protocol is not set or is empty")
+	}
 	validValues := []ProtocolType{ProtocolTypeTCP, ProtocolTypeUDP}
-	if util.InArray(p, validValues) == false {
+	if util.InArray(*p, validValues) == false {
 		return fmt.Errorf("invalid protocol type, value: %s, available values: %+v", p, validValues)
 	}
 	return nil
@@ -1795,16 +1799,20 @@ type PropertyPort struct {
 	AsDefaultValue *bool   `field:"as_default_value" json:"as_default_value" bson:"as_default_value"`
 }
 
-func (ti *PropertyPort) Validate() error {
-	if ti.Value == nil || len(*ti.Value) == 0 {
+// PropertyPortValue port value
+type PropertyPortValue string
+
+// Validate validate the PropertyPortValue
+func (ti *PropertyPortValue) Validate() error {
+	if ti == nil || len(*ti) == 0 {
 		return errors.New("port is not set or is empty")
 	}
 
-	if matched := ProcessPortFormat.MatchString(*ti.Value); matched == false {
+	if matched := ProcessPortFormat.MatchString(string(*ti)); matched == false {
 		return fmt.Errorf("port format invalid")
 	}
 	var tmpPortArr []propertyPortItem
-	strPortItemArr := strings.Split(*ti.Value, ",")
+	strPortItemArr := strings.Split(string(*ti), ",")
 	for _, strPortItem := range strPortItemArr {
 		portArr := strings.Split(strPortItem, "-")
 		var start, end int64
@@ -1860,17 +1868,6 @@ func (ti *PropertyBindIP) Validate() error {
 type PropertyProtocol struct {
 	Value          *ProtocolType `field:"value" json:"value" bson:"value"`
 	AsDefaultValue *bool         `field:"as_default_value" json:"as_default_value" bson:"as_default_value"`
-}
-
-func (ti *PropertyProtocol) Validate() error {
-	if ti.Value == nil || len(*ti.Value) == 0 {
-		return errors.New("protocol is not set or is empty")
-	}
-
-	if err := ti.Value.Validate(); err != nil {
-		return err
-	}
-	return nil
 }
 
 // ServiceInstance is a service, which created when a host binding with a service template.

--- a/src/common/metadata/process_bind_info.go
+++ b/src/common/metadata/process_bind_info.go
@@ -146,10 +146,12 @@ func (pbi *ProcPropertyBindInfo) Validate() (string, error) {
 		if err := property.Std.IP.Validate(); err != nil {
 			return fmt.Sprintf("%s[%d].%s", common.BKProcBindInfo, idx, common.BKIP), err
 		}
-		if err := property.Std.Port.Validate(); err != nil {
+		port := (*PropertyPortValue)(property.Std.Port.Value)
+
+		if err := port.Validate(); err != nil {
 			return fmt.Sprintf("%s[%d].%s", common.BKProcBindInfo, idx, common.BKPort), err
 		}
-		if err := property.Std.Protocol.Validate(); err != nil {
+		if err := property.Std.Protocol.Value.Validate(); err != nil {
 			return fmt.Sprintf("%s[%d].%s", common.BKProcBindInfo, idx, common.BKProtocol), err
 		}
 		if err := property.Std.Enable.Validate(); err != nil {
@@ -604,10 +606,12 @@ func (pbi *ProcPropertyBindInfoValue) Validate() (string, error) {
 	if err := pbi.Std.IP.Validate(); err != nil {
 		return common.BKIP, err
 	}
-	if err := pbi.Std.Port.Validate(); err != nil {
+
+	port := (*PropertyPortValue)(pbi.Std.Port.Value)
+	if err := port.Validate(); err != nil {
 		return common.BKPort, err
 	}
-	if err := pbi.Std.Protocol.Validate(); err != nil {
+	if err := pbi.Std.Protocol.Value.Validate(); err != nil {
 		return common.BKProtocol, err
 	}
 	if err := pbi.Std.Enable.Validate(); err != nil {

--- a/src/scene_server/proc_server/service/processinstance.go
+++ b/src/scene_server/proc_server/service/processinstance.go
@@ -629,16 +629,12 @@ func (ps *ProcServer) validateProcessInstance(kit *rest.Kit, process *metadata.P
 			}
 		}
 
-		port := metadata.PropertyPort{
-			Value: bindInfo.Std.Port,
-		}
+		port := (*metadata.PropertyPortValue)(bindInfo.Std.Port)
 		if err := port.Validate(); err != nil {
 			return kit.CCError.CCErrorf(common.CCErrCommParamsNeedSet, common.BKProcBindInfo+"."+common.BKPort)
 		}
 
-		protocol := metadata.PropertyProtocol{
-			Value: (*metadata.ProtocolType)(bindInfo.Std.Protocol),
-		}
+		protocol := (*metadata.ProtocolType)(bindInfo.Std.Protocol)
 		if err := protocol.Validate(); err != nil {
 			return kit.CCError.CCErrorf(common.CCErrCommParamsNeedSet, common.BKProcBindInfo+"."+common.BKProtocol)
 		}

--- a/src/scene_server/proc_server/service/processinstance.go
+++ b/src/scene_server/proc_server/service/processinstance.go
@@ -603,8 +603,7 @@ func (ps *ProcServer) getModule(kit *rest.Kit, moduleID int64) (*metadata.Module
 }
 
 var (
-	ipRegex   = `^((1?\d{1,2}|2[0-4]\d|25[0-5])[.]){3}(1?\d{1,2}|2[0-4]\d|25[0-5])$`
-	portRegex = `^([0-9]|[1-9]\d{1,3}|[1-5]\d{4}|6[0-5]{2}[0-3][0-5])$`
+	ipRegex = `^((1?\d{1,2}|2[0-4]\d|25[0-5])[.]){3}(1?\d{1,2}|2[0-4]\d|25[0-5])$`
 )
 
 func (ps *ProcServer) validateProcessInstance(kit *rest.Kit, process *metadata.Process) errors.CCErrorCoder {
@@ -630,19 +629,18 @@ func (ps *ProcServer) validateProcessInstance(kit *rest.Kit, process *metadata.P
 			}
 		}
 
-		if bindInfo.Std.Port == nil || len(*bindInfo.Std.Port) == 0 {
+		port := metadata.PropertyPort{
+			Value: bindInfo.Std.Port,
+		}
+		if err := port.Validate(); err != nil {
 			return kit.CCError.CCErrorf(common.CCErrCommParamsNeedSet, common.BKProcBindInfo+"."+common.BKPort)
 		}
-		if matched, err := regexp.MatchString(portRegex, *bindInfo.Std.Port); err != nil || !matched {
-			return kit.CCError.CCErrorf(common.CCErrCommParamsInvalid, common.BKProcBindInfo+"."+common.BKPort)
-		}
 
-		if bindInfo.Std.Protocol == nil || len(*bindInfo.Std.Protocol) == 0 {
-			return kit.CCError.CCErrorf(common.CCErrCommParamsNeedSet, common.BKProcBindInfo+"."+common.BKProtocol)
+		protocol := metadata.PropertyProtocol{
+			Value: (*metadata.ProtocolType)(bindInfo.Std.Protocol),
 		}
-		if *bindInfo.Std.Protocol != string(metadata.ProtocolTypeTCP) &&
-			*bindInfo.Std.Protocol != string(metadata.ProtocolTypeUDP) {
-			return kit.CCError.CCErrorf(common.CCErrCommParamsInvalid, common.BKProcBindInfo+"."+common.BKProtocol)
+		if err := protocol.Validate(); err != nil {
+			return kit.CCError.CCErrorf(common.CCErrCommParamsNeedSet, common.BKProcBindInfo+"."+common.BKProtocol)
 		}
 	}
 


### PR DESCRIPTION
### 修复的问题：
-close #6069
