### PR TITLE
修复search_instance_associations不支持双向查询关联关系

### DIFF
--- a/src/scene_server/topo_server/logics/inst/association.go
+++ b/src/scene_server/topo_server/logics/inst/association.go
@@ -82,7 +82,6 @@ func (assoc *association) SearchInstanceAssociations(kit *rest.Kit, objID string
 	if err != nil {
 		return nil, kit.CCError.Errorf(common.CCErrCommParamsInvalid, err)
 	}
-	cond[common.BKObjIDField] = objID
 
 	conditions := &metadata.InstAsstQueryCondition{
 		ObjID: objID,


### PR DESCRIPTION
### 修复的问题：
- search_instance_associations只支持查询源模型关联，不支持查询目标模型关联

issues #6112
