### PR TITLE
去除主机列表中hover显示的跳转业务拓扑tips避免极端情况下遮挡跳转icon

### DIFF
--- a/src/ui/src/components/host-topo-path/host-topo-path.vue
+++ b/src/ui/src/components/host-topo-path/host-topo-path.vue
@@ -22,7 +22,6 @@
       <template v-if="!isResourcePool">
         <i class="path-single-link icon-cc-share"
           v-if="isSingle"
-          v-bk-tooltips="$t('跳转业务拓扑')"
           @click="handleLinkToTopology(modules[0])">
         </i>
         <span v-else
@@ -44,7 +43,6 @@
         :key="moduleId">
         <span class="path-tooltip-text" :title="getModulePath(moduleId)">{{getModulePath(moduleId)}}</span>
         <i class="path-tooltip-link icon-cc-share"
-          :title="$t('跳转业务拓扑')"
           @click="handleLinkToTopology(moduleId)">
         </i>
       </div>

--- a/src/ui/src/components/ui/auth/auth-mask.vue
+++ b/src/ui/src/components/ui/auth/auth-mask.vue
@@ -1,3 +1,15 @@
+<!--
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2022 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+-->
+
 <script>
   import { defineComponent } from '@vue/composition-api'
 

--- a/src/ui/src/views/set-template/index.vue
+++ b/src/ui/src/views/set-template/index.vue
@@ -66,16 +66,6 @@
       </bk-table-column>
       <bk-table-column :label="$t('操作')" width="180">
         <template slot-scope="{ row }">
-          <!-- 与查询详情编辑有重合暂去掉 -->
-          <!-- <cmdb-auth :auth="{ type: $OPERATION.U_SET_TEMPLATE, relation: [bizId, row.id] }">
-                        <bk-button slot-scope="{ disabled }"
-                            text
-                            :disabled="disabled"
-                            @click="handleEdit(row)"
-                        >
-                            {{$t('编辑')}}
-                        </bk-button>
-                    </cmdb-auth> -->
           <span class="text-primary"
             style="color: #dcdee5 !important; cursor: not-allowed;"
             v-if="row.set_instance_count"


### PR DESCRIPTION
### 优化的功能:
- 去除主机列表中hover显示的跳转业务拓扑tips避免极端情况下遮挡跳转icon
### 修复的问题：
- 添加license和删除注释代码
