### PR TITLE
修复主备负责人在进行主机自动应用时，当修改目的负责人只有一个，并且属于原来一组负责人之一时，主机自动应用失效

### DIFF
--- a/src/common/metadata/host.go
+++ b/src/common/metadata/host.go
@@ -153,13 +153,15 @@ func (s *StringArrayToString) UnmarshalBSONValue(typo bsontype.Type, raw []byte)
 	return err
 }
 
-var specialFields = []string{common.BKHostInnerIPField, common.BKHostOuterIPField, common.BKOperatorField,
+// HostSpecialFields Special fields in the host attribute, in order to fuzzy query the following fields are stored in
+// the database as an array.
+var HostSpecialFields = []string{common.BKHostInnerIPField, common.BKHostOuterIPField, common.BKOperatorField,
 	common.BKBakOperatorField, common.BKHostInnerIPv6Field, common.BKHostOuterIPv6Field}
 
 // convert host ip and operator fields value from string to array
 // NOTICE: if host special value is empty, convert it to null to trespass the unique check, **do not change this logic**
 func ConvertHostSpecialStringToArray(host map[string]interface{}) map[string]interface{} {
-	for _, field := range specialFields {
+	for _, field := range HostSpecialFields {
 		value, ok := host[field]
 		if !ok {
 			continue

--- a/src/scene_server/host_server/service/hostapplyrule.go
+++ b/src/scene_server/host_server/service/hostapplyrule.go
@@ -261,13 +261,22 @@ func (s *Service) BatchCreateOrUpdateHostApplyRule(ctx *rest.Contexts) {
 	ctx.RespEntity(batchResult)
 }
 
-func generateCondition(dataStr string, hostIDs []int64) (map[string]interface{}, map[string]interface{}) {
+func generateCondition(dataStr string, hostIDs []int64) (map[string]interface{}, map[string]interface{},
+	errors.CCErrorCoder) {
+
 	data := make(map[string]interface{})
 	_ = json.Unmarshal([]byte(dataStr), &data)
 
 	cond := make([]map[string]interface{}, 0)
-
 	for key, value := range data {
+		// 对于主机特殊属性字段需要转化成数组进行查询
+		if util.InArray(key, metadata.HostSpecialFields) {
+			valueStr, ok := value.(string)
+			if !ok {
+				return nil, nil, errors.New(common.CCErrCommParamsNeedString, key)
+			}
+			value = strings.Split(valueStr, ",")
+		}
 		cond = append(cond, map[string]interface{}{
 			key: map[string]interface{}{common.BKDBNE: value},
 		})
@@ -276,7 +285,7 @@ func generateCondition(dataStr string, hostIDs []int64) (map[string]interface{},
 		common.BKHostIDField: map[string]interface{}{common.BKDBIN: hostIDs},
 		common.BKDBOR:        cond,
 	}
-	return mergeCond, data
+	return mergeCond, data, nil
 }
 
 // GenerateModuleApplyPlan generate module host apply rule plan
@@ -347,7 +356,14 @@ func (s *Service) updateHostPlan(planResult metadata.HostApplyPlanResult, kit *r
 				<-pipeline
 			}()
 
-			mergeCond, data := generateCondition(dataStr, hostIDs)
+			mergeCond, data, cErr := generateCondition(dataStr, hostIDs)
+			if cErr != nil {
+				if firstErr == nil {
+					firstErr = cErr
+				}
+				blog.Errorf("generate query condition failed, err: %v, rid: %s", cErr, kit.Rid)
+				return
+			}
 			counts, cErr := s.Engine.CoreAPI.CoreService().Count().GetCountByFilter(kit.Ctx, kit.Header,
 				common.BKTableNameBaseHost, []map[string]interface{}{mergeCond})
 			if cErr != nil {
@@ -557,7 +573,13 @@ func (s *Service) updateHostAttributes(kit *rest.Kit, planResult []metadata.Host
 	if err != nil {
 		return err
 	}
-	mergeCond, data := generateCondition(dataStr, hostIDs)
+
+	mergeCond, data, cErr := generateCondition(dataStr, hostIDs)
+	if cErr != nil {
+		blog.Errorf("generate query condition failed, err: %v, rid: %s", cErr, kit.Rid)
+		return cErr
+	}
+
 	counts, cErr := s.Engine.CoreAPI.CoreService().Count().GetCountByFilter(kit.Ctx, kit.Header,
 		common.BKTableNameBaseHost, []map[string]interface{}{mergeCond})
 	if cErr != nil {


### PR DESCRIPTION
### 修复的问题：
- 修复主备负责人在进行主机自动应用时，当修改目的负责人只有一个，并且属于原来一组负责人之一时，主机自动应用失效。
 例如原主机的主负责人是 ： A,B，需要通过主机自动应用改成A ，那么会触发原bug
