### PR TITLE
调整获取esb用户列表的请求用户名长度

### DIFF
--- a/src/web_server/service/util.go
+++ b/src/web_server/service/util.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -73,7 +74,7 @@ func (s *Service) getUsernameMapWithPropertyList(c *gin.Context, objID string, i
 					blog.Errorf("failed to cast %s instance info from interface{} to string, rid: %s", objID, rid)
 					return nil, nil, err
 				}
-				usernameList = append(usernameList, username)
+				usernameList = append(usernameList, strings.Split(username, ",")...)
 			}
 		}
 	}
@@ -94,75 +95,87 @@ func (s *Service) getUsernameFromEsb(c *gin.Context, userList []string) (map[str
 	rid := util.GetHTTPCCRequestID(c.Request.Header)
 	usernameMap := map[string]string{}
 
-	if userList != nil && len(userList) != 0 {
-		params := make(map[string]string)
-		params["fields"] = "username,display_name"
-		user := plugins.CurrentPlugin(c, s.Config.LoginVersion)
-		// 处理请求的用户数据，每100个用户组成一个字符串进行用户数据的获取
-		userListStr := s.getUserListStr(userList)
-		var wg sync.WaitGroup
-		var lock sync.RWMutex
-		var firstErr errors.CCErrorCoder
-		pipeline := make(chan bool, 10)
-		userListEsb := make([]*metadata.LoginSystemUserInfo, 0)
-		for _, subStr := range userListStr {
-			pipeline <- true
-			wg.Add(1)
-			go func(subStr string) {
-				defer func() {
-					wg.Done()
-					<-pipeline
-				}()
-				params["exact_lookups"] = subStr
-				userListEsbSub, errNew := user.GetUserList(c, params)
-				if errNew != nil {
-					blog.Errorf("get user list from ESB failed, err: %s, rid: %s", errNew.ToCCError(defErr), rid)
-					firstErr = errNew.ToCCError(defErr)
-					return
-				}
-
-				lock.Lock()
-				userListEsb = append(userListEsb, userListEsbSub...)
-				lock.Unlock()
-			}(subStr)
-		}
-		wg.Wait()
-
-		if firstErr != nil {
-			return nil, firstErr
-		}
-
-		for _, userInfo := range userListEsb {
-			username := fmt.Sprintf("%s(%s)", userInfo.EnName, userInfo.CnName)
-			usernameMap[userInfo.EnName] = username
-		}
+	if len(userList) == 0 {
 		return usernameMap, nil
+	}
+
+	params := make(map[string]string)
+	params["fields"] = "username,display_name"
+	user := plugins.CurrentPlugin(c, s.Config.LoginVersion)
+
+	// 处理请求的用户数据，将用户拼接成不超过500字节的字符串进行用户数据的获取
+	userListStr := s.getUserListStr(userList)
+
+	var wg sync.WaitGroup
+	var lock sync.RWMutex
+	var firstErr errors.CCErrorCoder
+	pipeline := make(chan bool, 10)
+	userListEsb := make([]*metadata.LoginSystemUserInfo, 0)
+
+	for _, subStr := range userListStr {
+		pipeline <- true
+		wg.Add(1)
+		go func(subStr string) {
+			defer func() {
+				wg.Done()
+				<-pipeline
+			}()
+
+			lock.Lock()
+			params["exact_lookups"] = subStr
+			c.Request.Header = c.Request.Header.Clone()
+			lock.Unlock()
+
+			userListEsbSub, errNew := user.GetUserList(c, params)
+			if errNew != nil {
+				firstErr = errNew.ToCCError(defErr)
+				blog.Errorf("get users(%s) list from ESB failed, err: %v, rid: %s", subStr, firstErr, rid)
+				return
+			}
+
+			lock.Lock()
+			userListEsb = append(userListEsb, userListEsbSub...)
+			lock.Unlock()
+		}(subStr)
+	}
+	wg.Wait()
+
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	for _, userInfo := range userListEsb {
+		username := fmt.Sprintf("%s(%s)", userInfo.EnName, userInfo.CnName)
+		usernameMap[userInfo.EnName] = username
 	}
 	return usernameMap, nil
 }
 
+const getUserMaxLength = 500
+
 // getUserListStr get user list str
 func (s *Service) getUserListStr(userList []string) []string {
-	userListLen := len(userList)
 	userListStr := make([]string, 0)
-	const getUserMaxCount = 100
-	if userListLen <= getUserMaxCount {
-		userStr := strings.Join(userList, ",")
-		userListStr = append(userListStr, userStr)
-		return userListStr
+
+	userBuffer := bytes.Buffer{}
+	for _, user := range userList {
+		if userBuffer.Len()+len(user) > getUserMaxLength {
+			userStr := userBuffer.String()
+			userListStr = append(userListStr, userStr[:len(userStr)-1])
+			userBuffer.Reset()
+			continue
+		}
+
+		userBuffer.WriteString(user)
+		userBuffer.WriteByte(',')
 	}
 
-	for i := 0; i < userListLen; i += getUserMaxCount {
-		if i+getUserMaxCount < userListLen {
-			subUserList := userList[i : i+getUserMaxCount]
-			userStr := strings.Join(subUserList, ",")
-			userListStr = append(userListStr, userStr)
-		} else {
-			subUserList := userList[i:userListLen]
-			userStr := strings.Join(subUserList, ",")
-			userListStr = append(userListStr, userStr)
-		}
+	if userBuffer.Len() == 0 {
+		return userList
 	}
+
+	userStr := userBuffer.String()
+	userListStr = append(userListStr, userStr[:len(userStr)-1])
 
 	return userListStr
 }


### PR DESCRIPTION
### 修复的问题：
- 修复excel导出时用户名太多导致超过esb限制的问题
- 修复excel导出时map并发读写panic的问题
