### PR TITLE
设置hostid文件同步到机器时旧文件的备份名

### DIFF
--- a/src/scene_server/event_server/sync/hostidentifier/hostIdentifier.go
+++ b/src/scene_server/event_server/sync/hostidentifier/hostIdentifier.go
@@ -429,6 +429,7 @@ func (h *HostIdentifier) buildPushFile(hostIdentifier, hostIP string, cloudID in
 	fileInfo.MFile.MPath = conf.FilePath
 	fileInfo.MFile.MOwner = conf.FileOwner
 	fileInfo.MFile.MRight = conf.FilePrivilege
+	fileInfo.MFile.MBackupName = conf.FileName + ".bak"
 
 	return fileInfo
 }


### PR DESCRIPTION
### 优化的功能:
- 设置hostid文件同步到机器时旧文件的备份名，防止根据时间更改旧文件名，导致文件越来越多

