### PR TITLE
修复主机转移模块场景下，如果涉及到新增服务实例，不能超过100的限制

### DIFF
--- a/src/scene_server/host_server/service/transfer.go
+++ b/src/scene_server/host_server/service/transfer.go
@@ -294,20 +294,19 @@ func (s *Service) upsertServiceInstance(kit *rest.Kit, bizID int64,
 				wg.Done()
 			}()
 
-			start := 0
-			flag := false
-			instances, tmpInstances := svrInstOpt.Instances, svrInstOpt.Instances
+			instances := svrInstOpt.Instances
 
-			for {
+			total := len(instances)
+			for start := 0; start < total; start += common.BKMaxUpdateOrCreatePageSize {
 				// 这里需要进行分批处理，一次处理100个
-				if len(tmpInstances) > common.BKMaxUpdateOrCreatePageSize {
-					svrInstOpt.Instances = tmpInstances[0:common.BKMaxUpdateOrCreatePageSize]
-					start = start + common.BKMaxUpdateOrCreatePageSize
-					tmpInstances = instances[start:]
+				var tmpInstances []metadata.CreateServiceInstanceDetail
+				if total-start >= common.BKMaxUpdateOrCreatePageSize {
+					tmpInstances = instances[start : start+common.BKMaxUpdateOrCreatePageSize]
 				} else {
-					svrInstOpt.Instances = instances[start:]
-					flag = true
+					tmpInstances = instances[start:total]
 				}
+
+				svrInstOpt.Instances = tmpInstances
 
 				_, ccErr := s.CoreAPI.ProcServer().Service().CreateServiceInstance(kit.Ctx, kit.Header, svrInstOpt)
 				if ccErr != nil {
@@ -317,9 +316,6 @@ func (s *Service) upsertServiceInstance(kit *rest.Kit, bizID int64,
 					blog.Errorf("create service instances failed, option: %#v, err: %v, rid: %s", ccErr, svrInstOpt,
 						kit.Rid)
 					return
-				}
-				if flag {
-					break
 				}
 			}
 		}(svrInstOpt)


### PR DESCRIPTION
### 修复的问题：
- 主机转移模块，如果目标模块需要创建服务实例，由于proc进程创建服务实例新增了不超过100的限制，所以主机模块转移需要同步做兼容处理。
