### PR TITLE
修复通过Excel修复通过Excel更新实例数据时，关联关系数据无法删除问题

### DIFF
--- a/src/web_server/logics/excel_util.go
+++ b/src/web_server/logics/excel_util.go
@@ -67,7 +67,8 @@ func getCustomFields(filterFields []string, customFieldsStr string) []string {
 }
 
 // checkExcelHeader check whether invalid fields exists in header and return headers
-func checkExcelHeader(ctx context.Context, sheet *xlsx.Sheet, fields map[string]Property, isCheckHeader bool, defLang lang.DefaultCCLanguageIf) (map[int]string, error) {
+func checkExcelHeader(ctx context.Context, sheet *xlsx.Sheet, fields map[string]Property, isCheckHeader bool,
+	defLang lang.DefaultCCLanguageIf) (map[int]string, error) {
 	rid := util.ExtractRequestIDFromContext(ctx)
 
 	// rowLen := len(sheet.Rows[headerRow-1].Cells)
@@ -94,11 +95,9 @@ func checkExcelHeader(ctx context.Context, sheet *xlsx.Sheet, fields map[string]
 		}
 		ret[index] = strName
 	}
-	// valid excel three row is instance property fields,
-	// excel three row  values  exceeding 1/2 does not appear in the field array,
-	// indicating that the third line of the excel template was deleted
-	if len(errCells) > len(sheet.Rows[headerRow-1].Cells)/2 && true == isCheckHeader {
-		blog.Errorf("err:%s, no found fields %s, rid:%s", defLang.Language("web_import_field_not_found"), strings.Join(errCells, ","), rid)
+	if len(sheet.Rows[headerRow-1].Cells) < 2 && true == isCheckHeader {
+		blog.Errorf("err:%s, no found fields %s, rid:%s", defLang.Language("web_import_field_not_found"),
+			strings.Join(errCells, ","), rid)
 		return ret, errors.New(defLang.Language("web_import_field_not_found"))
 	}
 	return ret, nil


### PR DESCRIPTION
### 修复的问题：
- 修复通过Excel修复通过Excel更新实例数据时，关联关系数据无法删除问题
