### PR TITLE
fix: v3.8.x关闭构建流程中的eslint检查解决过时依赖包兼容问题

### DIFF
--- a/src/ui/config/index.js
+++ b/src/ui/config/index.js
@@ -55,7 +55,7 @@ const dev = {
     // Use Eslint Loader?
     // If true, your code will be linted during bundling and
     // linting errors and warnings will be shown in the console.
-    useEslint: true,
+    useEslint: false,
     // If true, eslint errors and warnings will also be shown in the error overlay
     // in the browser.
     showEslintErrorsInOverlay: true,


### PR DESCRIPTION
### 修复的问题：
- 关闭构建流程中的eslint检查解决过时依赖包兼容问题
