### PR TITLE
修改monstache默认镜像版本为v2.0.0

### DIFF
--- a/docs/support-file/helm/values.yaml
+++ b/docs/support-file/helm/values.yaml
@@ -1718,7 +1718,7 @@ monstache:
   ##
   image:
     repository: blueking/cmdb_monstache
-    tag: v1.0.0
+    tag: v2.0.0
   ## @param monstache.replicas Number of monstache replicas to deploy
   ##
   replicas: 1


### PR DESCRIPTION
### 优化的功能:
- 修改monstache默认镜像版本为v2.0.0
