### PR TITLE
修复服务模板配置主机自动应用场景下，通过api接口转移主机未能实现主机自动应用

### DIFF
--- a/src/source_controller/coreservice/core/host/transfer/transfer.go
+++ b/src/source_controller/coreservice/core/host/transfer/transfer.go
@@ -113,7 +113,7 @@ func (t *genericTransfer) Transfer(kit *rest.Kit, hostIDs []int64, disableHostAp
 	}
 
 	// transfer host module config
-	if err := t.addHostModuleRelation(kit, hostIDs, disableHostApply); err != nil {
+	if err := t.addHostModuleRelationAndHostApply(kit, hostIDs, disableHostApply); err != nil {
 		return err
 	}
 
@@ -360,12 +360,12 @@ func (t *genericTransfer) delHostModuleRelationItem(kit *rest.Kit, bizIDs []int6
 	return nil
 }
 
-// AddSingleHostModuleRelation add single host module relation
-func (t *genericTransfer) addHostModuleRelation(kit *rest.Kit, hostIDs []int64, disable bool) errors.CCErrorCoder {
+// addHostModuleRelationAndHostApply add single host module relation and implement host properties apply
+func (t *genericTransfer) addHostModuleRelationAndHostApply(kit *rest.Kit, hostIDs []int64,
+	disable bool) errors.CCErrorCoder {
 	if len(hostIDs) == 0 || len(t.moduleIDArr) == 0 {
 		return nil
 	}
-
 	existHostModuleIDMap := make(map[int64]map[int64]struct{}, 0)
 
 	// filter already exist modules


### PR DESCRIPTION
### 修复的问题：
- 修复服务模板配置主机自动应用场景下，通过api接口转移主机未能实现主机自动应用 close#6254
