### PR TITLE
修复当没有配置集群模版属性时，查询不到对应模版的实例

### DIFF
--- a/src/scene_server/topo_server/logics/settemplate/sync_status.go
+++ b/src/scene_server/topo_server/logics/settemplate/sync_status.go
@@ -281,11 +281,11 @@ func (st *setTemplate) ListSetTemplateSyncStatus(kit *rest.Kit, option *metadata
 	if cErr != nil {
 		return nil, cErr
 	}
-	if len(propertyIDs) == 0 {
-		return &metadata.ListAPITaskSyncStatusResult{Count: 0, Info: make([]metadata.APITaskSyncStatus, 0)}, nil
-	}
+
 	fields := []string{common.BKSetIDField}
-	fields = append(fields, propertyIDs...)
+	if len(propertyIDs) > 0 {
+		fields = append(fields, propertyIDs...)
+	}
 
 	sets, err := st.getSetMapStrByOption(kit, option, fields)
 	if err != nil {


### PR DESCRIPTION
### 修复的问题：
- 修复当没有配置集群模版属性时，查询不到对应模版的实例
