### PR TITLE
修复权限迁移使用了GetInt64ByInterface解析string导致报错的问题

### DIFF
--- a/src/common/util/conv.go
+++ b/src/common/util/conv.go
@@ -85,7 +85,7 @@ func GetInt32ByInterface(a interface{}) (int32, error) {
 	return id, err
 }
 
-// GetInt64ByInterface get int64 by interface
+// GetInt64ByInterface parse interface to int64, **notice: string type is not allowed**
 func GetInt64ByInterface(a interface{}) (int64, error) {
 	var id int64 = 0
 	var err error
@@ -99,7 +99,7 @@ func GetInt64ByInterface(a interface{}) (int64, error) {
 	case int32:
 		id = int64(a.(int32))
 	case int64:
-		id = int64(a.(int64))
+		id = a.(int64)
 	case uint:
 		id = int64(a.(uint))
 	case uint8:

--- a/src/scene_server/admin_server/upgrader/y3.10.202109131607/util.go
+++ b/src/scene_server/admin_server/upgrader/y3.10.202109131607/util.go
@@ -139,11 +139,20 @@ func parseAutomaticInstancePolicy(policy *operator.Policy) (*parsedInstancePolic
 		// one id's policy uses equal operator, while multiple ids are aggregated into one policy with in operator
 		switch policy.Operator {
 		case operator.Equal:
-			id, err := util.GetInt64ByInterface(value)
-			if err != nil {
-				return nil, fmt.Errorf("parse policy op(%s) id value(%#v) failed, err: %v", policy.Operator, value, err)
+			switch v := value.(type) {
+			case string:
+				id, err := strconv.ParseInt(v, 10, 64)
+				if err != nil {
+					return nil, fmt.Errorf("parse policy op(%s) id(%s) failed, err: %v", policy.Operator, v, err)
+				}
+				ids = []int64{id}
+			default:
+				id, err := util.GetInt64ByInterface(v)
+				if err != nil {
+					return nil, fmt.Errorf("parse policy op(%s) id(%#v) failed, err: %v", policy.Operator, v, err)
+				}
+				ids = []int64{id}
 			}
-			ids = []int64{id}
 		case operator.In:
 			valueArr, ok := value.([]interface{})
 			if !ok || len(valueArr) == 0 {
@@ -152,9 +161,17 @@ func parseAutomaticInstancePolicy(policy *operator.Policy) (*parsedInstancePolic
 			var err error
 			ids = make([]int64, len(valueArr))
 			for index, val := range valueArr {
-				ids[index], err = util.GetInt64ByInterface(val)
-				if err != nil {
-					return nil, fmt.Errorf("parse policy op(%s) id(%#v) failed, err: %v", policy.Operator, val, err)
+				switch v := val.(type) {
+				case string:
+					ids[index], err = strconv.ParseInt(v, 10, 64)
+					if err != nil {
+						return nil, fmt.Errorf("parse policy op(%s) id(%s) failed, err: %v", policy.Operator, v, err)
+					}
+				default:
+					ids[index], err = util.GetInt64ByInterface(v)
+					if err != nil {
+						return nil, fmt.Errorf("parse policy op(%s) id(%#v) failed, err: %v", policy.Operator, v, err)
+					}
 				}
 			}
 		default:


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
