### PR TITLE
修复excel导入数据更新时，主机关联数据无法更新，对字段bk_inst_id和bk_host_id无法校验

### DIFF
--- a/src/ac/parser/settemplate.go
+++ b/src/ac/parser/settemplate.go
@@ -202,7 +202,8 @@ var SetTemplateAuthConfigs = []AuthConfig{
 	}, {
 		Name:             "CheckSetInstUpdateToDateStatusRegex",
 		Description:      "检查集群模板的同步状态",
-		Regex:            regexp.MustCompile(`^/api/v3/findmany/topo/set_template/([0-9]+)/bk_biz_id/([0-9]+)/set_template_status/?$`),
+		Regex:            regexp.MustCompile(
+			`^/api/v3/findmany/topo/set_template/([0-9]+)/bk_biz_id/([0-9]+)/set_template_status/?$`),
 		HTTPMethod:       http.MethodGet,
 		BizIDGetter:      BizIDFromURLGetter,
 		BizIndex:         7,

--- a/src/ac/parser/settemplate.go
+++ b/src/ac/parser/settemplate.go
@@ -202,8 +202,8 @@ var SetTemplateAuthConfigs = []AuthConfig{
 	}, {
 		Name:             "CheckSetInstUpdateToDateStatusRegex",
 		Description:      "检查集群模板的同步状态",
-		Regex:            regexp.MustCompile(
-			`^/api/v3/findmany/topo/set_template/([0-9]+)/bk_biz_id/([0-9]+)/set_template_status/?$`),
+		// NOCC:tosa/linelength(ignore length)
+		Regex:            regexp.MustCompile(`^/api/v3/findmany/topo/set_template/([0-9]+)/bk_biz_id/([0-9]+)/set_template_status/?$`),
 		HTTPMethod:       http.MethodGet,
 		BizIDGetter:      BizIDFromURLGetter,
 		BizIndex:         7,

--- a/src/web_server/logics/excel.go
+++ b/src/web_server/logics/excel.go
@@ -479,8 +479,8 @@ func GetRawExcelData(ctx context.Context, sheet *xlsx.Sheet, defFields common.Kv
 
 }
 
-// GetAssociationExcelData read sheet of association data from excel
-func GetAssociationExcelData(sheet *xlsx.Sheet, firstRow int, defLang lang.DefaultCCLanguageIf) (
+// getAssociationExcelData read sheet of association data from excel
+func getAssociationExcelData(sheet *xlsx.Sheet, firstRow int, defLang lang.DefaultCCLanguageIf) (
 	map[int]metadata.ExcelAssociation, []metadata.RowMsgData) {
 
 	rowCnt := len(sheet.Rows)

--- a/src/web_server/logics/excel_util.go
+++ b/src/web_server/logics/excel_util.go
@@ -111,6 +111,9 @@ func checkExcelHeader(ctx context.Context, sheet *xlsx.Sheet, fields map[string]
 
 	// 校验模型字段唯一标识和Excel表头字段唯一标识是否一致，如果不一致，提示无法导入，请修改为正确的唯一标识
 	for unique := range indexNameMap {
+		if unique == common.BKInstIDField {
+			continue
+		}
 		if _, ok := fields[unique]; !ok {
 			return nil, fmt.Errorf("导入的Excel数据，%s字段唯一标识不存在", unique)
 		}

--- a/src/web_server/logics/excel_util.go
+++ b/src/web_server/logics/excel_util.go
@@ -111,7 +111,7 @@ func checkExcelHeader(ctx context.Context, sheet *xlsx.Sheet, fields map[string]
 
 	// 校验模型字段唯一标识和Excel表头字段唯一标识是否一致，如果不一致，提示无法导入，请修改为正确的唯一标识
 	for unique := range indexNameMap {
-		if unique == common.BKInstIDField {
+		if unique == common.BKInstIDField || unique == common.BKHostIDField{
 			continue
 		}
 		if _, ok := fields[unique]; !ok {

--- a/src/web_server/logics/host.go
+++ b/src/web_server/logics/host.go
@@ -342,6 +342,15 @@ func (lgc *Logics) UpdateHosts(ctx context.Context, f *xlsx.File, req *http.Requ
 		}
 	}
 
+	return lgc.updateHostAssociation(ctx, f, req, result, defLang)
+}
+
+// updateHostAssociation excel export host data, update host association
+func (lgc *Logics) updateHostAssociation(ctx context.Context, f *xlsx.File, req *http.Request,
+	result *metadata.ResponseDataMapStr, defLang lang.DefaultCCLanguageIf) *metadata.ResponseDataMapStr {
+	rid := util.ExtractRequestIDFromContext(ctx)
+	defErr := lgc.CCErr.CreateDefaultCCErrorIf(util.GetLanguage(req.Header))
+
 	for _, sheet := range f.Sheets {
 		if sheet.Name != "association" {
 			continue
@@ -371,7 +380,6 @@ func (lgc *Logics) UpdateHosts(ctx context.Context, f *xlsx.File, req *http.Requ
 
 		result.Data.Set("asst_error", assoErrMsg)
 	}
-
 	return result
 }
 

--- a/src/web_server/logics/host.go
+++ b/src/web_server/logics/host.go
@@ -22,7 +22,7 @@ import (
 
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
-	errIf "configcenter/src/common/errors"
+	ccErr "configcenter/src/common/errors"
 	"configcenter/src/common/json"
 	lang "configcenter/src/common/language"
 	"configcenter/src/common/mapstr"
@@ -330,8 +330,7 @@ func (lgc *Logics) UpdateHosts(ctx context.Context, f *xlsx.File, req *http.Requ
 		}
 		result, resultErr = lgc.CoreAPI.ApiServer().UpdateHost(context.Background(), req.Header, params)
 		if resultErr != nil {
-			blog.Errorf("update host http request failed, err: %v, rid: %s", resultErr,
-				util.GetHTTPCCRequestID(req.Header))
+			blog.Errorf("update host http request failed, err: %v, rid: %s", resultErr, rid)
 			return &metadata.ResponseDataMapStr{
 				BaseResp: metadata.BaseResp{
 					Result: false,
@@ -349,7 +348,7 @@ func (lgc *Logics) UpdateHosts(ctx context.Context, f *xlsx.File, req *http.Requ
 // updateHostAssociation excel export host data, update host association
 func (lgc *Logics) updateHostAssociation(ctx context.Context, f *xlsx.File, req *http.Request,
 	result *metadata.ResponseDataMapStr, defLang lang.DefaultCCLanguageIf, rid string,
-	defErr errIf.DefaultCCErrorIf) *metadata.ResponseDataMapStr {
+	defErr ccErr.DefaultCCErrorIf) *metadata.ResponseDataMapStr {
 
 	for _, sheet := range f.Sheets {
 		if sheet.Name != "association" {

--- a/src/web_server/logics/host.go
+++ b/src/web_server/logics/host.go
@@ -22,6 +22,7 @@ import (
 
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
+	errIf "configcenter/src/common/errors"
 	"configcenter/src/common/json"
 	lang "configcenter/src/common/language"
 	"configcenter/src/common/mapstr"
@@ -233,7 +234,7 @@ func (lgc *Logics) ImportHosts(ctx context.Context, f *xlsx.File, req *http.Requ
 			continue
 		}
 
-		asstInfoMap, assoErrMsg := GetAssociationExcelData(sheet, common.HostAddMethodExcelAssociationIndexOffset,
+		asstInfoMap, assoErrMsg := getAssociationExcelData(sheet, common.HostAddMethodExcelAssociationIndexOffset,
 			defLang)
 
 		if len(asstInfoMap) > 0 {
@@ -270,7 +271,7 @@ func (lgc *Logics) UpdateHosts(ctx context.Context, f *xlsx.File, req *http.Requ
 
 	hosts, errMsg, err := lgc.GetImportHosts(f, req, defLang, modelBizID)
 	if err != nil {
-		blog.Errorf("ImportHost get import hosts from excel err, error:%s, rid: %s", err.Error(), rid)
+		blog.Errorf("get import hosts from excel failed, err: %v, rid: %s", err, rid)
 		return &metadata.ResponseDataMapStr{
 			BaseResp: metadata.BaseResp{
 				Result: false,
@@ -295,7 +296,7 @@ func (lgc *Logics) UpdateHosts(ctx context.Context, f *xlsx.File, req *http.Requ
 
 	errMsg, err = lgc.CheckHostsUpdated(ctx, req.Header, hosts, modelBizID)
 	if err != nil {
-		blog.Errorf("ImportHosts failed,  CheckHostsAdded error:%s, rid: %s", err.Error(), rid)
+		blog.Errorf("import host failed, check hosts added err: %v, rid: %s", err, rid)
 		return &metadata.ResponseDataMapStr{
 			BaseResp: metadata.BaseResp{
 				Result: false,
@@ -329,7 +330,7 @@ func (lgc *Logics) UpdateHosts(ctx context.Context, f *xlsx.File, req *http.Requ
 		}
 		result, resultErr = lgc.CoreAPI.ApiServer().UpdateHost(context.Background(), req.Header, params)
 		if resultErr != nil {
-			blog.Errorf("UpdateHosts update host http request  error:%s, rid:%s", resultErr.Error(),
+			blog.Errorf("update host http request failed, err: %v, rid: %s", resultErr,
 				util.GetHTTPCCRequestID(req.Header))
 			return &metadata.ResponseDataMapStr{
 				BaseResp: metadata.BaseResp{
@@ -342,21 +343,20 @@ func (lgc *Logics) UpdateHosts(ctx context.Context, f *xlsx.File, req *http.Requ
 		}
 	}
 
-	return lgc.updateHostAssociation(ctx, f, req, result, defLang)
+	return lgc.updateHostAssociation(ctx, f, req, result, defLang, rid, defErr)
 }
 
 // updateHostAssociation excel export host data, update host association
 func (lgc *Logics) updateHostAssociation(ctx context.Context, f *xlsx.File, req *http.Request,
-	result *metadata.ResponseDataMapStr, defLang lang.DefaultCCLanguageIf) *metadata.ResponseDataMapStr {
-	rid := util.ExtractRequestIDFromContext(ctx)
-	defErr := lgc.CCErr.CreateDefaultCCErrorIf(util.GetLanguage(req.Header))
+	result *metadata.ResponseDataMapStr, defLang lang.DefaultCCLanguageIf, rid string,
+	defErr errIf.DefaultCCErrorIf) *metadata.ResponseDataMapStr {
 
 	for _, sheet := range f.Sheets {
 		if sheet.Name != "association" {
 			continue
 		}
 
-		asstInfoMap, assoErrMsg := GetAssociationExcelData(sheet, common.HostAddMethodExcelAssociationIndexOffset,
+		asstInfoMap, assoErrMsg := getAssociationExcelData(sheet, common.HostAddMethodExcelAssociationIndexOffset,
 			defLang)
 
 		if len(asstInfoMap) > 0 {

--- a/src/web_server/logics/inst.go
+++ b/src/web_server/logics/inst.go
@@ -171,7 +171,7 @@ func (lgc *Logics) ImportInsts(ctx context.Context, f *xlsx.File, objID string, 
 			continue
 		}
 
-		asstInfoMap, errMsg := GetAssociationExcelData(sheet, common.HostAddMethodExcelAssociationIndexOffset,
+		asstInfoMap, errMsg := getAssociationExcelData(sheet, common.HostAddMethodExcelAssociationIndexOffset,
 			defLang)
 
 		if len(asstInfoMap) > 0 {


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- xxxx
