### PR TITLE
修复当watch产生error原因是context cancelled时，进程退出的问题

### DIFF
--- a/src/storage/stream/event/watch.go
+++ b/src/storage/stream/event/watch.go
@@ -14,6 +14,7 @@ package event
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 	"time"
@@ -88,7 +89,7 @@ func (e *Event) Watch(ctx context.Context, opts *types.WatchOptions) (*types.Wat
 		}
 
 		if err != nil {
-			if err == context.Canceled {
+			if errors.Is(err, context.Canceled) {
 				// if error is context cancelled, then loop watch will exit at the same time
 				return
 			}


### PR DESCRIPTION
### 修复的问题：
- 修复当watch产生error原因是context cancelled时，进程退出的问题
