### PR TITLE
instassttopo主机实例返回bk_host_innerip作为bk_inst_name

### DIFF
--- a/src/scene_server/topo_server/logics/inst/inst.go
+++ b/src/scene_server/topo_server/logics/inst/inst.go
@@ -1304,6 +1304,9 @@ func (c *commonInst) getAssociatedObjectWithInsts(kit *rest.Kit, objID string, i
 		if objPair.Object.IsCommon() {
 			innerCond.Condition[common.BKObjIDField] = objPair.Object.ObjectID
 		}
+		if objPair.Object.ObjectID == common.BKInnerObjIDHost {
+			innerCond.Fields = append(innerCond.Fields, common.BKHostInnerIPField)
+		}
 
 		rspItems, err := c.FindInst(kit, objPair.Object.ObjectID, innerCond)
 		if err != nil {


### PR DESCRIPTION
### 修复的问题：
- 查询实例topo时，主机实例没有bk_inst_name , 返回bk_host_innerip作为bk_inst_name
