### PR TITLE
修复创建模型时，supplierAccount不为0，模型在内置模型分组下创建失败问题

### DIFF
--- a/src/source_controller/coreservice/core/model/classification.go
+++ b/src/source_controller/coreservice/core/model/classification.go
@@ -289,27 +289,29 @@ func (m *modelClassification) DeleteModelClassification(kit *rest.Kit, inputPara
 	return &metadata.DeletedCount{Count: cnt}, nil
 }
 
-// SearchModelClassification TODO
-func (m *modelClassification) SearchModelClassification(kit *rest.Kit, inputParam metadata.QueryCondition) (*metadata.QueryModelClassificationDataResult, error) {
+// SearchModelClassification search model classification
+func (m *modelClassification) SearchModelClassification(kit *rest.Kit, inputParam metadata.QueryCondition) (
+	*metadata.QueryModelClassificationDataResult, error) {
 
 	dataResult := &metadata.QueryModelClassificationDataResult{
 		Info: []metadata.Classification{},
 	}
 	searchCond, err := mongo.NewConditionFromMapStr(inputParam.Condition.ToMapInterface())
 	if nil != err {
-		blog.Errorf("request(%s): it is failed to convert the condition (%#v) from mapstr into condition object, error info is %s", kit.Rid, inputParam.Condition, err.Error())
+		blog.Errorf("convert the condition from mapstr into condition object failed, cond: %v, err: %v, rid: %s",
+			inputParam.Condition, err, kit.Rid)
 		return dataResult, err
 	}
 
-	totalCount, err := m.count(kit, searchCond)
-	if nil != err {
-		blog.Errorf("request(%s): it is failed to get the count by the condition (%#v), error info is %s", kit.Rid, searchCond.ToMapStr(), err.Error())
+	totalCount, err := m.count(kit, searchCond.ToMapStr())
+	if err != nil {
+		blog.Errorf("get classification count failed, cond: %v, err: %v, rid: %s", searchCond.ToMapStr(), err, kit.Rid)
 		return dataResult, err
 	}
 
 	classificationItems, err := m.search(kit, searchCond)
-	if nil != err {
-		blog.Errorf("request(%s): it is failed to search some classifications by the condition (%#v), error info is %s", kit.Rid, searchCond.ToMapStr(), err.Error())
+	if err != nil {
+		blog.Errorf("search classifications failed, cond: %v, err: %v, rid: %s", searchCond.ToMapStr(), err, kit.Rid)
 		return dataResult, err
 	}
 

--- a/src/source_controller/coreservice/core/model/classification_crud.go
+++ b/src/source_controller/coreservice/core/model/classification_crud.go
@@ -23,11 +23,11 @@ import (
 	"configcenter/src/storage/driver/mongodb"
 )
 
-func (m *modelClassification) count(kit *rest.Kit, cond universalsql.Condition) (cnt uint64, err error) {
-	filter := util.SetModOwner(cond.ToMapStr(), kit.SupplierAccount)
+func (m *modelClassification) count(kit *rest.Kit, cond mapstr.MapStr) (cnt uint64, err error) {
+	filter := util.SetQueryOwner(cond, kit.SupplierAccount)
 	cnt, err = mongodb.Client().Table(common.BKTableNameObjClassification).Find(filter).Count(kit.Ctx)
 	if nil != err {
-		blog.Errorf("request(%s): it is failed to execute a database count operation on the table(%s) by the condition(%#v), error info is %s", kit.Rid, common.BKTableNameObjClassification, cond.ToMapStr(), err.Error())
+		blog.Errorf("execute a database count operation failed, cond: %#v, err: %v, rid: %s", cond, err, kit.Rid)
 		return 0, err
 	}
 	return cnt, err

--- a/src/source_controller/coreservice/core/model/classification_private.go
+++ b/src/source_controller/coreservice/core/model/classification_private.go
@@ -28,7 +28,7 @@ func (m *modelClassification) isValid(kit *rest.Kit, classificationID string) (b
 
 	cond := mongo.NewCondition()
 	cond.Element(&mongo.Eq{Key: metadata.ClassFieldClassificationID, Val: classificationID})
-	cnt, err := m.count(kit, cond)
+	cnt, err := m.count(kit, cond.ToMapStr())
 	return 0 != cnt, err
 }
 


### PR DESCRIPTION
### 修复的问题：
- 修复创建模型时，supplierAccount不为0，模型在内置模型分组下创建失败问题
