### PR TITLE
修复组织类型字段为空时，无法导出实例数据

### DIFF
--- a/src/web_server/logics/excel_util.go
+++ b/src/web_server/logics/excel_util.go
@@ -110,15 +110,17 @@ func checkExcelHeader(ctx context.Context, sheet *xlsx.Sheet, fields map[string]
 	}
 
 	// 校验模型字段唯一标识和Excel表头字段唯一标识是否一致，如果不一致，提示无法导入，请修改为正确的唯一标识
-	for unique := range indexNameMap {
-		if unique == common.BKInstIDField || unique == common.BKHostIDField{
-			continue
-		}
-		if _, ok := fields[unique]; !ok {
-			return nil, fmt.Errorf("导入的Excel数据，%s字段唯一标识不存在", unique)
+	// 当导入模型字段时，fields为空，跳过校验
+	if len(fields) > 0 {
+		for unique := range indexNameMap {
+			if unique == common.BKInstIDField || unique == common.BKHostIDField {
+				continue
+			}
+			if _, ok := fields[unique]; !ok {
+				return nil, fmt.Errorf("导入的Excel数据，%s字段唯一标识不存在", unique)
+			}
 		}
 	}
-
 	// valid excel three row is instance property fields
 	// indicating that the third line of the excel template was deleted
 	if len(sheet.Rows[headerRow-1].Cells) < 2 && isCheckHeader {

--- a/src/web_server/logics/util.go
+++ b/src/web_server/logics/util.go
@@ -231,7 +231,7 @@ func replaceDepartmentFullName(rid string, rowMap mapstr.MapStr, org []metadata.
 
 	for _, property := range propertyList {
 		orgIDInterface, exist := rowMap[property]
-		if !exist {
+		if !exist || orgIDInterface == nil{
 			continue
 		}
 


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- 修复组织类型字段为空时，无法导出实例数据
- 修复导入模型字段时，fields为空，无法做字段是否存在的校验
