### PR TITLE
修复当没有自定义层级时，调用查询主机及其对应topo接口报错问题

### DIFF
--- a/src/scene_server/host_server/logics/host.go
+++ b/src/scene_server/host_server/logics/host.go
@@ -1220,11 +1220,10 @@ loop:
 		idField := common.GetInstIDField(root)
 		for _, children := range rootInstances {
 
-			childObj := reverseRankMap[root]
 			for _, one := range children {
-				childID, err := util.GetInt64ByInterface(one[common.GetInstIDField(childObj)])
+				childID, err := util.GetInt64ByInterface(one[common.GetInstIDField(root)])
 				if err != nil {
-					blog.Errorf("get %s instance id failed, inst: %v, err: %v, rid: %s", childObj, one, err, rid)
+					blog.Errorf("get %s instance id failed, inst: %v, err: %v, rid: %s", root, one, err, rid)
 					return nil, err
 				}
 				node := &metadata.HostTopoNode{


### PR DESCRIPTION
### 修复的问题：
- 修复当没有自定义层级时，调用查询主机及其对应topo接口报错问题
