### PR TITLE
适配主机只有单独ipv6地址的场景

### DIFF
--- a/src/scene_server/topo_server/logics/inst/association.go
+++ b/src/scene_server/topo_server/logics/inst/association.go
@@ -162,6 +162,10 @@ func (assoc *association) SearchInstAssociationUIList(kit *rest.Kit, objID strin
 	for instObjID, instIDArr := range objIDInstIDMap {
 
 		idField := metadata.GetInstIDFieldByObjID(instObjID)
+		fields := []string{metadata.GetInstNameFieldName(instObjID), idField}
+		if instObjID == common.BKInnerObjIDHost {
+			fields = append(fields, common.BKHostInnerIPv6Field)
+		}
 		input := &metadata.QueryCondition{
 			Condition: mapstr.MapStr{
 				idField: mapstr.MapStr{common.BKDBIN: instIDArr},
@@ -170,7 +174,7 @@ func (assoc *association) SearchInstAssociationUIList(kit *rest.Kit, objID strin
 				Start: 0,
 				Limit: common.BKNoLimit,
 			},
-			Fields: []string{metadata.GetInstNameFieldName(instObjID), idField},
+			Fields: fields,
 		}
 		instResp, err := assoc.clientSet.CoreService().Instance().ReadInstance(kit.Ctx, kit.Header, instObjID, input)
 		if err != nil {
@@ -253,7 +257,7 @@ func (assoc *association) CreateInstanceAssociation(kit *rest.Kit, request *meta
 		Condition: mapstr.MapStr{
 			common.AssociationObjAsstIDField: request.ObjectAsstID,
 		},
-		Fields: []string{common.AssociationKindIDField},
+		Fields:         []string{common.AssociationKindIDField},
 		DisableCounter: true,
 	}
 	result, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(kit.Ctx, kit.Header, cond)
@@ -329,7 +333,7 @@ func (assoc *association) CreateManyInstAssociation(kit *rest.Kit, request *meta
 		Condition: mapstr.MapStr{
 			common.AssociationObjAsstIDField: request.ObjectAsstID,
 		},
-		Fields: []string{common.AssociationKindIDField},
+		Fields:         []string{common.AssociationKindIDField},
 		DisableCounter: true,
 	}
 	result, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(kit.Ctx, kit.Header, cond)

--- a/src/source_controller/coreservice/core/hostapplyrule/plan.go
+++ b/src/source_controller/coreservice/core/hostapplyrule/plan.go
@@ -62,7 +62,8 @@ func (p *hostApplyRule) GenerateApplyPlan(kit *rest.Kit, bizID int64, option met
 		return result, err
 	}
 
-	fields := []string{common.BKHostIDField, common.BKHostInnerIPField, common.BKCloudIDField, common.BKHostNameField}
+	fields := []string{common.BKHostIDField, common.BKHostInnerIPField, common.BKHostInnerIPv6Field,
+		common.BKCloudIDField, common.BKHostNameField}
 	for _, attr := range attributes {
 		fields = append(fields, attr.PropertyID)
 	}

--- a/src/source_controller/coreservice/core/process/service_instance.go
+++ b/src/source_controller/coreservice/core/process/service_instance.go
@@ -662,6 +662,9 @@ func (p *processOperation) ConstructServiceInstanceName(kit *rest.Kit, instanceI
 	process *metadata.Process) (string, errors.CCErrorCoder) {
 
 	serviceInstanceName := util.GetStrByInterface(host[common.BKHostInnerIPField])
+	if serviceInstanceName == "" {
+		serviceInstanceName = util.GetStrByInterface(host[common.BKHostInnerIPv6Field])
+	}
 
 	if process != nil {
 		if process.ProcessName != nil && len(*process.ProcessName) > 0 {
@@ -792,9 +795,11 @@ func (p *processOperation) AutoCreateServiceInstanceModuleHost(kit *rest.Kit, ho
 	}
 
 	hosts := make([]metadata.HostMapStr, 0)
+	fields := []string{common.BKHostIDField, common.BKHostInnerIPField,
+		common.BKHostInnerIPv6Field, common.BKHostOuterIPField}
 	hostFilter := map[string]interface{}{common.BKHostIDField: map[string]interface{}{common.BKDBIN: hostIDs}}
-	if err = mongodb.Client().Table(common.BKTableNameBaseHost).Find(hostFilter).Fields(common.BKHostIDField,
-		common.BKHostInnerIPField, common.BKHostOuterIPField).All(kit.Ctx, &hosts); err != nil {
+	if err = mongodb.Client().Table(common.BKTableNameBaseHost).Find(hostFilter).Fields(fields...).
+		All(kit.Ctx, &hosts); err != nil {
 		return kit.CCError.CCError(common.CCErrCommDBSelectFailed)
 	}
 


### PR DESCRIPTION
### 新加的功能:
- 关联关系中显示只有ipv6地址的主机
- 服务实例名字支持只有ipv6地址的主机
- 主机自动应用预览场景支持显示ipv6地址

