### PR TITLE
优化权限中心的主机列表ipv4和ipv6字段用竖线分割

### DIFF
--- a/src/scene_server/auth_server/logics/util.go
+++ b/src/scene_server/auth_server/logics/util.go
@@ -177,7 +177,7 @@ func getHostDisplayName(innerIP string, innerIPv6 string, cloudName string) stri
 		innerIPv6 = "--"
 	}
 
-	return innerIP + "/" + innerIPv6 + "(" + cloudName + ")"
+	return innerIP + "|" + innerIPv6 + "(" + cloudName + ")"
 }
 
 // GetModelsIDNameMap get a map, key is id, value is bk_obj_name


### PR DESCRIPTION
### 优化的功能:
- 优化权限中心的主机列表ipv4和IPv6字段用竖线分割