### PR TITLE
excel导入关联关系时，对关联关系映射进行校验

### DIFF
--- a/src/scene_server/topo_server/logics/inst/association.go
+++ b/src/scene_server/topo_server/logics/inst/association.go
@@ -47,7 +47,8 @@ type AssociationOperationInterface interface {
 	// TopoNodeHostAndSerInstCount get topo node host and service instance count
 	TopoNodeHostAndSerInstCount(kit *rest.Kit, input *metadata.HostAndSerInstCountOption) (
 		[]*metadata.TopoNodeHostAndSerInstCount, errors.CCError)
-
+	CheckInstAsstMapping(kit *rest.Kit, objID string, mapping metadata.AssociationMapping,
+		input *metadata.CreateAssociationInstRequest) error
 	// SetProxy proxy the interface
 	SetProxy(inst InstOperationInterface)
 }
@@ -190,8 +191,8 @@ func (assoc *association) SearchInstAssociationUIList(kit *rest.Kit, objID strin
 	return result, rsp.Count, nil
 }
 
-// checkInstAsstMapping use to check if instance association mapping correct, used by CreateInstanceAssociation
-func (assoc *association) checkInstAsstMapping(kit *rest.Kit, objID string, mapping metadata.AssociationMapping,
+// CheckInstAsstMapping use to check if instance association mapping correct, used by CreateInstanceAssociation
+func (assoc *association) CheckInstAsstMapping(kit *rest.Kit, objID string, mapping metadata.AssociationMapping,
 	input *metadata.CreateAssociationInstRequest) error {
 
 	tableName := common.GetObjectInstAsstTableName(objID, kit.SupplierAccount)
@@ -253,7 +254,7 @@ func (assoc *association) CreateInstanceAssociation(kit *rest.Kit, request *meta
 		Condition: mapstr.MapStr{
 			common.AssociationObjAsstIDField: request.ObjectAsstID,
 		},
-		Fields: []string{common.AssociationKindIDField},
+		Fields:         []string{common.AssociationKindIDField},
 		DisableCounter: true,
 	}
 	result, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(kit.Ctx, kit.Header, cond)
@@ -272,7 +273,7 @@ func (assoc *association) CreateInstanceAssociation(kit *rest.Kit, request *meta
 		return nil, kit.CCError.Error(common.CCErrorTopoObjectAssociationNotUnique)
 	}
 
-	if err := assoc.checkInstAsstMapping(kit, result.Info[0].ObjectID, result.Info[0].Mapping, request); err != nil {
+	if err := assoc.CheckInstAsstMapping(kit, result.Info[0].ObjectID, result.Info[0].Mapping, request); err != nil {
 		blog.Errorf("check mapping failed, err: %v, rid: %s", err, kit.Rid)
 		return nil, err
 	}
@@ -329,7 +330,7 @@ func (assoc *association) CreateManyInstAssociation(kit *rest.Kit, request *meta
 		Condition: mapstr.MapStr{
 			common.AssociationObjAsstIDField: request.ObjectAsstID,
 		},
-		Fields: []string{common.AssociationKindIDField},
+		Fields:         []string{common.AssociationKindIDField},
 		DisableCounter: true,
 	}
 	result, err := assoc.clientSet.CoreService().Association().ReadModelAssociation(kit.Ctx, kit.Header, cond)

--- a/src/scene_server/topo_server/logics/logics.go
+++ b/src/scene_server/topo_server/logics/logics.go
@@ -83,6 +83,7 @@ func New(client apimachinery.ClientSetInterface, authManager *extensions.AuthMan
 	instOperation.SetProxy(instAssociationOperation)
 	instAssociationOperation.SetProxy(instOperation)
 	associationOperation.SetProxy(objectOperation, instOperation, instAssociationOperation)
+	importAssociationOperation.SetProxy(instAssociationOperation)
 	groupOperation.SetProxy(objectOperation)
 	setOperation.SetProxy(instOperation, moduleOperation)
 	moduleOperation.SetProxy(instOperation)


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- excel导入关联关系数据时，对1:1,1:n进行校验
