### PR TITLE
全文检索放开查询字符串的长度

### DIFF
--- a/src/scene_server/topo_server/service/fulltextsearch.go
+++ b/src/scene_server/topo_server/service/fulltextsearch.go
@@ -78,7 +78,7 @@ var (
 	esPipelineConcurrency = 50
 
 	// esQueryStringLengthLimit query_string length limit(utf-8).
-	esQueryStringLengthLimit = 32
+	esQueryStringLengthLimit = 50
 )
 
 // SearchResult fulltext search result.


### PR DESCRIPTION
### 优化的功能:
- 由于需要支持完整的ipv6地址进行全文检索，将全文检索的查询字符长度到放开到50.
