### PR TITLE
放框全文检索的查询字符串长度

### DIFF
--- a/src/scene_server/topo_server/service/fulltextsearch.go
+++ b/src/scene_server/topo_server/service/fulltextsearch.go
@@ -78,7 +78,7 @@ var (
 	esPipelineConcurrency = 50
 
 	// esQueryStringLengthLimit query_string length limit(utf-8).
-	esQueryStringLengthLimit = 32
+	esQueryStringLengthLimit = 50
 )
 
 // SearchResult fulltext search result.


### PR DESCRIPTION
### 优化的功能:
- 支持ipv6全字符全文检索查询，放宽允许查询的字符长度

