### PR TITLE
更新实例时，唯一校验失败提示不明确

### DIFF
--- a/src/source_controller/coreservice/core/instances/instance_crud.go
+++ b/src/source_controller/coreservice/core/instances/instance_crud.go
@@ -92,7 +92,7 @@ func (m *instanceManager) update(kit *rest.Kit, objID string, data mapstr.MapStr
 		blog.ErrorJSON("update instance error. err: %s, objID: %s, instance: %s, cond: %s, rid: %s",
 			err.Error(), objID, data, cond, kit.Rid)
 		if mongodb.Client().IsDuplicatedError(err) {
-			return kit.CCError.CCError(common.CCErrCommDuplicateItem)
+			return kit.CCError.CCErrorf(common.CCErrCommDuplicateItem, mongodb.GetDuplicateKey(err))
 		}
 		return kit.CCError.Error(common.CCErrCommDBUpdateFailed)
 	}


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- 更新实例时，唯一校验失败，错误提示不明显，没有将真正的错误展示给用户，导致用户觉得很奇怪
![image](https://user-images.githubusercontent.com/39582223/209623519-e900bf06-6284-4265-94c4-c00d27490fd0.png)
![image](https://user-images.githubusercontent.com/39582223/209623544-cce8e50d-3f36-4414-a2a1-eb82cd9ca2fc.png)
将真实的错误返回，用户看到错误即可看出错误原因了
![image](https://user-images.githubusercontent.com/39582223/209624056-4b804433-bf50-4112-9c07-c20a9f5ac547.png)

