### PR TITLE
拷贝时使用绝对路径, 资源压根就没有拷贝进镜像.

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -31,7 +31,7 @@ def generate_docker_file(image, src_dir, dst_dir, output):
             run_cmd_params.append("RUN mkdir -p /" + target_dir)
         for f in files:
             target_file = os.path.normpath(dst_dir+"/"+new_root+"/"+f)
-            copy_cmd_params.append("COPY /" + os.path.normpath(dst_dir+"/"+new_root) + "/" + f + " /" + target_file)
+            copy_cmd_params.append("COPY " + os.path.normpath(dst_dir+"/"+new_root) + "/" + f + " /" + target_file)
 
     template = DockerfileTemplate(docker_file_template_str)
     result = template.substitute(dict(


### PR DESCRIPTION
### 修复的问题：
- 使用image.sh打包Docker镜像, 生成的Dockerfile中拷贝资源的路径为绝对路径
```
FROM  image_placeholder
....
COPY /cmdb_adminserver/stop.sh /cmdb_adminserver/stop.sh
COPY /cmdb_adminserver/refresh_config.sh /cmdb_adminserver/refresh_config.sh
COPY /cmdb_adminserver/ip.py /cmdb_adminserver/ip.py
COPY /cmdb_adminserver/template.sh.start /cmdb_adminserver/template.sh.start
COPY /cmdb_adminserver/init_db.sh /cmdb_adminserver/init_db.sh
```
其实这些脚本根本就没有被拷贝进镜像.

修改后生成的Dockerfile为:
```
FROM  image_placeholder
....
COPY cmdb_adminserver/stop.sh /cmdb_adminserver/stop.sh
COPY cmdb_adminserver/refresh_config.sh /cmdb_adminserver/refresh_config.sh
COPY cmdb_adminserver/ip.py /cmdb_adminserver/ip.py
COPY cmdb_adminserver/template.sh.start /cmdb_adminserver/template.sh.start
COPY cmdb_adminserver/init_db.sh /cmdb_adminserver/init_db.sh
```