### PR TITLE
fix: 修复查询业务使用bizPropertyFilter参数越权问题

### DIFF
--- a/src/scene_server/topo_server/service/inst_business.go
+++ b/src/scene_server/topo_server/service/inst_business.go
@@ -591,44 +591,12 @@ func (s *Service) SearchBusiness(ctx *rest.Contexts) {
 		userFields = append(userFields, attribute.PropertyID)
 	}
 
-	if searchCond.BizPropertyFilter != nil {
-		defErr := ctx.Kit.CCError
-		option := &querybuilder.RuleOption{
-			NeedSameSliceElementType: true,
-			MaxSliceElementsCount:    querybuilder.DefaultMaxSliceElementsCount,
-			MaxConditionOrRulesCount: querybuilder.DefaultMaxConditionOrRulesCount,
-		}
-
-		if key, err := searchCond.BizPropertyFilter.Validate(option); err != nil {
-			blog.Errorf("bizPropertyFilter is illegal, err: %v, rid:%s", err, ctx.Kit.Rid)
-			ccErr := defErr.CCErrorf(common.CCErrCommParamsInvalid, fmt.Sprintf("biz.property.%s", key))
-			ctx.RespAutoError(ccErr)
-			return
-		}
-
-		if searchCond.BizPropertyFilter.GetDeep() > querybuilder.MaxDeep {
-			blog.Errorf("bizPropertyFilter is illegal, rid: %s", ctx.Kit.Rid)
-			ccErr := defErr.CCErrorf(common.CCErrCommParamsInvalid,
-				fmt.Sprintf("exceed max query condition deepth: %d", querybuilder.MaxDeep))
-			ctx.RespAutoError(ccErr)
-			return
-		}
-
-		mgoFilter, key, err := searchCond.BizPropertyFilter.ToMgo()
-		if err != nil {
-			blog.Errorf("BizPropertyFilter ToMgo failed: %s, err: %v,  rid:%s", searchCond.BizPropertyFilter,
-				err, ctx.Kit.Rid)
-			ctx.RespAutoError(ctx.Kit.CCError.CCErrorf(common.CCErrCommParamsInvalid,
-				err.Error()+fmt.Sprintf(", biz_property_filter.%s", key)))
-			return
-		}
-		searchCond.Condition = mgoFilter
-	}
-
 	searchCond.Condition = handleSpecialBusinessFieldSearchCond(searchCond.Condition, userFields)
 
+	// parse business id from user's condition for testing.
 	bizIDs := make([]int64, 0)
 	authBizIDs := make([]int64, 0)
+	defErr := ctx.Kit.CCError
 	biz, exist := searchCond.Condition[common.BKAppIDField]
 	if exist {
 		// constrict that bk_biz_id field can only be a numeric value,
@@ -662,6 +630,41 @@ func (s *Service) SearchBusiness(ctx *rest.Contexts) {
 			}
 			bizIDs = []int64{bizID}
 		}
+	}
+
+	// Only one of biz_property_filter and condition parameters can take effect, and condition is not recommended to
+	// continue to use it.
+	if searchCond.BizPropertyFilter != nil {
+		option := &querybuilder.RuleOption{
+			NeedSameSliceElementType: true,
+			MaxSliceElementsCount:    querybuilder.DefaultMaxSliceElementsCount,
+			MaxConditionOrRulesCount: querybuilder.DefaultMaxConditionOrRulesCount,
+		}
+
+		if key, err := searchCond.BizPropertyFilter.Validate(option); err != nil {
+			blog.Errorf("bizPropertyFilter is illegal, err: %v, rid:%s", err, ctx.Kit.Rid)
+			ccErr := defErr.CCErrorf(common.CCErrCommParamsInvalid, fmt.Sprintf("biz.property.%s", key))
+			ctx.RespAutoError(ccErr)
+			return
+		}
+
+		if searchCond.BizPropertyFilter.GetDeep() > querybuilder.MaxDeep {
+			blog.Errorf("bizPropertyFilter is illegal, err: %v, rid: %s", err, ctx.Kit.Rid, ctx.Kit.Rid)
+			ccErr := defErr.CCErrorf(common.CCErrCommParamsInvalid,
+				fmt.Sprintf("exceed max query condition deepth: %d", querybuilder.MaxDeep))
+			ctx.RespAutoError(ccErr)
+			return
+		}
+
+		mgoFilter, key, err := searchCond.BizPropertyFilter.ToMgo()
+		if err != nil {
+			blog.Errorf("BizPropertyFilter ToMgo failed: %s, err: %v,  rid:%s", searchCond.BizPropertyFilter,
+				err, ctx.Kit.Rid)
+			ctx.RespAutoError(ctx.Kit.CCError.CCErrorf(common.CCErrCommParamsInvalid,
+				err.Error()+fmt.Sprintf(", biz_property_filter.%s", key)))
+			return
+		}
+		searchCond.Condition = mgoFilter
 	}
 
 	if s.AuthManager.Enabled() {


### PR DESCRIPTION
查询业务接口存在越权问题，Condition写了用户权限过滤的条件，然后如果是是用BizPropertyFilter参数，最后整个Condition会被直接覆盖，丢失前面写的过滤条件。

调整代码结构顺序，把过滤权限条件的构建放在构建查询条件的Condition之后，避免被覆盖