### PR TITLE
feat：redis 支持 tls 连接

### DIFF
--- a/docs/smart/web/extra-data/configure/readme.md
+++ b/docs/smart/web/extra-data/configure/readme.md
@@ -36,3 +36,7 @@
 | BK_CMDB_REDIS_MAX_OPEN_CONNS           | cmdb redis最大连接数                  | 3000        |
 | BK_CMDB_REDIS_MAX_IDLE_CONNS           | cmdb redis最大空闲连接数                | 1000        |
 | BK_CMDB_REDIS_MASTER_NAME              | cmdb redis master 名称             |             |
+| BK_CMDB_REDIS_SSL_CERT_PATH            | cmdb redis ssl 客户端证书的路径          |             | 
+| BK_CMDB_REDIS_SSL_KEY_PATH             | cmdb redis ssl 私钥的路径             |             | 
+| BK_CMDB_REDIS_SSL_CA_CERT_PATH         | cmdb redis ssl CA 证书的路径          |             | 
+| BK_CMDB_REDIS_SSL_SKIP_VERIFY          | cmdb redis ssl 是否跳过证书验证, 默认false | true        | 

--- a/docs/smart/web/extra-data/configure/web.yaml.tmpl
+++ b/docs/smart/web/extra-data/configure/web.yaml.tmpl
@@ -173,3 +173,8 @@ redis:
   maxOpenConns: ${BK_CMDB_REDIS_MAX_OPEN_CONNS}
   maxIDleConns: ${BK_CMDB_REDIS_MAX_IDLE_CONNS}
   masterName: ${BK_CMDB_REDIS_MASTER_NAME}
+  tls:
+    certFile: ${BK_CMDB_REDIS_SSL_CERT_PATH}
+    keyFile: ${BK_CMDB_REDIS_SSL_KEY_PATH}
+    caFile: ${BK_CMDB_REDIS_SSL_CA_CERT_PATH}
+    insecureSkipVerify: ${BK_CMDB_REDIS_SSL_SKIP_VERIFY}

--- a/docs/support-file/helm/backend/templates/_helpers.tpl
+++ b/docs/support-file/helm/backend/templates/_helpers.tpl
@@ -241,3 +241,63 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
     {{ .Values.image.registry }}/{{ .Values.migrate.image.repository }}:v{{ default .Chart.AppVersion .Values.migrate.image.tag }}
 {{- end -}}
 
+{{- define "cmdb.redis.certVolumeMount" -}}
+{{- if or .Values.redisCert.redis.ca .Values.redisCert.redis.key .Values.redisCert.redis.cert }}
+- name: redis-certs
+  mountPath: {{ .Values.certPath }}/redis
+{{- end }}
+{{- end -}}
+
+{{- define "cmdb.redis.certVolume" -}}
+{{- if or .Values.redisCert.redis.ca .Values.redisCert.redis.key .Values.redisCert.redis.cert }}
+- name: redis-certs
+  configMap:
+    name: {{ template "bk-cmdb.fullname" . }}-redis-certs
+{{- end }}
+{{- end -}}
+
+{{- define "cmdb.redis.snapshotCertVolumeMount" -}}
+{{- if or .Values.redisCert.snapshotRedis.ca .Values.redisCert.snapshotRedis.key .Values.redisCert.snapshotRedis.cert }}
+- name: snapshot-redis-certs
+  mountPath: {{ .Values.certPath }}/snapshot-redis
+{{- end }}
+{{- end -}}
+
+{{- define "cmdb.redis.snapshotCertVolume" -}}
+{{- if or .Values.redisCert.snapshotRedis.ca .Values.redisCert.snapshotRedis.key .Values.redisCert.snapshotRedis.cert }}
+- name: snapshot-redis-certs
+  configMap:
+    name: {{ template "bk-cmdb.fullname" . }}-snapshot-redis-certs
+{{- end }}
+{{- end -}}
+
+{{- define "cmdb.redis.discoverCertVolumeMount" -}}
+{{- if or .Values.redisCert.discoverRedis.ca .Values.redisCert.discoverRedis.key .Values.redisCert.discoverRedis.cert }}
+- name: discover-redis-certs
+  mountPath: {{ .Values.certPath }}/discover-redis
+{{- end }}
+{{- end -}}
+
+{{- define "cmdb.redis.discoverCertVolume" -}}
+{{- if or .Values.redisCert.discoverRedis.ca .Values.redisCert.discoverRedis.key .Values.redisCert.discoverRedis.cert }}
+- name: discover-redis-certs
+  configMap:
+    name: {{ template "bk-cmdb.fullname" . }}-discover-redis-certs
+{{- end }}
+{{- end -}}
+
+{{- define "cmdb.redis.netCollectCertVolumeMount" -}}
+{{- if or .Values.redisCert.netCollectRedis.ca .Values.redisCert.netCollectRedis.key .Values.redisCert.netCollectRedis.cert }}
+- name: netcollect-redis-certs
+  mountPath: {{ .Values.certPath }}/netcollect-redis
+{{- end }}
+{{- end -}}
+
+{{- define "cmdb.redis.netCollectCertVolume" -}}
+{{- if or .Values.redisCert.netCollectRedis.ca .Values.redisCert.netCollectRedis.key .Values.redisCert.netCollectRedis.cert }}
+- name: netcollect-redis-certs
+  configMap:
+    name: {{ template "bk-cmdb.fullname" . }}-netcollect-redis-certs
+{{- end }}
+{{- end -}}
+

--- a/docs/support-file/helm/backend/templates/adminserver/adminserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/adminserver/adminserver-dpl.yaml
@@ -84,6 +84,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- end }}
+        {{- include "cmdb.redis.certVolumeMount" . | nindent 8 }}
       volumes:
       - name: configures
         configMap:
@@ -93,6 +94,7 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- end }}
+      {{- include "cmdb.redis.certVolume" . | nindent 6 }}
       {{- with .Values.adminserver.nodeSelector }}
       nodeSelector:
       {{ toYaml . | nindent 8 }}

--- a/docs/support-file/helm/backend/templates/adminserver/configmap.yaml
+++ b/docs/support-file/helm/backend/templates/adminserver/configmap.yaml
@@ -363,6 +363,15 @@ data:
       maxIdleConns: {{ .Values.redis.redis.maxIdleConns }}
       sentinelPwd: {{ .Values.redis.redis.sentinelPwd }}
       masterName: {{ .Values.redis.redis.masterName }}
+      tls:
+        insecureSkipVerify: {{ .Values.redis.redis.tls.insecureSkipVerify }}
+      {{- if .Values.redisCert.redis.ca }}
+        caFile: {{ .Values.redis.redis.tls.caFile }}
+      {{- end }}
+      {{- if and .Values.redisCert.redis.cert .Values.redisCert.redis.key }}
+        certFile: {{ .Values.redis.redis.tls.certFile }}
+        keyFile: {{ .Values.redis.redis.tls.keyFile }}
+      {{- end }}
       snap:
         host: {{ include "cmdb.redis.snap.host" . | quote }}
         pwd: {{ include "cmdb.redis.snap.pwd" . | quote }}
@@ -371,6 +380,15 @@ data:
         maxIdleConns: {{ .Values.redis.snapshotRedis.maxIdleConns }}
         sentinelPwd: {{ .Values.redis.snapshotRedis.sentinelPwd }}
         masterName: {{ .Values.redis.snapshotRedis.masterName }}
+        tls:
+          insecureSkipVerify: {{ .Values.redis.snapshotRedis.tls.insecureSkipVerify }}
+          {{- if and .Values.redisCert.snapshotRedis.ca }}
+          caFile: {{ .Values.redis.snapshotRedis.tls.caFile }}
+          {{- end }}
+          {{- if and .Values.redisCert.snapshotRedis.cert .Values.redisCert.snapshotRedis.key }}
+          certFile: {{ .Values.redis.snapshotRedis.tls.certFile }}
+          keyFile: {{ .Values.redis.snapshotRedis.tls.keyFile }}
+          {{- end }}
       discover:
         host: {{ include "cmdb.redis.discover.host" . | quote }}
         pwd: {{ include "cmdb.redis.discover.pwd" . | quote }}
@@ -379,6 +397,15 @@ data:
         maxIdleConns: {{ .Values.redis.discoverRedis.maxIdleConns }}
         sentinelPwd: {{ .Values.redis.discoverRedis.sentinelPwd }}
         masterName: {{ .Values.redis.discoverRedis.masterName }}
+        tls:
+          insecureSkipVerify: {{ .Values.redis.discoverRedis.tls.insecureSkipVerify }}
+          {{- if and .Values.redisCert.discoverRedis.ca }}
+          caFile: {{ .Values.redis.discoverRedis.tls.caFile }}
+          {{- end }}
+          {{- if and .Values.redisCert.discoverRedis.cert .Values.redisCert.discoverRedis.key }}
+          certFile: {{ .Values.redis.discoverRedis.tls.certFile }}
+          keyFile: {{ .Values.redis.discoverRedis.tls.keyFile }}
+          {{- end }}
       netcollect:
         host: {{ include "cmdb.redis.netcollect.host" . | quote }}
         pwd: {{ include "cmdb.redis.netcollect.pwd" . | quote }}
@@ -387,3 +414,12 @@ data:
         maxIdleConns: {{ .Values.redis.netCollectRedis.maxIdleConns }}
         sentinelPwd: {{ .Values.redis.netCollectRedis.sentinelPwd }}
         masterName: {{ .Values.redis.netCollectRedis.masterName }}
+        tls:
+          insecureSkipVerify: {{ .Values.redis.netCollectRedis.tls.insecureSkipVerify }}
+          {{- if and .Values.redisCert.netCollectRedis.ca (ne .Values.redisCert.netCollectRedis.ca "") }}
+          caFile: {{ .Values.redis.netCollectRedis.tls.caFile }}
+          {{- end }}
+          {{- if and .Values.redisCert.netCollectRedis.cert .Values.redisCert.netCollectRedis.key }}
+          certFile: {{ .Values.redis.netCollectRedis.tls.certFile }}
+          keyFile: {{ .Values.redis.netCollectRedis.tls.keyFile }}
+          {{- end }}

--- a/docs/support-file/helm/backend/templates/adminserver/configmap.yaml
+++ b/docs/support-file/helm/backend/templates/adminserver/configmap.yaml
@@ -366,11 +366,11 @@ data:
       tls:
         insecureSkipVerify: {{ .Values.redis.redis.tls.insecureSkipVerify }}
       {{- if .Values.redisCert.redis.ca }}
-        caFile: {{ .Values.redis.redis.tls.caFile }}
+        caFile: {{ .Values.certPath }}/{{ .Values.redis.redis.tls.caFile }}
       {{- end }}
       {{- if and .Values.redisCert.redis.cert .Values.redisCert.redis.key }}
-        certFile: {{ .Values.redis.redis.tls.certFile }}
-        keyFile: {{ .Values.redis.redis.tls.keyFile }}
+        certFile: {{ .Values.certPath }}/{{ .Values.redis.redis.tls.certFile }}
+        keyFile: {{ .Values.certPath }}/{{ .Values.redis.redis.tls.keyFile }}
       {{- end }}
       snap:
         host: {{ include "cmdb.redis.snap.host" . | quote }}
@@ -383,11 +383,11 @@ data:
         tls:
           insecureSkipVerify: {{ .Values.redis.snapshotRedis.tls.insecureSkipVerify }}
           {{- if and .Values.redisCert.snapshotRedis.ca }}
-          caFile: {{ .Values.redis.snapshotRedis.tls.caFile }}
+          caFile: {{ .Values.certPath }}/{{ .Values.redis.snapshotRedis.tls.caFile }}
           {{- end }}
           {{- if and .Values.redisCert.snapshotRedis.cert .Values.redisCert.snapshotRedis.key }}
-          certFile: {{ .Values.redis.snapshotRedis.tls.certFile }}
-          keyFile: {{ .Values.redis.snapshotRedis.tls.keyFile }}
+          certFile: {{ .Values.certPath }}/{{ .Values.redis.snapshotRedis.tls.certFile }}
+          keyFile: {{ .Values.certPath }}/{{ .Values.redis.snapshotRedis.tls.keyFile }}
           {{- end }}
       discover:
         host: {{ include "cmdb.redis.discover.host" . | quote }}
@@ -400,11 +400,11 @@ data:
         tls:
           insecureSkipVerify: {{ .Values.redis.discoverRedis.tls.insecureSkipVerify }}
           {{- if and .Values.redisCert.discoverRedis.ca }}
-          caFile: {{ .Values.redis.discoverRedis.tls.caFile }}
+          caFile: {{ .Values.certPath }}/{{ .Values.redis.discoverRedis.tls.caFile }}
           {{- end }}
           {{- if and .Values.redisCert.discoverRedis.cert .Values.redisCert.discoverRedis.key }}
-          certFile: {{ .Values.redis.discoverRedis.tls.certFile }}
-          keyFile: {{ .Values.redis.discoverRedis.tls.keyFile }}
+          certFile: {{ .Values.certPath }}/{{ .Values.redis.discoverRedis.tls.certFile }}
+          keyFile: {{ .Values.certPath }}/{{ .Values.redis.discoverRedis.tls.keyFile }}
           {{- end }}
       netcollect:
         host: {{ include "cmdb.redis.netcollect.host" . | quote }}
@@ -417,9 +417,9 @@ data:
         tls:
           insecureSkipVerify: {{ .Values.redis.netCollectRedis.tls.insecureSkipVerify }}
           {{- if and .Values.redisCert.netCollectRedis.ca (ne .Values.redisCert.netCollectRedis.ca "") }}
-          caFile: {{ .Values.redis.netCollectRedis.tls.caFile }}
+          caFile: {{ .Values.certPath }}/{{ .Values.redis.netCollectRedis.tls.caFile }}
           {{- end }}
           {{- if and .Values.redisCert.netCollectRedis.cert .Values.redisCert.netCollectRedis.key }}
-          certFile: {{ .Values.redis.netCollectRedis.tls.certFile }}
-          keyFile: {{ .Values.redis.netCollectRedis.tls.keyFile }}
+          certFile: {{ .Values.certPath }}/{{ .Values.redis.netCollectRedis.tls.certFile }}
+          keyFile: {{ .Values.certPath }}/{{ .Values.redis.netCollectRedis.tls.keyFile }}
           {{- end }}

--- a/docs/support-file/helm/backend/templates/apiserver/apiserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/apiserver/apiserver-dpl.yaml
@@ -88,6 +88,7 @@ spec:
           - name: configures
             mountPath: {{ .Values.apiserver.configDir }}
           {{- end }}
+          {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.apiserver.configDir }}
         - name: configures
@@ -95,6 +96,7 @@ spec:
             name: {{ .Release.Name }}-apiserver-configures
         {{- end }}
 
+      {{- include "cmdb.redis.certVolume" . | nindent 6 }}
       {{- with .Values.apiserver.nodeSelector }}
       nodeSelector:
       {{ toYaml . | nindent 8 }}

--- a/docs/support-file/helm/backend/templates/cacheservice/cacheservice-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/cacheservice/cacheservice-dpl.yaml
@@ -88,12 +88,14 @@ spec:
           - name: configures
             mountPath: {{ .Values.cacheservice.configDir }}
           {{- end }}
+          {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.cacheservice.configDir }}
         - name: configures
           configMap:
             name: {{ .Release.Name }}-cacheservice-configures
         {{- end }}
+        {{- include "cmdb.redis.certVolume" . | nindent 6 }}
 
       {{- with .Values.cacheservice.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/coreservice/coreservice-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/coreservice/coreservice-dpl.yaml
@@ -87,12 +87,14 @@ spec:
           - name: configures
             mountPath: {{ .Values.coreservice.configDir }}
           {{- end }}
+          {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.coreservice.configDir }}
         - name: configures
           configMap:
             name: {{ .Release.Name }}-coreservice-configures
         {{- end }}
+        {{- include "cmdb.redis.certVolume" . | nindent 6 }}
 
       {{- with .Values.coreservice.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/datacollection/datacollection-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/datacollection/datacollection-dpl.yaml
@@ -87,12 +87,20 @@ spec:
           - name: configures
             mountPath: {{ .Values.datacollection.configDir }}
           {{- end }}
+          {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.redis.snapshotCertVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.redis.discoverCertVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.redis.netCollectCertVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.datacollection.configDir }}
         - name: configures
           configMap:
             name: {{ .Release.Name }}-datacollection-configures
         {{- end }}
+        {{- include "cmdb.redis.certVolume" . | nindent 6 }}
+        {{- include "cmdb.redis.snapshotCertVolume" . | nindent 6 }}
+        {{- include "cmdb.redis.discoverCertVolume" . | nindent 6 }}
+        {{- include "cmdb.redis.netCollectCertVolume" . | nindent 6 }}
 
       {{- with .Values.datacollection.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/eventserver/eventserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/eventserver/eventserver-dpl.yaml
@@ -87,20 +87,22 @@ spec:
         volumeMounts:
           - name: cert
             mountPath: {{ .Values.certPath }}
-        {{- if .Values.eventserver.configDir }}
+          {{- if .Values.eventserver.configDir }}
           - name: configures
             mountPath: {{ .Values.eventserver.configDir }}
-        {{- end }}
+          {{- end }}
+          {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
 
       volumes:
         - name: cert
           configMap:
             name: {{ template "bk-cmdb.fullname" . }}-certs
-      {{- if .Values.eventserver.configDir }}
+        {{- if .Values.eventserver.configDir }}
         - name: configures
           configMap:
             name: {{ .Release.Name }}-eventserver-configures
-      {{- end }}
+        {{- end }}
+        {{- include "cmdb.redis.certVolume" . | nindent 8 }}
 
       {{- with .Values.eventserver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/hostserver/hostserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/hostserver/hostserver-dpl.yaml
@@ -88,12 +88,14 @@ spec:
           - name: configures
             mountPath: {{ .Values.hostserver.configDir }}
           {{- end }}
+          {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.hostserver.configDir }}
         - name: configures
           configMap:
             name: {{ .Release.Name }}-hostserver-configures
         {{- end }}
+        {{- include "cmdb.redis.certVolume" . | nindent 6 }}
 
       {{- with .Values.hostserver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/redis-cert-configmap.yaml
+++ b/docs/support-file/helm/backend/templates/redis-cert-configmap.yaml
@@ -1,0 +1,22 @@
+{{- $redisTypes := dict "redis" "redis" "snapshotRedis" "snapshot-redis" "discoverRedis" "discover-redis" "netCollectRedis" "netcollect-redis" }}
+
+{{- range $redisType, $prefix := $redisTypes }}
+{{- $certData := index $.Values.redisCert $redisType }}
+{{- if or $certData.ca $certData.cert $certData.key }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "bk-cmdb.fullname" $ }}-{{ $prefix }}-certs
+data:
+  {{- if $certData.ca }}
+  {{ $prefix }}.ca: {{ $certData.ca | b64dec | quote }}
+  {{- end }}
+  {{- if $certData.cert }}
+  {{ $prefix }}.cert: {{ $certData.cert | b64dec | quote }}
+  {{- end }}
+  {{- if $certData.key }}
+  {{ $prefix }}.key: {{ $certData.key | b64dec | quote }}
+  {{- end }}
+---
+{{- end }}
+{{- end }} 

--- a/docs/support-file/helm/backend/templates/synchronizeserver/synchronizeserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/synchronizeserver/synchronizeserver-dpl.yaml
@@ -88,12 +88,14 @@ spec:
           - name: configures
             mountPath: {{ .Values.synchronizeserver.configDir }}
           {{- end }}
+          {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.synchronizeserver.configDir }}
         - name: configures
           configMap:
             name: {{ .Release.Name }}-synchronizeserver-configures
         {{- end }}
+        {{- include "cmdb.redis.certVolume" . | nindent 6 }}
 
       {{- with .Values.synchronizeserver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/taskserver/taskserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/taskserver/taskserver-dpl.yaml
@@ -86,12 +86,14 @@ spec:
           - name: configures
             mountPath: {{ .Values.taskserver.configDir }}
           {{- end }}
+          {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.taskserver.configDir }}
         - name: configures
           configMap:
             name: {{ .Release.Name }}-taskserver-configures
         {{- end }}
+        {{- include "cmdb.redis.certVolume" . | nindent 6 }}
 
       {{- with .Values.taskserver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/toposerver/toposerver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/toposerver/toposerver-dpl.yaml
@@ -88,12 +88,14 @@ spec:
           - name: configures
             mountPath: {{ .Values.toposerver.configDir }}
           {{- end }}
+          {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.toposerver.configDir }}
         - name: configures
           configMap:
             name: {{ .Release.Name }}-toposerver-configures
         {{- end }}
+        {{- include "cmdb.redis.certVolume" . | nindent 6 }}
 
       {{- with .Values.toposerver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/values.yaml
+++ b/docs/support-file/helm/backend/values.yaml
@@ -1574,6 +1574,24 @@ redis:
     ## @param redis.redis.masterName external redis master name
     ##
     masterName:
+    ## @param redis.redis.tls external redis TLS config
+    ## 
+    tls:
+      ## @param redis.redis.tls.caFile redis TLS CA file
+      ## Certificate file name, will be combined with certPath
+      ##
+      caFile: "/data/cmdb/cert/redis/redis.ca"
+      ## @param redis.redis.tls.certFile redis TLS cert file
+      ## Certificate file name, will be combined with certPath
+      ##
+      certFile: "/data/cmdb/cert/redis/redis.cert"
+      ## @param redis.redis.tls.keyFile redis TLS key file
+      ## Key file name, will be combined with certPath
+      ##
+      keyFile: "/data/cmdb/cert/redis/redis.key"
+      ## @param redis.redis.tls.insecureSkipVerify redis TLS insecure skip verify
+      ## 
+      insecureSkipVerify: true
   ## external redis for host snapshot parameters
   ##
   snapshotRedis:
@@ -1592,12 +1610,27 @@ redis:
     ## @param redis.snapshotRedis.maxIdleConns external redis max idle connections
     ##
     maxIdleConns: 100
-    ## @param redis.redis.sentinelPwd external redis sentinel password
+    ## @param redis.snapshotRedis.sentinelPwd external redis sentinel password
     ##
     sentinelPwd:
-    ## @param redis.redis.masterName external redis master name
+    ## @param redis.snapshotRedis.masterName external redis master name
     ##
     masterName:
+    ## @param redis.snapshotRedis.tls external redis TLS config
+    ## 
+    tls:
+      ## @param redis.snapshotRedis.tls.caFile external redis TLS CA file
+      ##
+      caFile: "/data/cmdb/cert/snapshot-redis/snapshot-redis.ca"
+      ## @param redis.snapshotRedis.tls.certFile external redis TLS cert file
+      ##
+      certFile: "/data/cmdb/cert/snapshot-redis/snapshot-redis.cert"
+      ## @param redis.snapshotRedis.tls.keyFile external redis TLS key file
+      ##
+      keyFile: "/data/cmdb/cert/snapshot-redis/snapshot-redis.key"
+      ## @param redis.snapshotRedis.tls.insecureSkipVerify redis TLS insecure skip verify
+      ## 
+      insecureSkipVerify: true
   ## external redis for discover parameters
   ##
   discoverRedis:
@@ -1616,12 +1649,27 @@ redis:
     ## @param redis.discoverRedis.maxIdleConns external redis max idle connections
     ##
     maxIdleConns: 100
-    ## @param redis.redis.sentinelPwd external redis sentinel password
+    ## @param redis.discoverRedis.sentinelPwd external redis sentinel password
     ##
     sentinelPwd:
-    ## @param redis.redis.masterName external redis master name
+    ## @param redis.discoverRedis.masterName external redis master name
     ##
     masterName:
+    ## @param redis.discoverRedis.tls external redis TLS config
+    ## 
+    tls:
+      ## @param redis.discoverRedis.tls.caFile discover redis TLS CA file
+      ##
+      caFile: "/data/cmdb/cert/discover-redis/discover-redis.ca"
+      ## @param redis.discoverRedis.tls.certFile discover redis TLS cert file
+      ##
+      certFile: "/data/cmdb/cert/discover-redis/discover-redis.cert"
+      ## @param redis.discoverRedis.tls.keyFile discover redis TLS key file
+      ##
+      keyFile: "/data/cmdb/cert/discover-redis/discover-redis.key"
+      ## @param redis.discoverRedis.tls.insecureSkipVerify redis TLS insecure skip verify
+      ## 
+      insecureSkipVerify: true
   ## external redis for network device collecting parameters
   ##
   netCollectRedis:
@@ -1640,13 +1688,27 @@ redis:
     ## @param redis.netCollectRedis.maxIdleConns external redis max idle connections
     ##
     maxIdleConns: 100
-    ## @param redis.redis.sentinelPwd external redis sentinel password
+    ## @param redis.netCollectRedis.sentinelPwd external redis sentinel password
     ##
     sentinelPwd:
-    ## @param redis.redis.masterName external redis master name
+    ## @param redis.netCollectRedis.masterName external redis master name
     ##
     masterName:
-
+    ## @param redis.netCollectRedis.tls external redis TLS config
+    ## 
+    tls:
+      ## @param redis.netCollectRedis.tls.caFile netcollect redis TLS CA file
+      ##
+      caFile: "/data/cmdb/cert/netcollect-redis/netcollect-redis.ca"
+      ## @param redis.netCollectRedis.tls.certFile netcollect redis TLS cert file
+      ##
+      certFile: "/data/cmdb/cert/netcollect-redis/netcollect-redis.cert"
+      ## @param redis.netCollectRedis.tls.keyFile netcollect redis TLS key file
+      ##
+      keyFile: "/data/cmdb/cert/netcollect-redis/netcollect-redis.key"
+      ## @param redis.netCollectRedis.tls.insecureSkipVerify redis TLS insecure skip verify
+      ## 
+      insecureSkipVerify: true
 ## @section elasticsearch parameters
 ##
 elasticsearch:
@@ -1829,3 +1891,62 @@ topologySpreadConstraints:
   ## - "ScheduleAnyway": Schedule new Pods as usual but still try to achieve even distribution over time.
   whenUnsatisfiable: ScheduleAnyway
 
+## @section redis certificates parameters
+##
+redisCert:
+  ## redis main instance certificates
+  redis:
+    ## @param redisCert.redis.ca CA certificate for redis connection
+    ## certificate content encoded in base64
+    ##
+    ca: ""
+    ## @param redisCert.redis.cert client certificate for redis connection
+    ## certificate content encoded in base64
+    ##
+    cert: ""
+    ## @param redisCert.redis.key client key for redis connection
+    ## key content encoded in base64
+    ##
+    key: ""
+  ## snapshot redis instance certificates
+  snapshotRedis:
+    ## @param redisCert.snapshotRedis.ca CA certificate for snapshot redis connection
+    ## certificate content encoded in base64
+    ##
+    ca: ""
+    ## @param redisCert.snapshotRedis.cert client certificate for snapshot redis connection
+    ## certificate content encoded in base64
+    ##
+    cert: ""
+    ## @param redisCert.snapshotRedis.key client key for snapshot redis connection
+    ## key content encoded in base64
+    ##
+    key: ""
+  ## discover redis instance certificates
+  discoverRedis:
+    ## @param redisCert.discoverRedis.ca CA certificate for discover redis connection
+    ## certificate content encoded in base64
+    ##
+    ca: ""
+    ## @param redisCert.discoverRedis.cert client certificate for discover redis connection
+    ## certificate content encoded in base64
+    ##
+    cert: ""
+    ## @param redisCert.discoverRedis.key client key for discover redis connection
+    ## key content encoded in base64
+    ##
+    key: ""
+  ## network collect redis instance certificates
+  netCollectRedis:
+    ## @param redisCert.netCollectRedis.ca CA certificate for network collect redis connection
+    ## certificate content encoded in base64
+    ##
+    ca: ""
+    ## @param redisCert.netCollectRedis.cert client certificate for network collect redis connection
+    ## certificate content encoded in base64
+    ##
+    cert: ""
+    ## @param redisCert.netCollectRedis.key client key for network collect redis connection
+    ## key content encoded in base64
+    ##
+    key: ""

--- a/docs/support-file/helm/backend/values.yaml
+++ b/docs/support-file/helm/backend/values.yaml
@@ -1580,15 +1580,15 @@ redis:
       ## @param redis.redis.tls.caFile redis TLS CA file
       ## Certificate file name, will be combined with certPath
       ##
-      caFile: "/data/cmdb/cert/redis/redis.ca"
+      caFile: "redis/redis.ca"
       ## @param redis.redis.tls.certFile redis TLS cert file
       ## Certificate file name, will be combined with certPath
       ##
-      certFile: "/data/cmdb/cert/redis/redis.cert"
+      certFile: "redis/redis.cert"
       ## @param redis.redis.tls.keyFile redis TLS key file
       ## Key file name, will be combined with certPath
       ##
-      keyFile: "/data/cmdb/cert/redis/redis.key"
+      keyFile: "redis/redis.key"
       ## @param redis.redis.tls.insecureSkipVerify redis TLS insecure skip verify
       ## 
       insecureSkipVerify: true
@@ -1621,13 +1621,13 @@ redis:
     tls:
       ## @param redis.snapshotRedis.tls.caFile external redis TLS CA file
       ##
-      caFile: "/data/cmdb/cert/snapshot-redis/snapshot-redis.ca"
+      caFile: "snapshot-redis/snapshot-redis.ca"
       ## @param redis.snapshotRedis.tls.certFile external redis TLS cert file
       ##
-      certFile: "/data/cmdb/cert/snapshot-redis/snapshot-redis.cert"
+      certFile: "snapshot-redis/snapshot-redis.cert"
       ## @param redis.snapshotRedis.tls.keyFile external redis TLS key file
       ##
-      keyFile: "/data/cmdb/cert/snapshot-redis/snapshot-redis.key"
+      keyFile: "snapshot-redis/snapshot-redis.key"
       ## @param redis.snapshotRedis.tls.insecureSkipVerify redis TLS insecure skip verify
       ## 
       insecureSkipVerify: true
@@ -1660,13 +1660,13 @@ redis:
     tls:
       ## @param redis.discoverRedis.tls.caFile discover redis TLS CA file
       ##
-      caFile: "/data/cmdb/cert/discover-redis/discover-redis.ca"
+      caFile: "discover-redis/discover-redis.ca"
       ## @param redis.discoverRedis.tls.certFile discover redis TLS cert file
       ##
-      certFile: "/data/cmdb/cert/discover-redis/discover-redis.cert"
+      certFile: "discover-redis/discover-redis.cert"
       ## @param redis.discoverRedis.tls.keyFile discover redis TLS key file
       ##
-      keyFile: "/data/cmdb/cert/discover-redis/discover-redis.key"
+      keyFile: "discover-redis/discover-redis.key"
       ## @param redis.discoverRedis.tls.insecureSkipVerify redis TLS insecure skip verify
       ## 
       insecureSkipVerify: true
@@ -1699,13 +1699,13 @@ redis:
     tls:
       ## @param redis.netCollectRedis.tls.caFile netcollect redis TLS CA file
       ##
-      caFile: "/data/cmdb/cert/netcollect-redis/netcollect-redis.ca"
+      caFile: "netcollect-redis/netcollect-redis.ca"
       ## @param redis.netCollectRedis.tls.certFile netcollect redis TLS cert file
       ##
-      certFile: "/data/cmdb/cert/netcollect-redis/netcollect-redis.cert"
+      certFile: "netcollect-redis/netcollect-redis.cert"
       ## @param redis.netCollectRedis.tls.keyFile netcollect redis TLS key file
       ##
-      keyFile: "/data/cmdb/cert/netcollect-redis/netcollect-redis.key"
+      keyFile: "netcollect-redis/netcollect-redis.key"
       ## @param redis.netCollectRedis.tls.insecureSkipVerify redis TLS insecure skip verify
       ## 
       insecureSkipVerify: true

--- a/docs/support-file/helm/web/templates/webserver/configmap.yaml
+++ b/docs/support-file/helm/web/templates/webserver/configmap.yaml
@@ -196,3 +196,12 @@ data:
       maxIdleConns: {{ .Values.redis.redis.maxIdleConns }}
       sentinelPwd: {{ .Values.redis.redis.sentinelPwd }}
       masterName: {{ .Values.redis.redis.masterName }}
+      tls:
+        insecureSkipVerify: {{ .Values.redis.redis.insecureSkipVerify }}
+        {{- if and .Values.redisCert.redis.ca }}
+        caFile: {{ .Values.redis.redis.tls.caFile }}
+        {{- end }}
+        {{- if and .Values.redisCert.redis.cert .Values.redisCert.redis.key }}
+        certFile: {{ .Values.redis.redis.tls.certFile }}
+        keyFile: {{ .Values.redis.redis.tls.keyFile }}
+        {{- end }}

--- a/docs/support-file/helm/web/templates/webserver/configmap.yaml
+++ b/docs/support-file/helm/web/templates/webserver/configmap.yaml
@@ -199,9 +199,9 @@ data:
       tls:
         insecureSkipVerify: {{ .Values.redis.redis.insecureSkipVerify }}
         {{- if and .Values.redisCert.redis.ca }}
-        caFile: {{ .Values.redis.redis.tls.caFile }}
+        caFile: {{ .Values.certPath }}/{{ .Values.redis.redis.tls.caFile }}
         {{- end }}
         {{- if and .Values.redisCert.redis.cert .Values.redisCert.redis.key }}
-        certFile: {{ .Values.redis.redis.tls.certFile }}
-        keyFile: {{ .Values.redis.redis.tls.keyFile }}
+        certFile: {{ .Values.certPath }}/{{ .Values.redis.redis.tls.certFile }}
+        keyFile: {{ .Values.certPath }}/{{ .Values.redis.redis.tls.keyFile }}
         {{- end }}

--- a/docs/support-file/helm/web/templates/webserver/webserver-dpl.yaml
+++ b/docs/support-file/helm/web/templates/webserver/webserver-dpl.yaml
@@ -91,7 +91,7 @@ spec:
           {{- end }}
           {{- if or .Values.redisCert.redis.ca .Values.redisCert.redis.cert .Values.redisCert.redis.key }}
           - name: redis-cert
-            mountPath: "/data/cmdb/cert/redis"
+            mountPath: {{ .Values.certPath}}/redis
           {{- end }}
       volumes:
         {{- if .Values.webserver.configDir }}
@@ -99,7 +99,7 @@ spec:
           configMap:
             name: {{ .Release.Name }}-webserver-configures
         {{- end }}
-        {{- if or .Value.redidsCert.redis.tls.ca .Value.redidsCert.redis.tls.cert .Value.redidsCert.redis.tls.key }}
+        {{- if or .Values.redisCert.redis.ca .Values.redisCert.redis.cert .Values.redisCert.redis.key }}
         - name: redis-cert
           configMap:
             name: "{{ template "bk-cmdb.fullname" $ }}-web-redis-certs"

--- a/docs/support-file/helm/web/templates/webserver/webserver-dpl.yaml
+++ b/docs/support-file/helm/web/templates/webserver/webserver-dpl.yaml
@@ -89,11 +89,20 @@ spec:
           - name: configures
             mountPath: {{ .Values.webserver.configDir }}
           {{- end }}
+          {{- if or .Values.redisCert.redis.ca .Values.redisCert.redis.cert .Values.redisCert.redis.key }}
+          - name: redis-cert
+            mountPath: "/data/cmdb/cert/redis"
+          {{- end }}
       volumes:
         {{- if .Values.webserver.configDir }}
         - name: configures
           configMap:
             name: {{ .Release.Name }}-webserver-configures
+        {{- end }}
+        {{- if or .Value.redidsCert.redis.tls.ca .Value.redidsCert.redis.tls.cert .Value.redidsCert.redis.tls.key }}
+        - name: redis-cert
+          configMap:
+            name: "{{ template "bk-cmdb.fullname" $ }}-web-redis-certs"
         {{- end }}
 
       {{- with .Values.webserver.nodeSelector }}

--- a/docs/support-file/helm/web/templates/webserver/webserver-redis-cert-configmap.yaml
+++ b/docs/support-file/helm/web/templates/webserver/webserver-redis-cert-configmap.yaml
@@ -1,0 +1,17 @@
+{{- $certData := index $.Values.redisCert "redis" }}
+{{- if or $certData.ca $certData.cert $certData.key }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "bk-cmdb.fullname" $ }}-web-redis-certs
+data:
+  {{- if $certData.ca }}
+  redis.ca: {{ $certData.ca | b64dec | quote }}
+  {{- end }}
+  {{- if $certData.cert }}
+  redis.cert: {{ $certData.cert | b64dec | quote }}
+  {{- end }}
+  {{- if $certData.key }}
+  redis.key: {{ $certData.key | b64dec | quote }}
+  {{- end }}
+{{- end }} 

--- a/docs/support-file/helm/web/values.yaml
+++ b/docs/support-file/helm/web/values.yaml
@@ -454,6 +454,10 @@ mongodb:
     ##
     socketTimeoutSeconds: 10
 
+## @param certPath cert path.
+##
+certPath: "/data/cmdb/cert"
+
 ## @section redis certificates parameters
 ##
 redisCert:
@@ -520,13 +524,13 @@ redis:
     tls:
       ## @param redis.redis.tls.caFile redis TLS CA file
       ##
-      caFile: "/data/cmdb/cert/redis/redis.ca"
+      caFile: "redis/redis.ca"
       ## @param redis.redis.tls.certFile redis TLS cert file
       ##
-      certFile: "/data/cmdb/cert/redis/redis.cert"
+      certFile: "redis/redis.cert"
       ## @param redis.redis.tls.keyFile redis TLS key file
       ##
-      keyFile: "/data/cmdb/cert/redis/redis.key"
+      keyFile: "redis/redis.key"
       ## @param redis.redis.tls.insecureSkipVerify redis TLS insecure skip verify
       ## 
       insecureSkipVerify: true

--- a/docs/support-file/helm/web/values.yaml
+++ b/docs/support-file/helm/web/values.yaml
@@ -454,6 +454,24 @@ mongodb:
     ##
     socketTimeoutSeconds: 10
 
+## @section redis certificates parameters
+##
+redisCert:
+  ## redis main instance certificates
+  redis:
+    ## @param redisCert.redis.ca CA certificate for redis connection
+    ## certificate content encoded in base64
+    ##
+    ca: ""
+    ## @param redisCert.redis.cert client certificate for redis connection
+    ## certificate content encoded in base64
+    ##
+    cert: ""
+    ## @param redisCert.redis.key client key for redis connection
+    ## key content encoded in base64
+    ##
+    key: ""
+
 ## @section redis parameters
 ##
 redis:
@@ -497,6 +515,21 @@ redis:
     ## @param redis.redis.masterName external redis master name
     ##
     masterName:
+    ## @param redis.redis.tls external redis TLS config
+    ## 
+    tls:
+      ## @param redis.redis.tls.caFile redis TLS CA file
+      ##
+      caFile: "/data/cmdb/cert/redis/redis.ca"
+      ## @param redis.redis.tls.certFile redis TLS cert file
+      ##
+      certFile: "/data/cmdb/cert/redis/redis.cert"
+      ## @param redis.redis.tls.keyFile redis TLS key file
+      ##
+      keyFile: "/data/cmdb/cert/redis/redis.key"
+      ## @param redis.redis.tls.insecureSkipVerify redis TLS insecure skip verify
+      ## 
+      insecureSkipVerify: true
 
 ## @section ServiceMonitor parameters
 ##

--- a/src/ac/iam/iam.go
+++ b/src/ac/iam/iam.go
@@ -28,6 +28,7 @@ import (
 	"configcenter/src/apimachinery/rest"
 	"configcenter/src/apimachinery/util"
 	"configcenter/src/common/auth"
+	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
 	httpheader "configcenter/src/common/http/header"
 	"configcenter/src/common/lock"
@@ -53,7 +54,7 @@ func NewIAM(cfg AuthConfig, reg prometheus.Registerer) (*IAM, error) {
 	}
 
 	var tls *ssl.TLSClientConfig
-	config, err := util.NewTLSClientConfigFromConfig("authServer.authCenter.tls")
+	config, err := cc.NewTLSClientConfigFromConfig("authServer.authCenter.tls")
 	if err != nil {
 		blog.Infof("get authCenter.tls config error, err: %v", err)
 		return nil, err

--- a/src/ac/iam/iam.go
+++ b/src/ac/iam/iam.go
@@ -32,6 +32,7 @@ import (
 	httpheader "configcenter/src/common/http/header"
 	"configcenter/src/common/lock"
 	"configcenter/src/common/metadata"
+	"configcenter/src/common/ssl"
 	commonutil "configcenter/src/common/util"
 	"configcenter/src/scene_server/auth_server/sdk/types"
 	"configcenter/src/storage/dal/redis"
@@ -51,7 +52,7 @@ func NewIAM(cfg AuthConfig, reg prometheus.Registerer) (*IAM, error) {
 		return new(IAM), nil
 	}
 
-	var tls *util.TLSClientConfig
+	var tls *ssl.TLSClientConfig
 	config, err := util.NewTLSClientConfigFromConfig("authServer.authCenter.tls")
 	if err != nil {
 		blog.Infof("get authCenter.tls config error, err: %v", err)

--- a/src/apimachinery/util/client.go
+++ b/src/apimachinery/util/client.go
@@ -23,7 +23,7 @@ import (
 )
 
 // NewClient create a new http client
-func NewClient(c *TLSClientConfig, conf ...ExtraClientConfig) (*http.Client, error) {
+func NewClient(c *ssl.TLSClientConfig, conf ...ExtraClientConfig) (*http.Client, error) {
 	tlsConf := new(tls.Config)
 	if c != nil && len(c.CAFile) != 0 && len(c.CertFile) != 0 && len(c.KeyFile) != 0 {
 		var err error

--- a/src/apimachinery/util/type.go
+++ b/src/apimachinery/util/type.go
@@ -13,13 +13,10 @@
 package util
 
 import (
-	"crypto/tls"
-	"fmt"
 	"time"
 
 	"configcenter/src/apimachinery/discovery"
 	"configcenter/src/apimachinery/flowctrl"
-	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/ssl"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -62,61 +59,8 @@ type MockInfo struct {
 	MockData    interface{}
 }
 
-// NewTLSClientConfigFromConfig new config about tls client config
-func NewTLSClientConfigFromConfig(prefix string) (ssl.TLSClientConfig, error) {
-	tlsConfig := ssl.TLSClientConfig{}
-
-	skipVerifyKey := fmt.Sprintf("%s.insecureSkipVerify", prefix)
-	if val, err := cc.String(skipVerifyKey); err == nil {
-		skipVerifyVal := val
-		if skipVerifyVal == "true" {
-			tlsConfig.InsecureSkipVerify = true
-		}
-	}
-
-	certFileKey := fmt.Sprintf("%s.certFile", prefix)
-	if val, err := cc.String(certFileKey); err == nil {
-		tlsConfig.CertFile = val
-	}
-
-	keyFileKey := fmt.Sprintf("%s.keyFile", prefix)
-	if val, err := cc.String(keyFileKey); err == nil {
-		tlsConfig.KeyFile = val
-	}
-
-	caFileKey := fmt.Sprintf("%s.caFile", prefix)
-	if val, err := cc.String(caFileKey); err == nil {
-		tlsConfig.CAFile = val
-	}
-
-	passwordKey := fmt.Sprintf("%s.password", prefix)
-	if val, err := cc.String(passwordKey); err == nil {
-		tlsConfig.Password = val
-	}
-
-	return tlsConfig, nil
-}
-
 // ExtraClientConfig extra http client configuration
 type ExtraClientConfig struct {
 	// ResponseHeaderTimeout the amount of time to wait for a server's response headers
 	ResponseHeaderTimeout time.Duration
-}
-
-// GetClientTLSConfig get client tls config
-func GetClientTLSConfig(prefix string) (*tls.Config, error) {
-	config, err := NewTLSClientConfigFromConfig(prefix)
-	if err != nil {
-		return nil, err
-	}
-	tlsConf := &tls.Config{InsecureSkipVerify: config.InsecureSkipVerify}
-
-	if len(config.CAFile) != 0 && len(config.CertFile) != 0 && len(config.KeyFile) != 0 {
-		tlsConf, err = ssl.ClientTLSConfVerity(config.CAFile, config.CertFile, config.KeyFile, config.Password)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return tlsConf, nil
 }

--- a/src/apimachinery/util/type.go
+++ b/src/apimachinery/util/type.go
@@ -31,7 +31,7 @@ type APIMachineryConfig struct {
 	QPS int64
 	// request's burst value
 	Burst     int64
-	TLSConfig *TLSClientConfig
+	TLSConfig *ssl.TLSClientConfig
 	ExtraConf *ExtraClientConfig
 }
 
@@ -62,23 +62,9 @@ type MockInfo struct {
 	MockData    interface{}
 }
 
-// TLSClientConfig TODO
-type TLSClientConfig struct {
-	// Server should be accessed without verifying the TLS certificate. For testing only.
-	InsecureSkipVerify bool
-	// Server requires TLS client certificate authentication
-	CertFile string
-	// Server requires TLS client certificate authentication
-	KeyFile string
-	// Trusted root certificates for server
-	CAFile string
-	// the password to decrypt the certificate
-	Password string
-}
-
 // NewTLSClientConfigFromConfig new config about tls client config
-func NewTLSClientConfigFromConfig(prefix string) (TLSClientConfig, error) {
-	tlsConfig := TLSClientConfig{}
+func NewTLSClientConfigFromConfig(prefix string) (ssl.TLSClientConfig, error) {
+	tlsConfig := ssl.TLSClientConfig{}
 
 	skipVerifyKey := fmt.Sprintf("%s.insecureSkipVerify", prefix)
 	if val, err := cc.String(skipVerifyKey); err == nil {

--- a/src/apiserver/app/server.go
+++ b/src/apiserver/app/server.go
@@ -68,7 +68,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 		return err
 	}
 
-	config, err := util.NewTLSClientConfigFromConfig("tls")
+	config, err := cc.NewTLSClientConfigFromConfig("tls")
 	if err != nil {
 		blog.Errorf("get tls config error, err: %v", err)
 		return err

--- a/src/common/backbone/backbone.go
+++ b/src/common/backbone/backbone.go
@@ -408,7 +408,7 @@ func (e *Engine) GetSrvInfo() *types.ServerInfo {
 }
 
 func getTLSConf() (*ssl.TLSClientConfig, error) {
-	config, err := util.NewTLSClientConfigFromConfig("tls")
+	config, err := cc.NewTLSClientConfigFromConfig("tls")
 	return &config, err
 }
 

--- a/src/common/backbone/backbone.go
+++ b/src/common/backbone/backbone.go
@@ -31,6 +31,7 @@ import (
 	"configcenter/src/common/errors"
 	"configcenter/src/common/language"
 	"configcenter/src/common/metrics"
+	"configcenter/src/common/ssl"
 	"configcenter/src/common/types"
 	"configcenter/src/storage/dal/mongo"
 	"configcenter/src/storage/dal/redis"
@@ -406,12 +407,12 @@ func (e *Engine) GetSrvInfo() *types.ServerInfo {
 	return e.srvInfo
 }
 
-func getTLSConf() (*util.TLSClientConfig, error) {
+func getTLSConf() (*ssl.TLSClientConfig, error) {
 	config, err := util.NewTLSClientConfigFromConfig("tls")
 	return &config, err
 }
 
-func isTLS(config *util.TLSClientConfig) bool {
+func isTLS(config *ssl.TLSClientConfig) bool {
 	if config == nil || len(config.CertFile) == 0 || len(config.KeyFile) == 0 {
 		return false
 	}

--- a/src/common/backbone/configcenter/viper.go
+++ b/src/common/backbone/configcenter/viper.go
@@ -667,13 +667,6 @@ func (vp *viperParser) unmarshalKey(key string, val interface{}) error {
 	return vp.parser.UnmarshalKey(key, val)
 }
 
-func (vp *viperParser) getBoolOrDefault(path string, defaultValue bool) bool {
-	if vp.parser.IsSet(path) {
-		return vp.parser.GetBool(path)
-	}
-	return defaultValue
-}
-
 // NewTLSClientConfigFromConfig new config about tls client config
 func NewTLSClientConfigFromConfig(prefix string) (ssl.TLSClientConfig, error) {
 	tlsConfig := ssl.TLSClientConfig{}

--- a/src/common/backbone/configcenter/viper.go
+++ b/src/common/backbone/configcenter/viper.go
@@ -283,7 +283,7 @@ func Redis(prefix string) (redis.Config, error) {
 		Enable:           parser.getString(prefix + ".enable"),
 		MaxOpenConns:     parser.getInt(prefix + ".maxOpenConns"),
 		TLSConfig: &ssl.TLSClientConfig{
-			InsecureSkipVerify: parser.getBool(prefix + ".tls.insecureSkipVerify"),
+			InsecureSkipVerify: parser.getBoolOrDefault(prefix+".tls.insecureSkipVerify", true),
 			CertFile:           parser.getString(prefix + ".tls.certFile"),
 			KeyFile:            parser.getString(prefix + ".tls.keyFile"),
 			CAFile:             parser.getString(prefix + ".tls.caFile"),
@@ -659,4 +659,11 @@ func (vp *viperParser) isConfigBoolType(path string) bool {
 
 func (vp *viperParser) unmarshalKey(key string, val interface{}) error {
 	return vp.parser.UnmarshalKey(key, val)
+}
+
+func (vp *viperParser) getBoolOrDefault(path string, defaultValue bool) bool {
+	if vp.parser.IsSet(path) {
+		return vp.parser.GetBool(path)
+	}
+	return defaultValue
 }

--- a/src/common/backbone/configcenter/viper.go
+++ b/src/common/backbone/configcenter/viper.go
@@ -282,7 +282,7 @@ func Redis(prefix string) (redis.Config, error) {
 		SentinelPassword: parser.getString(prefix + ".sentinelPwd"),
 		Enable:           parser.getString(prefix + ".enable"),
 		MaxOpenConns:     parser.getInt(prefix + ".maxOpenConns"),
-		TLSConfig: ssl.TLSClientConfig{
+		TLSConfig: &ssl.TLSClientConfig{
 			InsecureSkipVerify: parser.getBool(prefix + ".tls.insecureSkipVerify"),
 			CertFile:           parser.getString(prefix + ".tls.certFile"),
 			KeyFile:            parser.getString(prefix + ".tls.keyFile"),

--- a/src/common/backbone/configcenter/viper.go
+++ b/src/common/backbone/configcenter/viper.go
@@ -28,6 +28,7 @@ import (
 	"configcenter/src/common/cryptor"
 	ccerr "configcenter/src/common/errors"
 	"configcenter/src/common/language"
+	"configcenter/src/common/ssl"
 	"configcenter/src/storage/dal/kafka"
 	"configcenter/src/storage/dal/mongo"
 	"configcenter/src/storage/dal/redis"
@@ -281,6 +282,12 @@ func Redis(prefix string) (redis.Config, error) {
 		SentinelPassword: parser.getString(prefix + ".sentinelPwd"),
 		Enable:           parser.getString(prefix + ".enable"),
 		MaxOpenConns:     parser.getInt(prefix + ".maxOpenConns"),
+		TLSConfig: ssl.TLSClientConfig{
+			InsecureSkipVerify: parser.getBool(prefix + ".tls.insecureSkipVerify"),
+			CertFile:           parser.getString(prefix + ".tls.certFile"),
+			KeyFile:            parser.getString(prefix + ".tls.keyFile"),
+			CAFile:             parser.getString(prefix + ".tls.caFile"),
+		},
 	}, nil
 }
 

--- a/src/common/backbone/configcenter/viper.go
+++ b/src/common/backbone/configcenter/viper.go
@@ -14,6 +14,7 @@ package configcenter
 
 import (
 	"bytes"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"os"
@@ -274,6 +275,12 @@ func Redis(prefix string) (redis.Config, error) {
 		return redis.Config{}, errors.New("can't find redis configuration")
 	}
 
+	tlsConf, err := NewTLSClientConfigFromConfig(prefix + ".tls")
+	if err != nil {
+		blog.Errorf("fail to get redis tls configuration")
+		return redis.Config{}, err
+	}
+
 	return redis.Config{
 		Address:          parser.getString(prefix + ".host"),
 		Password:         parser.getString(prefix + ".pwd"),
@@ -282,12 +289,7 @@ func Redis(prefix string) (redis.Config, error) {
 		SentinelPassword: parser.getString(prefix + ".sentinelPwd"),
 		Enable:           parser.getString(prefix + ".enable"),
 		MaxOpenConns:     parser.getInt(prefix + ".maxOpenConns"),
-		TLSConfig: &ssl.TLSClientConfig{
-			InsecureSkipVerify: parser.getBoolOrDefault(prefix+".tls.insecureSkipVerify", true),
-			CertFile:           parser.getString(prefix + ".tls.certFile"),
-			KeyFile:            parser.getString(prefix + ".tls.keyFile"),
-			CAFile:             parser.getString(prefix + ".tls.caFile"),
-		},
+		TLSConfig:        &tlsConf,
 	}, nil
 }
 
@@ -578,6 +580,10 @@ func getKeyValueParser(key string) (*viperParser, error) {
 		return extraParser, nil
 	}
 
+	if redisParser != nil && redisParser.isSet(key) {
+		return redisParser, nil
+	}
+
 	return nil, fmt.Errorf("%s key's config not found", key)
 }
 
@@ -666,4 +672,57 @@ func (vp *viperParser) getBoolOrDefault(path string, defaultValue bool) bool {
 		return vp.parser.GetBool(path)
 	}
 	return defaultValue
+}
+
+// NewTLSClientConfigFromConfig new config about tls client config
+func NewTLSClientConfigFromConfig(prefix string) (ssl.TLSClientConfig, error) {
+	tlsConfig := ssl.TLSClientConfig{}
+
+	skipVerifyKey := fmt.Sprintf("%s.insecureSkipVerify", prefix)
+	if val, err := String(skipVerifyKey); err == nil {
+		skipVerifyVal := val
+		if skipVerifyVal == "true" {
+			tlsConfig.InsecureSkipVerify = true
+		}
+	}
+
+	certFileKey := fmt.Sprintf("%s.certFile", prefix)
+	if val, err := String(certFileKey); err == nil {
+		tlsConfig.CertFile = val
+	}
+
+	keyFileKey := fmt.Sprintf("%s.keyFile", prefix)
+	if val, err := String(keyFileKey); err == nil {
+		tlsConfig.KeyFile = val
+	}
+
+	caFileKey := fmt.Sprintf("%s.caFile", prefix)
+	if val, err := String(caFileKey); err == nil {
+		tlsConfig.CAFile = val
+	}
+
+	passwordKey := fmt.Sprintf("%s.password", prefix)
+	if val, err := String(passwordKey); err == nil {
+		tlsConfig.Password = val
+	}
+
+	return tlsConfig, nil
+}
+
+// GetClientTLSConfig get client tls config
+func GetClientTLSConfig(prefix string) (*tls.Config, error) {
+	config, err := NewTLSClientConfigFromConfig(prefix)
+	if err != nil {
+		return nil, err
+	}
+	tlsConf := &tls.Config{InsecureSkipVerify: config.InsecureSkipVerify}
+
+	if len(config.CAFile) != 0 && len(config.CertFile) != 0 && len(config.KeyFile) != 0 {
+		tlsConf, err = ssl.ClientTLSConfVerity(config.CAFile, config.CertFile, config.KeyFile, config.Password)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return tlsConf, nil
 }

--- a/src/common/backbone/type.go
+++ b/src/common/backbone/type.go
@@ -16,7 +16,7 @@ import (
 	"net/http"
 
 	"configcenter/src/apimachinery"
-	"configcenter/src/apimachinery/util"
+	"configcenter/src/common/ssl"
 	"configcenter/src/common/types"
 )
 
@@ -32,6 +32,6 @@ type Server struct {
 	ListenAddr   string
 	ListenPort   uint
 	Handler      http.Handler
-	TLS          *util.TLSClientConfig
+	TLS          *ssl.TLSClientConfig
 	PProfEnabled bool
 }

--- a/src/common/http/httpclient/client.go
+++ b/src/common/http/httpclient/client.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"time"
 
-	"configcenter/src/apimachinery/util"
 	"configcenter/src/common/ssl"
 )
 
@@ -74,7 +73,7 @@ func (client *HttpClient) SetTlsVerityServer(caFile string) error {
 }
 
 // SetTLSVerify set tls verify config
-func (client *HttpClient) SetTLSVerify(c *util.TLSClientConfig) error {
+func (client *HttpClient) SetTLSVerify(c *ssl.TLSClientConfig) error {
 	// load cert
 	tlsConf, err := ssl.ClientTLSConfVerity(c.CAFile, c.CertFile, c.KeyFile, c.Password)
 	if err != nil {

--- a/src/common/http/httpclient/forwardclient.go
+++ b/src/common/http/httpclient/forwardclient.go
@@ -20,7 +20,7 @@ import (
 	"net/url"
 	"time"
 
-	"configcenter/src/apimachinery/util"
+	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
 
 	"github.com/emicklei/go-restful/v3"
@@ -83,7 +83,7 @@ func ReqHttp(req *restful.Request, url, method string, body []byte) (string, err
 // ProxyHttp TODO
 // porxy http
 func ProxyHttp(c *gin.Context, addr string) {
-	tlsConf, err := util.GetClientTLSConfig("tls")
+	tlsConf, err := cc.GetClientTLSConfig("tls")
 	if err != nil {
 		c.Writer.Write([]byte(err.Error()))
 		blog.Errorf("get tls config error, err: %v", err)

--- a/src/common/resource/esb/esb.go
+++ b/src/common/resource/esb/esb.go
@@ -19,6 +19,7 @@ import (
 	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/errors"
+	"configcenter/src/common/ssl"
 	"configcenter/src/thirdparty/esbserver"
 	"configcenter/src/thirdparty/esbserver/esbutil"
 )
@@ -29,7 +30,7 @@ var (
 
 	lastInitErr   errors.CCErrorCoder
 	lastConfigErr errors.CCErrorCoder
-	tlsConfig     util.TLSClientConfig
+	tlsConfig     ssl.TLSClientConfig
 )
 
 // EsbClient TODO

--- a/src/common/resource/esb/esb.go
+++ b/src/common/resource/esb/esb.go
@@ -66,7 +66,7 @@ func ParseEsbConfig() (*esbutil.EsbConfig, errors.CCErrorCoder) {
 	}
 
 	// 不支持热更新
-	tlsConfig, err = util.NewTLSClientConfigFromConfig("esb")
+	tlsConfig, err = cc.NewTLSClientConfigFromConfig("esb")
 	if err != nil {
 		lastInitErr = errors.NewCCError(common.CCErrCommResourceInitFailed, "'esb' initialization failed")
 		return nil, lastInitErr

--- a/src/common/ssl/type.go
+++ b/src/common/ssl/type.go
@@ -16,18 +16,36 @@ type TLSClientConfig struct {
 	Password string
 }
 
+// Verify checks if the TLS client configuration is valid
+func (cfg *TLSClientConfig) Verify() bool {
+	if cfg == nil {
+		return false
+	}
+
+	// If CAFile is configured, it's considered valid
+	if len(cfg.CAFile) > 0 {
+		return true
+	}
+
+	// If both CertFile and KeyFile are configured, it's considered valid
+	if len(cfg.CertFile) > 0 && len(cfg.KeyFile) > 0 {
+		return true
+	}
+
+	return false
+}
+
 // NewTLSConfigFromConf creates a new TLS configuration from TLSClientConfig
 func NewTLSConfigFromConf(cfg *TLSClientConfig) (*tls.Config, error) {
 	// createTLSConfig creates tls.Config based on TLSConfig.
 	// It handles one-way and mutual TLS authentication, and TLS disabling.
-	var tlsConf *tls.Config = nil // initialize tlsConf to nil, which means TLS is disabled by default
+	tlsConf := &tls.Config{}
 
-	if len(cfg.CAFile) != 0 { // if CAFile is configured, then enable TLS
+	if cfg != nil && len(cfg.CAFile) != 0 { // if CAFile is configured, then enable TLS
 		var err error
-		if cfg.CertFile != "" && cfg.KeyFile != "" {
+		if len(cfg.CertFile) != 0 && len(cfg.KeyFile) != 0 {
 			// if CertFile and KeyFile are both configured, then use mutual TLS authentication
-			tlsConf, err = ClientTLSConfVerity(cfg.CAFile, cfg.CertFile,
-				cfg.KeyFile, "")
+			tlsConf, err = ClientTLSConfVerity(cfg.CAFile, cfg.CertFile, cfg.KeyFile, "")
 		} else {
 			// otherwise, only CAFile is configured, use one-way TLS authentication, only verify server certificate
 			tlsConf, err = ClientTslConfVerityServer(cfg.CAFile)
@@ -35,10 +53,7 @@ func NewTLSConfigFromConf(cfg *TLSClientConfig) (*tls.Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		if tlsConf != nil {
-			tlsConf.InsecureSkipVerify = cfg.InsecureSkipVerify
-		}
 	}
-	// if cfg.TLSConfig.CAFile is empty, then tlsConf remains nil, which means TLS is disabled
+	tlsConf.InsecureSkipVerify = cfg.InsecureSkipVerify
 	return tlsConf, nil
 }

--- a/src/common/ssl/type.go
+++ b/src/common/ssl/type.go
@@ -28,25 +28,6 @@ type TLSClientConfig struct {
 	Password string
 }
 
-// Verify checks if the TLS client configuration is valid
-func (cfg *TLSClientConfig) Verify() bool {
-	if cfg == nil {
-		return false
-	}
-
-	// If CAFile is configured, it's considered valid
-	if len(cfg.CAFile) > 0 {
-		return true
-	}
-
-	// If both CertFile and KeyFile are configured, it's considered valid
-	if len(cfg.CertFile) > 0 && len(cfg.KeyFile) > 0 {
-		return true
-	}
-
-	return false
-}
-
 // NewTLSConfigFromConf creates a new TLS configuration from TLSClientConfig
 // Returns:
 // - *tls.Config: TLS configuration

--- a/src/common/ssl/type.go
+++ b/src/common/ssl/type.go
@@ -1,0 +1,44 @@
+package ssl
+
+import "crypto/tls"
+
+// TLSClientConfig TODO
+type TLSClientConfig struct {
+	// Server should be accessed without verifying the TLS certificate. For testing only.
+	InsecureSkipVerify bool
+	// Server requires TLS client certificate authentication
+	CertFile string
+	// Server requires TLS client certificate authentication
+	KeyFile string
+	// Trusted root certificates for server
+	CAFile string
+	// the password to decrypt the certificate
+	Password string
+}
+
+// NewTLSConfigFromConf TODO
+func NewTLSConfigFromConf(cfg TLSClientConfig) (*tls.Config, error) {
+	// createTLSConfig creates tls.Config based on TLSConfig.
+	// It handles one-way and mutual TLS authentication, and TLS disabling.
+	var tlsConf *tls.Config = nil // initialize tlsConf to nil, which means TLS is disabled by default
+
+	if len(cfg.CAFile) != 0 { // if CAFile is configured, then enable TLS
+		var err error
+		if cfg.CertFile != "" && cfg.KeyFile != "" {
+			// if CertFile and KeyFile are both configured, then use mutual TLS authentication
+			tlsConf, err = ClientTLSConfVerity(cfg.CAFile, cfg.CertFile,
+				cfg.KeyFile, "")
+		} else {
+			// otherwise, only CAFile is configured, use one-way TLS authentication, only verify server certificate
+			tlsConf, err = ClientTslConfVerityServer(cfg.CAFile)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if tlsConf != nil {
+			tlsConf.InsecureSkipVerify = cfg.InsecureSkipVerify
+		}
+	}
+	// if cfg.TLSConfig.CAFile is empty, then tlsConf remains nil, which means TLS is disabled
+	return tlsConf, nil
+}

--- a/src/common/ssl/type.go
+++ b/src/common/ssl/type.go
@@ -1,3 +1,15 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ssl
 
 import "crypto/tls"
@@ -36,10 +48,18 @@ func (cfg *TLSClientConfig) Verify() bool {
 }
 
 // NewTLSConfigFromConf creates a new TLS configuration from TLSClientConfig
-func NewTLSConfigFromConf(cfg *TLSClientConfig) (*tls.Config, error) {
+// Returns:
+// - *tls.Config: TLS configuration
+// - bool: whether TLS is enabled
+// - error: any error occurred during configuration
+func NewTLSConfigFromConf(cfg *TLSClientConfig) (*tls.Config, bool, error) {
 	// createTLSConfig creates tls.Config based on TLSConfig.
 	// It handles one-way and mutual TLS authentication, and TLS disabling.
 	tlsConf := &tls.Config{}
+
+	if cfg == nil {
+		return tlsConf, false, nil
+	}
 
 	if cfg != nil && len(cfg.CAFile) != 0 { // if CAFile is configured, then enable TLS
 		var err error
@@ -51,9 +71,11 @@ func NewTLSConfigFromConf(cfg *TLSClientConfig) (*tls.Config, error) {
 			tlsConf, err = ClientTslConfVerityServer(cfg.CAFile)
 		}
 		if err != nil {
-			return nil, err
+			return tlsConf, false, err
 		}
+		tlsConf.InsecureSkipVerify = cfg.InsecureSkipVerify
+		return tlsConf, true, nil
 	}
-	tlsConf.InsecureSkipVerify = cfg.InsecureSkipVerify
-	return tlsConf, nil
+
+	return tlsConf, false, nil
 }

--- a/src/common/ssl/type.go
+++ b/src/common/ssl/type.go
@@ -2,7 +2,7 @@ package ssl
 
 import "crypto/tls"
 
-// TLSClientConfig TODO
+// TLSClientConfig Common TLS client configuration
 type TLSClientConfig struct {
 	// Server should be accessed without verifying the TLS certificate. For testing only.
 	InsecureSkipVerify bool
@@ -16,8 +16,8 @@ type TLSClientConfig struct {
 	Password string
 }
 
-// NewTLSConfigFromConf TODO
-func NewTLSConfigFromConf(cfg TLSClientConfig) (*tls.Config, error) {
+// NewTLSConfigFromConf creates a new TLS configuration from TLSClientConfig
+func NewTLSConfigFromConf(cfg *TLSClientConfig) (*tls.Config, error) {
 	// createTLSConfig creates tls.Config based on TLSConfig.
 	// It handles one-way and mutual TLS authentication, and TLS disabling.
 	var tlsConf *tls.Config = nil // initialize tlsConf to nil, which means TLS is disabled by default

--- a/src/scene_server/auth_server/app/options/options.go
+++ b/src/scene_server/auth_server/app/options/options.go
@@ -15,9 +15,9 @@ package options
 
 import (
 	"configcenter/src/ac/iam"
-	"configcenter/src/apimachinery/util"
 	"configcenter/src/common/auth"
 	"configcenter/src/common/core/cc/config"
+	"configcenter/src/common/ssl"
 
 	"github.com/spf13/pflag"
 )
@@ -45,5 +45,5 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 // Config TODO
 type Config struct {
 	Auth iam.AuthConfig
-	TLS  util.TLSClientConfig
+	TLS  ssl.TLSClientConfig
 }

--- a/src/scene_server/auth_server/app/server.go
+++ b/src/scene_server/auth_server/app/server.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"configcenter/src/ac/iam"
-	"configcenter/src/apimachinery/util"
 	"configcenter/src/common/backbone"
 	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
@@ -133,7 +132,7 @@ func (a *AuthServer) onAuthConfigUpdate(previous, current cc.ProcessConfig) {
 			blog.Warnf("parse auth center config failed: %v", err)
 		}
 
-		a.Config.TLS, err = util.NewTLSClientConfigFromConfig("authServer")
+		a.Config.TLS, err = cc.NewTLSClientConfigFromConfig("authServer")
 		if err != nil {
 			blog.Warnf("parse auth center tls config failed: %v", err)
 		}

--- a/src/scene_server/auth_server/sdk/types/auth.go
+++ b/src/scene_server/auth_server/sdk/types/auth.go
@@ -16,7 +16,7 @@ import (
 	"errors"
 	"fmt"
 
-	"configcenter/src/apimachinery/util"
+	"configcenter/src/common/ssl"
 	"configcenter/src/scene_server/auth_server/sdk/operator"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -39,7 +39,7 @@ type IamConfig struct {
 	// the system id which used in auth center.
 	SystemID string
 	// http TLS config
-	TLS util.TLSClientConfig
+	TLS ssl.TLSClientConfig
 }
 
 // Validate TODO

--- a/src/scene_server/datacollection/app/server.go
+++ b/src/scene_server/datacollection/app/server.go
@@ -308,7 +308,7 @@ func (c *DataCollection) initModules() error {
 	blog.Info("DataCollection| init modules, create mongo client success[%+v]", c.config.MongoDB.GetMongoConf())
 
 	// create blueking ESB client.
-	tlsConfig, err := apiutil.NewTLSClientConfigFromConfig("esb")
+	tlsConfig, err := cc.NewTLSClientConfigFromConfig("esb")
 	if err != nil {
 		return err
 	}

--- a/src/storage/dal/redis/redis.go
+++ b/src/storage/dal/redis/redis.go
@@ -15,7 +15,6 @@ package redis
 
 import (
 	"context"
-	"crypto/tls"
 	"strconv"
 	"strings"
 
@@ -48,14 +47,9 @@ func NewFromConfig(cfg Config) (Client, error) {
 		cfg.MaxOpenConns = 3000
 	}
 
-	useTLS := cfg.TLSConfig.Verify()
-	var tlsConf *tls.Config
-	if useTLS {
-		var err error
-		tlsConf, err = ssl.NewTLSConfigFromConf(cfg.TLSConfig)
-		if err != nil {
-			return nil, err
-		}
+	tlsConf, useTLS, err := ssl.NewTLSConfigFromConf(cfg.TLSConfig)
+	if err != nil {
+		return nil, err
 	}
 
 	var client Client

--- a/src/storage/dal/redis/redis.go
+++ b/src/storage/dal/redis/redis.go
@@ -15,6 +15,7 @@ package redis
 
 import (
 	"context"
+	"crypto/tls"
 	"strconv"
 	"strings"
 
@@ -47,19 +48,26 @@ func NewFromConfig(cfg Config) (Client, error) {
 		cfg.MaxOpenConns = 3000
 	}
 
-	tlsConf, err := ssl.NewTLSConfigFromConf(cfg.TLSConfig)
-	if err != nil {
-		return nil, err
+	useTLS := cfg.TLSConfig.Verify()
+	var tlsConf *tls.Config
+	if useTLS {
+		var err error
+		tlsConf, err = ssl.NewTLSConfigFromConf(cfg.TLSConfig)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var client Client
 	if cfg.MasterName == "" {
 		option := &redis.Options{
-			Addr:      cfg.Address,
-			Password:  cfg.Password,
-			DB:        dbNum,
-			PoolSize:  cfg.MaxOpenConns,
-			TLSConfig: tlsConf,
+			Addr:     cfg.Address,
+			Password: cfg.Password,
+			DB:       dbNum,
+			PoolSize: cfg.MaxOpenConns,
+		}
+		if useTLS {
+			option.TLSConfig = tlsConf
 		}
 		client = NewClient(option)
 	} else {
@@ -71,7 +79,9 @@ func NewFromConfig(cfg Config) (Client, error) {
 			DB:               dbNum,
 			PoolSize:         cfg.MaxOpenConns,
 			SentinelPassword: cfg.SentinelPassword,
-			TLSConfig:        tlsConf,
+		}
+		if useTLS {
+			option.TLSConfig = tlsConf
 		}
 		client = NewFailoverClient(option)
 	}

--- a/src/storage/dal/redis/redis.go
+++ b/src/storage/dal/redis/redis.go
@@ -18,7 +18,7 @@ import (
 	"strconv"
 	"strings"
 
-	commonSSL "configcenter/src/common/ssl"
+	"configcenter/src/common/ssl"
 
 	"github.com/go-redis/redis/v7"
 )
@@ -34,7 +34,7 @@ type Config struct {
 	Enable       string
 	MaxOpenConns int
 	// tls config
-	TLSConfig commonSSL.TLSClientConfig
+	TLSConfig *ssl.TLSClientConfig
 }
 
 // NewFromConfig returns new redis client from config
@@ -47,7 +47,7 @@ func NewFromConfig(cfg Config) (Client, error) {
 		cfg.MaxOpenConns = 3000
 	}
 
-	tlsConf, err := commonSSL.NewTLSConfigFromConf(cfg.TLSConfig)
+	tlsConf, err := ssl.NewTLSConfigFromConf(cfg.TLSConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/src/storage/dal/redis/redis.go
+++ b/src/storage/dal/redis/redis.go
@@ -18,6 +18,8 @@ import (
 	"strconv"
 	"strings"
 
+	commonSSL "configcenter/src/common/ssl"
+
 	"github.com/go-redis/redis/v7"
 )
 
@@ -31,25 +33,33 @@ type Config struct {
 	// for datacollection, notify if the snapshot redis is in use
 	Enable       string
 	MaxOpenConns int
+	// tls config
+	TLSConfig commonSSL.TLSClientConfig
 }
 
 // NewFromConfig returns new redis client from config
 func NewFromConfig(cfg Config) (Client, error) {
 	dbNum, err := strconv.Atoi(cfg.Database)
-	if nil != err {
+	if err != nil {
 		return nil, err
 	}
 	if cfg.MaxOpenConns == 0 {
 		cfg.MaxOpenConns = 3000
 	}
 
+	tlsConf, err := commonSSL.NewTLSConfigFromConf(cfg.TLSConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	var client Client
 	if cfg.MasterName == "" {
 		option := &redis.Options{
-			Addr:     cfg.Address,
-			Password: cfg.Password,
-			DB:       dbNum,
-			PoolSize: cfg.MaxOpenConns,
+			Addr:      cfg.Address,
+			Password:  cfg.Password,
+			DB:        dbNum,
+			PoolSize:  cfg.MaxOpenConns,
+			TLSConfig: tlsConf,
 		}
 		client = NewClient(option)
 	} else {
@@ -61,6 +71,7 @@ func NewFromConfig(cfg Config) (Client, error) {
 			DB:               dbNum,
 			PoolSize:         cfg.MaxOpenConns,
 			SentinelPassword: cfg.SentinelPassword,
+			TLSConfig:        tlsConf,
 		}
 		client = NewFailoverClient(option)
 	}

--- a/src/storage/dal/redis/redis_store.go
+++ b/src/storage/dal/redis/redis_store.go
@@ -20,6 +20,8 @@ package redis
 import (
 	"time"
 
+	commonSSL "configcenter/src/common/ssl"
+
 	"github.com/FZambia/sentinel"
 	"github.com/boj/redistore"
 	"github.com/gin-contrib/sessions"
@@ -46,8 +48,38 @@ type RedisStore interface {
 //
 // It is recommended to use an authentication key with 32 or 64 bytes. The encryption key,
 // if set, must be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256 modes.
-func NewRedisStore(size int, network, address, password string, keyPairs ...[]byte) (RedisStore, error) {
-	store, err := redistore.NewRediStore(size, network, address, password, keyPairs...)
+func NewRedisStore(size int, network, address, password string, tlsConf commonSSL.TLSClientConfig,
+	keyPairs ...[]byte) (RedisStore, error) {
+	tls, err := commonSSL.NewTLSConfigFromConf(tlsConf)
+	if err != nil {
+		return nil, err
+	}
+
+	pool := &redis.Pool{
+		MaxIdle:     size,
+		IdleTimeout: 240 * time.Second,
+		TestOnBorrow: func(c redis.Conn, t time.Time) error {
+			_, err := c.Do("PING")
+			return err
+		},
+		Dial: func() (redis.Conn, error) {
+			c, err := redis.Dial(network, address,
+				redis.DialUseTLS(tls != nil),
+				redis.DialTLSConfig(tls))
+			if err != nil {
+				return nil, err
+			}
+			if password != "" {
+				if _, err := c.Do("AUTH", password); err != nil {
+					c.Close()
+					return nil, err
+				}
+			}
+			return c, nil
+		},
+	}
+
+	store, err := redistore.NewRediStoreWithPool(pool, keyPairs...)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +118,11 @@ func (c *redisStore) Options(options sessions.Options) {
 // It is recommended to use an authentication key with 32 or 64 bytes. The encryption key,
 // if set, must be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256 modes.
 func NewRedisStoreWithSentinel(address []string, size int, masterName, network, password string, sentinelPwd string,
-	keyPairs ...[]byte) (RedisStore, error) {
+	tlsConf commonSSL.TLSClientConfig, keyPairs ...[]byte) (RedisStore, error) {
+	tls, err := commonSSL.NewTLSConfigFromConf(tlsConf)
+	if err != nil {
+		return nil, err
+	}
 
 	sntnl := &sentinel.Sentinel{
 		Addrs:      address,
@@ -98,6 +134,8 @@ func NewRedisStoreWithSentinel(address []string, size int, masterName, network, 
 				redis.DialReadTimeout(timeout),
 				redis.DialWriteTimeout(timeout),
 				redis.DialPassword(sentinelPwd),
+				redis.DialUseTLS(tls != nil),
+				redis.DialTLSConfig(tls),
 			)
 		},
 	}

--- a/src/storage/dal/redis/redis_store.go
+++ b/src/storage/dal/redis/redis_store.go
@@ -22,6 +22,8 @@ import (
 
 	"configcenter/src/common/ssl"
 
+	"crypto/tls"
+
 	"github.com/FZambia/sentinel"
 	"github.com/boj/redistore"
 	"github.com/gin-contrib/sessions"
@@ -50,14 +52,19 @@ type RedisStore interface {
 // if set, must be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256 modes.
 func NewRedisStore(size int, network, address, password string, tlsConf *ssl.TLSClientConfig,
 	keyPairs ...[]byte) (RedisStore, error) {
-	tls, err := ssl.NewTLSConfigFromConf(tlsConf)
-	if err != nil {
-		return nil, err
+	useTLS := tlsConf.Verify()
+	var tls *tls.Config
+	if useTLS {
+		var err error
+		tls, err = ssl.NewTLSConfigFromConf(tlsConf)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	dialFunc := func() (redis.Conn, error) {
 		c, err := redis.Dial(network, address,
-			redis.DialUseTLS(tls != nil),
+			redis.DialUseTLS(useTLS),
 			redis.DialTLSConfig(tls))
 		if err != nil {
 			return nil, err
@@ -107,9 +114,14 @@ func (c *redisStore) Options(options sessions.Options) {
 // if set, must be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256 modes.
 func NewRedisStoreWithSentinel(address []string, size int, masterName, network, password string, sentinelPwd string,
 	tlsConf *ssl.TLSClientConfig, keyPairs ...[]byte) (RedisStore, error) {
-	tls, err := ssl.NewTLSConfigFromConf(tlsConf)
-	if err != nil {
-		return nil, err
+	useTLS := tlsConf.Verify()
+	var tls *tls.Config
+	if useTLS {
+		var err error
+		tls, err = ssl.NewTLSConfigFromConf(tlsConf)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	sntnl := &sentinel.Sentinel{
@@ -122,7 +134,7 @@ func NewRedisStoreWithSentinel(address []string, size int, masterName, network, 
 				redis.DialReadTimeout(timeout),
 				redis.DialWriteTimeout(timeout),
 				redis.DialPassword(sentinelPwd),
-				redis.DialUseTLS(tls != nil),
+				redis.DialUseTLS(useTLS),
 				redis.DialTLSConfig(tls),
 			)
 		},

--- a/src/storage/dal/redis/redis_store.go
+++ b/src/storage/dal/redis/redis_store.go
@@ -20,7 +20,7 @@ package redis
 import (
 	"time"
 
-	commonSSL "configcenter/src/common/ssl"
+	"configcenter/src/common/ssl"
 
 	"github.com/FZambia/sentinel"
 	"github.com/boj/redistore"
@@ -48,42 +48,30 @@ type RedisStore interface {
 //
 // It is recommended to use an authentication key with 32 or 64 bytes. The encryption key,
 // if set, must be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256 modes.
-func NewRedisStore(size int, network, address, password string, tlsConf commonSSL.TLSClientConfig,
+func NewRedisStore(size int, network, address, password string, tlsConf *ssl.TLSClientConfig,
 	keyPairs ...[]byte) (RedisStore, error) {
-	tls, err := commonSSL.NewTLSConfigFromConf(tlsConf)
+	tls, err := ssl.NewTLSConfigFromConf(tlsConf)
 	if err != nil {
 		return nil, err
 	}
 
-	pool := &redis.Pool{
-		MaxIdle:     size,
-		IdleTimeout: 240 * time.Second,
-		TestOnBorrow: func(c redis.Conn, t time.Time) error {
-			_, err := c.Do("PING")
-			return err
-		},
-		Dial: func() (redis.Conn, error) {
-			c, err := redis.Dial(network, address,
-				redis.DialUseTLS(tls != nil),
-				redis.DialTLSConfig(tls))
-			if err != nil {
+	dialFunc := func() (redis.Conn, error) {
+		c, err := redis.Dial(network, address,
+			redis.DialUseTLS(tls != nil),
+			redis.DialTLSConfig(tls))
+		if err != nil {
+			return nil, err
+		}
+		if password != "" {
+			if _, err := c.Do("AUTH", password); err != nil {
+				c.Close()
 				return nil, err
 			}
-			if password != "" {
-				if _, err := c.Do("AUTH", password); err != nil {
-					c.Close()
-					return nil, err
-				}
-			}
-			return c, nil
-		},
+		}
+		return c, nil
 	}
 
-	store, err := redistore.NewRediStoreWithPool(pool, keyPairs...)
-	if err != nil {
-		return nil, err
-	}
-	return &redisStore{store}, nil
+	return createRedisStoreWithPool(size, dialFunc, false, keyPairs...)
 }
 
 type redisStore struct {
@@ -118,8 +106,8 @@ func (c *redisStore) Options(options sessions.Options) {
 // It is recommended to use an authentication key with 32 or 64 bytes. The encryption key,
 // if set, must be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256 modes.
 func NewRedisStoreWithSentinel(address []string, size int, masterName, network, password string, sentinelPwd string,
-	tlsConf commonSSL.TLSClientConfig, keyPairs ...[]byte) (RedisStore, error) {
-	tls, err := commonSSL.NewTLSConfigFromConf(tlsConf)
+	tlsConf *ssl.TLSClientConfig, keyPairs ...[]byte) (RedisStore, error) {
+	tls, err := ssl.NewTLSConfigFromConf(tlsConf)
 	if err != nil {
 		return nil, err
 	}
@@ -140,27 +128,15 @@ func NewRedisStoreWithSentinel(address []string, size int, masterName, network, 
 		},
 	}
 
-	pool := &redis.Pool{
-		MaxIdle:     size,
-		IdleTimeout: 240 * time.Second,
-		TestOnBorrow: func(c redis.Conn, t time.Time) error {
-			_, err := c.Do("PING")
-			return err
-		},
-		Dial: func() (redis.Conn, error) {
-			masterAddr, err := sntnl.MasterAddr()
-			if err != nil {
-				return nil, err
-			}
-			return dial(network, masterAddr, password)
-		},
+	dialFunc := func() (redis.Conn, error) {
+		masterAddr, err := sntnl.MasterAddr()
+		if err != nil {
+			return nil, err
+		}
+		return dial(network, masterAddr, password)
 	}
 
-	store, err := redistore.NewRediStoreWithPool(pool, keyPairs...)
-	if err != nil {
-		return nil, err
-	}
-	return &redisSentinelStore{store}, nil
+	return createRedisStoreWithPool(size, dialFunc, true, keyPairs...)
 }
 
 func dial(network, address, password string) (redis.Conn, error) {
@@ -190,4 +166,26 @@ func (c *redisSentinelStore) Options(options sessions.Options) {
 		Secure:   options.Secure,
 		HttpOnly: options.HttpOnly,
 	}
+}
+
+// createRedisStoreWithPool creates a Redis store with connection pool
+func createRedisStoreWithPool(size int, dialFunc func() (redis.Conn, error), isSentinel bool, keyPairs ...[]byte) (RedisStore, error) {
+	pool := &redis.Pool{
+		MaxIdle:     size,
+		IdleTimeout: 240 * time.Second,
+		TestOnBorrow: func(c redis.Conn, t time.Time) error {
+			_, err := c.Do("PING")
+			return err
+		},
+		Dial: dialFunc,
+	}
+
+	store, err := redistore.NewRediStoreWithPool(pool, keyPairs...)
+	if err != nil {
+		return nil, err
+	}
+	if isSentinel {
+		return &redisSentinelStore{store}, nil
+	}
+	return &redisStore{store}, nil
 }

--- a/src/storage/dal/redis/redis_store.go
+++ b/src/storage/dal/redis/redis_store.go
@@ -55,23 +55,23 @@ func NewRedisStore(size int, network, address, password string, tlsConf *ssl.TLS
 		return nil, err
 	}
 
-	dialFunc := func() (redis.Conn, error) {
-		c, err := redis.Dial(network, address,
-			redis.DialUseTLS(useTLS),
-			redis.DialTLSConfig(tls))
-		if err != nil {
-			return nil, err
-		}
-		if password != "" {
-			if _, err := c.Do("AUTH", password); err != nil {
-				c.Close()
-				return nil, err
-			}
-		}
-		return c, nil
+	// 准备连接选项
+	options := []redis.DialOption{}
+	if useTLS {
+		options = append(options, redis.DialUseTLS(true))
+		options = append(options, redis.DialTLSConfig(tls))
 	}
 
-	return createRedisStoreWithPool(size, dialFunc, false, keyPairs...)
+	dialFunc := func() (redis.Conn, error) {
+		return dial(network, address, password, options...)
+	}
+
+	store, err := createRedisStoreWithPool(size, dialFunc, keyPairs...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &redisStore{store}, nil
 }
 
 type redisStore struct {
@@ -112,19 +112,23 @@ func NewRedisStoreWithSentinel(address []string, size int, masterName, network, 
 		return nil, err
 	}
 
+	tlsOptions := []redis.DialOption{}
+	if useTLS {
+		tlsOptions = append(tlsOptions, redis.DialUseTLS(true))
+		tlsOptions = append(tlsOptions, redis.DialTLSConfig(tls))
+	}
+
 	sntnl := &sentinel.Sentinel{
 		Addrs:      address,
 		MasterName: masterName,
 		Dial: func(addr string) (redis.Conn, error) {
 			timeout := time.Second
-			return redis.Dial(network, addr,
+			sentinelOptions := append(tlsOptions,
 				redis.DialConnectTimeout(timeout),
 				redis.DialReadTimeout(timeout),
-				redis.DialWriteTimeout(timeout),
-				redis.DialPassword(sentinelPwd),
-				redis.DialUseTLS(useTLS),
-				redis.DialTLSConfig(tls),
-			)
+				redis.DialWriteTimeout(timeout))
+
+			return dial(network, addr, sentinelPwd, sentinelOptions...)
 		},
 	}
 
@@ -133,14 +137,19 @@ func NewRedisStoreWithSentinel(address []string, size int, masterName, network, 
 		if err != nil {
 			return nil, err
 		}
-		return dial(network, masterAddr, password)
+		return dial(network, masterAddr, password, tlsOptions...)
 	}
 
-	return createRedisStoreWithPool(size, dialFunc, true, keyPairs...)
+	store, err := createRedisStoreWithPool(size, dialFunc, keyPairs...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &redisSentinelStore{store}, nil
 }
 
-func dial(network, address, password string) (redis.Conn, error) {
-	c, err := redis.Dial(network, address)
+func dial(network, address, password string, options ...redis.DialOption) (redis.Conn, error) {
+	c, err := redis.Dial(network, address, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +178,7 @@ func (c *redisSentinelStore) Options(options sessions.Options) {
 }
 
 // createRedisStoreWithPool creates a Redis store with connection pool
-func createRedisStoreWithPool(size int, dialFunc func() (redis.Conn, error), isSentinel bool, keyPairs ...[]byte) (RedisStore, error) {
+func createRedisStoreWithPool(size int, dialFunc func() (redis.Conn, error), keyPairs ...[]byte) (*redistore.RediStore, error) {
 	pool := &redis.Pool{
 		MaxIdle:     size,
 		IdleTimeout: 240 * time.Second,
@@ -184,8 +193,6 @@ func createRedisStoreWithPool(size int, dialFunc func() (redis.Conn, error), isS
 	if err != nil {
 		return nil, err
 	}
-	if isSentinel {
-		return &redisSentinelStore{store}, nil
-	}
-	return &redisStore{store}, nil
+
+	return store, nil
 }

--- a/src/storage/dal/redis/redis_store.go
+++ b/src/storage/dal/redis/redis_store.go
@@ -22,8 +22,6 @@ import (
 
 	"configcenter/src/common/ssl"
 
-	"crypto/tls"
-
 	"github.com/FZambia/sentinel"
 	"github.com/boj/redistore"
 	"github.com/gin-contrib/sessions"
@@ -52,14 +50,9 @@ type RedisStore interface {
 // if set, must be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256 modes.
 func NewRedisStore(size int, network, address, password string, tlsConf *ssl.TLSClientConfig,
 	keyPairs ...[]byte) (RedisStore, error) {
-	useTLS := tlsConf.Verify()
-	var tls *tls.Config
-	if useTLS {
-		var err error
-		tls, err = ssl.NewTLSConfigFromConf(tlsConf)
-		if err != nil {
-			return nil, err
-		}
+	tls, useTLS, err := ssl.NewTLSConfigFromConf(tlsConf)
+	if err != nil {
+		return nil, err
 	}
 
 	dialFunc := func() (redis.Conn, error) {
@@ -114,14 +107,9 @@ func (c *redisStore) Options(options sessions.Options) {
 // if set, must be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256 modes.
 func NewRedisStoreWithSentinel(address []string, size int, masterName, network, password string, sentinelPwd string,
 	tlsConf *ssl.TLSClientConfig, keyPairs ...[]byte) (RedisStore, error) {
-	useTLS := tlsConf.Verify()
-	var tls *tls.Config
-	if useTLS {
-		var err error
-		tls, err = ssl.NewTLSConfigFromConf(tlsConf)
-		if err != nil {
-			return nil, err
-		}
+	tls, useTLS, err := ssl.NewTLSConfigFromConf(tlsConf)
+	if err != nil {
+		return nil, err
 	}
 
 	sntnl := &sentinel.Sentinel{

--- a/src/storage/dal/redis/test/redis_test.go
+++ b/src/storage/dal/redis/test/redis_test.go
@@ -1,3 +1,15 @@
+/*
+ * Tencent is pleased to support the open source community by making 蓝鲸 available.
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package redis_test
 
 import (
@@ -5,32 +17,32 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"configcenter/src/common/ssl"
-	localRedis "configcenter/src/storage/dal/redis"
+	"configcenter/src/storage/dal/redis"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewFromConfig(t *testing.T) {
-	// 使用真实Redis服务器地址和认证信息
-	redisAddr := "127.0.0.1:6379" // 默认地址，可以根据实际环境修改
-	redisPassword := "cmdb"       // 用户提供的密码
+	redisAddr := ""     // 默认地址，可以根据实际环境修改
+	redisPassword := "" // 用户提供的密码
+	caFile := ""        // ca 证书路径
 
 	// 测试普通客户端配置
 	t.Run("基本功能测试", func(t *testing.T) {
-		cfg := localRedis.Config{
+		cfg := redis.Config{
 			Address:      redisAddr,
 			Password:     redisPassword,
 			Database:     "0",
 			MaxOpenConns: 10,
-			TLSConfig: ssl.TLSClientConfig{
-				CAFile:             "/Users/yuyudeqiu/Desktop/canway/cmdb/redis_cert/ca-cert.pem",
+			TLSConfig: &ssl.TLSClientConfig{
+				CAFile:             caFile,
 				InsecureSkipVerify: true,
 			},
 		}
 
 		// 连接Redis
-		client, err := localRedis.NewFromConfig(cfg)
+		client, err := redis.NewFromConfig(cfg)
 		if err != nil {
 			t.Fatalf("连接Redis失败: %v", err)
 		}
@@ -57,6 +69,6 @@ func TestNewFromConfig(t *testing.T) {
 
 		// 4. 验证删除结果
 		_, err = client.Get(ctx, testKey).Result()
-		assert.True(t, localRedis.IsNilErr(err), "键应该已被删除")
+		assert.True(t, redis.IsNilErr(err), "键应该已被删除")
 	})
 }

--- a/src/storage/dal/redis/test/redis_test.go
+++ b/src/storage/dal/redis/test/redis_test.go
@@ -1,0 +1,62 @@
+package redis_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"configcenter/src/common/ssl"
+	localRedis "configcenter/src/storage/dal/redis"
+)
+
+func TestNewFromConfig(t *testing.T) {
+	// 使用真实Redis服务器地址和认证信息
+	redisAddr := "127.0.0.1:6379" // 默认地址，可以根据实际环境修改
+	redisPassword := "cmdb"       // 用户提供的密码
+
+	// 测试普通客户端配置
+	t.Run("基本功能测试", func(t *testing.T) {
+		cfg := localRedis.Config{
+			Address:      redisAddr,
+			Password:     redisPassword,
+			Database:     "0",
+			MaxOpenConns: 10,
+			TLSConfig: ssl.TLSClientConfig{
+				CAFile:             "/Users/yuyudeqiu/Desktop/canway/cmdb/redis_cert/ca-cert.pem",
+				InsecureSkipVerify: true,
+			},
+		}
+
+		// 连接Redis
+		client, err := localRedis.NewFromConfig(cfg)
+		if err != nil {
+			t.Fatalf("连接Redis失败: %v", err)
+		}
+		assert.NotNil(t, client)
+
+		// 测试基本操作
+		ctx := context.Background()
+
+		// 1. SET - 设置键值
+		testKey := "test_key"
+		testValue := "test_value"
+		err = client.Set(ctx, testKey, testValue, time.Minute).Err()
+		assert.NoError(t, err)
+
+		// 2. GET - 获取键值
+		val, err := client.Get(ctx, testKey).Result()
+		assert.NoError(t, err)
+		assert.Equal(t, testValue, val)
+
+		// 3. DEL - 删除键值
+		n, err := client.Del(ctx, testKey).Result()
+		assert.NoError(t, err)
+		assert.Equal(t, int64(1), n)
+
+		// 4. 验证删除结果
+		_, err = client.Get(ctx, testKey).Result()
+		assert.True(t, localRedis.IsNilErr(err), "键应该已被删除")
+	})
+}

--- a/src/thirdparty/apigw/apigwutil/common.go
+++ b/src/thirdparty/apigw/apigwutil/common.go
@@ -24,6 +24,7 @@ import (
 	"configcenter/src/apimachinery/util"
 	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
+	"configcenter/src/common/ssl"
 )
 
 // ApiGWBaseResponse api gateway base response
@@ -38,7 +39,7 @@ type ApiGWConfig struct {
 	AppCode   string
 	AppSecret string
 	Username  string
-	TLSConfig *util.TLSClientConfig
+	TLSConfig *ssl.TLSClientConfig
 }
 
 // ApiGWDiscovery api gateway discovery struct

--- a/src/thirdparty/apigw/apigwutil/common.go
+++ b/src/thirdparty/apigw/apigwutil/common.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"sync"
 
-	"configcenter/src/apimachinery/util"
 	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/ssl"
@@ -93,7 +92,7 @@ func ParseApiGWConfig(path string) (*ApiGWConfig, error) {
 		return nil, err
 	}
 
-	tlsConfig, err := util.NewTLSClientConfigFromConfig(path + ".tls")
+	tlsConfig, err := cc.NewTLSClientConfigFromConfig(path + ".tls")
 	if err != nil {
 		blog.Errorf("get api gateway tls config error, err: %v", err)
 		return nil, err

--- a/src/thirdparty/elasticsearch/esclient.go
+++ b/src/thirdparty/elasticsearch/esclient.go
@@ -129,7 +129,7 @@ type EsConfig struct {
 	EsUrl           string
 	EsUser          string
 	EsPassword      string
-	TLSClientConfig apiutil.TLSClientConfig
+	TLSClientConfig ssl.TLSClientConfig
 }
 
 // ParseConfigFromKV returns a new config

--- a/src/thirdparty/elasticsearch/esclient.go
+++ b/src/thirdparty/elasticsearch/esclient.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strings"
 
-	apiutil "configcenter/src/apimachinery/util"
 	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
 	"configcenter/src/common/metadata"
@@ -146,6 +145,6 @@ func ParseConfigFromKV(prefix string, configMap map[string]string) (EsConfig, er
 		EsPassword:     pwd,
 	}
 	var err error
-	conf.TLSClientConfig, err = apiutil.NewTLSClientConfigFromConfig(prefix)
+	conf.TLSClientConfig, err = cc.NewTLSClientConfigFromConfig(prefix)
 	return conf, err
 }

--- a/src/thirdparty/gse/client/config.go
+++ b/src/thirdparty/gse/client/config.go
@@ -13,15 +13,15 @@
 package client
 
 import (
-	"configcenter/src/apimachinery/util"
 	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
+	"configcenter/src/common/ssl"
 )
 
 // GseConnConfig connect to gse config
 type GseConnConfig struct {
 	Endpoints []string
-	TLSConf   *util.TLSClientConfig
+	TLSConf   *ssl.TLSClientConfig
 }
 
 // NewGseConnConfig new GseConnConfig struct
@@ -31,7 +31,7 @@ func NewGseConnConfig(prefix string) (*GseConnConfig, error) {
 		return nil, err
 	}
 
-	tlsConfig := new(util.TLSClientConfig)
+	tlsConfig := new(ssl.TLSClientConfig)
 	if tlsConfig.InsecureSkipVerify, err = cc.Bool(prefix + ".insecureSkipVerify"); err != nil {
 		blog.Errorf("get gse %v insecureSkipVerify config error, err: %v", prefix, err)
 		return nil, err

--- a/src/thirdparty/gse/client/gseclient.go
+++ b/src/thirdparty/gse/client/gseclient.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"sync"
 
-	"configcenter/src/apimachinery/util"
 	"configcenter/src/common/ssl"
 	apiserver "configcenter/src/thirdparty/gse/get_agent_state_forsyncdata"
 	taskserver "configcenter/src/thirdparty/gse/push_file_forsyncdata"
@@ -27,13 +26,13 @@ import (
 // GseApiServerClient TODO
 type GseApiServerClient struct {
 	endpoints []string
-	tlsConf   *util.TLSClientConfig
+	tlsConf   *ssl.TLSClientConfig
 	index     int
 	sync.Mutex
 }
 
 // NewGseApiServerClient new gse api server client
-func NewGseApiServerClient(endpoints []string, conf *util.TLSClientConfig) (*GseApiServerClient, error) {
+func NewGseApiServerClient(endpoints []string, conf *ssl.TLSClientConfig) (*GseApiServerClient, error) {
 	return &GseApiServerClient{
 		endpoints: endpoints,
 		tlsConf:   conf,
@@ -69,13 +68,13 @@ func (g *GseApiServerClient) getClient() (*apiClient, error) {
 // GseTaskServerClient TODO
 type GseTaskServerClient struct {
 	endpoints []string
-	tlsConf   *util.TLSClientConfig
+	tlsConf   *ssl.TLSClientConfig
 	index     int
 	sync.Mutex
 }
 
 // NewGseTaskServerClient new gse task server client
-func NewGseTaskServerClient(endpoints []string, conf *util.TLSClientConfig) (*GseTaskServerClient, error) {
+func NewGseTaskServerClient(endpoints []string, conf *ssl.TLSClientConfig) (*GseTaskServerClient, error) {
 	return &GseTaskServerClient{
 		endpoints: endpoints,
 		tlsConf:   conf,
@@ -118,7 +117,7 @@ func (g *GseTaskServerClient) getClient() (*taskClient, error) {
 }
 
 // createGseApiServerClient create thrift client for gse apiServer
-func createGseApiServerClient(endpoint string, conf *util.TLSClientConfig) (*apiClient, error) {
+func createGseApiServerClient(endpoint string, conf *ssl.TLSClientConfig) (*apiClient, error) {
 	var trans thrift.TTransport
 	cfg, err := ssl.ClientTLSConfVerity(conf.CAFile, conf.CertFile, conf.KeyFile, conf.Password)
 	if err != nil {
@@ -145,7 +144,7 @@ func createGseApiServerClient(endpoint string, conf *util.TLSClientConfig) (*api
 }
 
 // createGseTaskServerClient create thrift client for gse taskServer
-func createGseTaskServerClient(endpoint string, conf *util.TLSClientConfig) (*taskClient, error) {
+func createGseTaskServerClient(endpoint string, conf *ssl.TLSClientConfig) (*taskClient, error) {
 	cfg, err := ssl.ClientTLSConfVerity(conf.CAFile, conf.CertFile, conf.KeyFile, conf.Password)
 	if err != nil {
 		return nil, err

--- a/src/thirdparty/secrets/secrets.go
+++ b/src/thirdparty/secrets/secrets.go
@@ -21,6 +21,7 @@ import (
 	"configcenter/src/apimachinery/flowctrl"
 	"configcenter/src/apimachinery/rest"
 	"configcenter/src/apimachinery/util"
+	"configcenter/src/common/ssl"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -32,7 +33,7 @@ type SecretsClient interface {
 }
 
 // NewSecretsClient new a secrets client
-func NewSecretsClient(tls *util.TLSClientConfig, config SecretsConfig, reg prometheus.Registerer) (SecretsClient,
+func NewSecretsClient(tls *ssl.TLSClientConfig, config SecretsConfig, reg prometheus.Registerer) (SecretsClient,
 	error) {
 	if err := config.Validate(); err != nil {
 		return nil, err

--- a/src/web_server/app/server.go
+++ b/src/web_server/app/server.go
@@ -113,12 +113,12 @@ func initWebService(webSvr *WebServer, engine *backbone.Engine) (*websvc.Service
 	if webSvr.Config.Redis.MasterName == "" {
 		// MasterName 为空，表示使用直连redis 。 使用Host,Port 做链接redis参数
 		service.Session, redisErr = redis.NewRedisStore(10, "tcp", webSvr.Config.Redis.Address,
-			webSvr.Config.Redis.Password, []byte("secret"))
+			webSvr.Config.Redis.Password, webSvr.Config.Redis.TLSConfig, []byte("secret"))
 	} else {
 		// MasterName 不为空，表示使用哨兵模式的redis。MasterName 是Master标记
 		address := strings.Split(webSvr.Config.Redis.Address, ";")
 		service.Session, redisErr = redis.NewRedisStoreWithSentinel(address, 10, webSvr.Config.Redis.MasterName, "tcp",
-			webSvr.Config.Redis.Password, webSvr.Config.Redis.SentinelPassword, []byte("secret"))
+			webSvr.Config.Redis.Password, webSvr.Config.Redis.SentinelPassword, webSvr.Config.Redis.TLSConfig, []byte("secret"))
 	}
 	if redisErr != nil {
 		return nil, fmt.Errorf("create new redis store failed, err: %v", redisErr)

--- a/src/web_server/middleware/user/plugins/method/blueking/userinfo.go
+++ b/src/web_server/middleware/user/plugins/method/blueking/userinfo.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"time"
 
-	apiutil "configcenter/src/apimachinery/util"
 	"configcenter/src/common"
 	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
@@ -83,7 +82,7 @@ func (m *user) LoginUser(c *gin.Context, config map[string]string, isMultiOwner 
 	httpCli := httpclient.NewHttpClient()
 	httpCli.SetTimeOut(30 * time.Second)
 
-	tlsConf, err := apiutil.NewTLSClientConfigFromConfig("webServer.site.paas.tls")
+	tlsConf, err := cc.NewTLSClientConfigFromConfig("webServer.site.paas.tls")
 	if err != nil {
 		blog.Errorf("get tls config error, err: %v, rid: %s", err, rid)
 		return nil, false

--- a/src/web_server/middleware/user/plugins/method/blueking/userinfo.go
+++ b/src/web_server/middleware/user/plugins/method/blueking/userinfo.go
@@ -28,6 +28,7 @@ import (
 	"configcenter/src/common/http/httpclient"
 	"configcenter/src/common/metadata"
 	"configcenter/src/common/resource/esb"
+	"configcenter/src/common/ssl"
 	"configcenter/src/web_server/middleware/user/plugins/manager"
 
 	"github.com/gin-gonic/gin"
@@ -230,7 +231,7 @@ func (m *user) GetUserList(c *gin.Context, params map[string]string) ([]*metadat
 	return users, nil
 }
 
-func (m *user) setTLSConf(tlsConf *apiutil.TLSClientConfig, httpCli *httpclient.HttpClient, rid string) error {
+func (m *user) setTLSConf(tlsConf *ssl.TLSClientConfig, httpCli *httpclient.HttpClient, rid string) error {
 	if tlsConf != nil && !tlsConf.InsecureSkipVerify {
 		if err := httpCli.SetTLSVerify(tlsConf); err != nil {
 			return err

--- a/src/web_server/service/proxy.go
+++ b/src/web_server/service/proxy.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"time"
 
-	apiutil "configcenter/src/apimachinery/util"
 	"configcenter/src/common"
+	cc "configcenter/src/common/backbone/configcenter"
 	"configcenter/src/common/blog"
 	httpheader "configcenter/src/common/http/header"
 	webCommon "configcenter/src/web_server/common"
@@ -64,7 +64,7 @@ func (s *Service) ProxyRequest(c *gin.Context) {
 		return
 	}
 
-	tlsConf, err := apiutil.GetClientTLSConfig("webServer.site.paas.tls")
+	tlsConf, err := cc.GetClientTLSConfig("webServer.site.paas.tls")
 	if err != nil {
 		c.Writer.Write([]byte(err.Error()))
 		blog.Errorf("get webServer.site.paas.tls config error, err: %v", err)


### PR DESCRIPTION
根据[issue](https://github.com/TencentBlueKing/bk-cmdb/issues/8379)进行修改
**涉及的修改如下**：

- 抽离 `apimachinery/util` 中的 TLSClientConfig，解决import cycle
  - 抽离 TLSClientConfig  到 `common/ssl`
  - 修改引用处
- redis 客户端增加 TLS 配置
  - redis 客户端
- redisstore 客户端
  - 构建客户端函数参数支持 TLS
  - webserver 调用 redisstore 部分增加传入 tls 参数
- viper 读取配置增加读取 TLS 配置
- ini.py 初始化配置脚本增加 TLS 配置
- Helm chart 增加配置
  - 增加证书 configmap
  - values.yaml 增加证书路径
  - 依赖 redis 服务 的 deployment 挂载 证书 configmap
