### PR TITLE
feat: mongodb支持tls连接

### DIFF
--- a/docs/smart/web/extra-data/configure/readme.md
+++ b/docs/smart/web/extra-data/configure/readme.md
@@ -1,4 +1,5 @@
 ### 变量说明
+
 | 变量名称                                   | 变量含义                             | 可直接设置成的变量值  |
 |----------------------------------------|----------------------------------|-------------|
 | BK_CMDB_ES_STATUS                      | 全文检索功能开关(取值：off/on)，默认是off，开启是on | "off"       |
@@ -28,6 +29,10 @@
 | BK_CMDB_MONGODB_MECHANISM              | cmdb mongodb mechanism           | SCRAM-SHA-1 |
 | BK_CMDB_MONGODB_RS_NAME                | cmdb mongodb  rsName             | rs0         |
 | BK_CMDB_MONGODB_SOCKET_TIMEOUT_SECONDS | cmdb mongodb socket连接的超时时间       | 10          |
+| BK_CMDB_MONGODB_SSL_CERT_PATH          | cmdb mongodb ssl 客户端证书的路径          |         |
+| BK_CMDB_MONGODB_SSL_KEY_PATH           | cmdb mongodb ssl 私钥的路径             |         |
+| BK_CMDB_MONGODB_SSL_CA_CERT_PATH       | cmdb mongodb ssl CA 证书的路径          |         |
+| BK_CMDB_MONGODB_SSL_SKIP_VERIFY        | cmdb mongodb ssl 是否跳过证书验证, 默认false | true        |
 | BK_CMDB_REDIS_SENTINEL_HOST            | cmdb redis sentinel地址            |             |
 | BK_CMDB_REDIS_SENTINEL_PORT            | cmdb redis sentinel端口            |             |
 | BK_CMDB_REDIS_PASSWORD                 | cmdb redis密码                     |             |

--- a/docs/smart/web/extra-data/configure/web.yaml.tmpl
+++ b/docs/smart/web/extra-data/configure/web.yaml.tmpl
@@ -163,6 +163,11 @@ mongodb:
   rsName: ${BK_CMDB_MONGODB_RS_NAME}
   #mongo的socket连接的超时时间，以秒为单位，默认10s，最小5s，最大30s。
   socketTimeoutSeconds: ${BK_CMDB_MONGODB_SOCKET_TIMEOUT_SECONDS}
+  tls:
+    insecureSkipVerify: ${BK_CMDB_MONGODB_SSL_SKIP_VERIFY}
+    caFile: ${BK_CMDB_MONGODB_SSL_CA_CERT_PATH}
+    certFile: ${BK_CMDB_MONGODB_SSL_CERT_PATH}
+    keyFile: ${BK_CMDB_MONGODB_SSL_KEY_PATH}
 
 redis:
   # 公共redis配置信息,用于存取缓存，用户信息等数据

--- a/docs/support-file/helm/backend/templates/adminserver/adminserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/adminserver/adminserver-dpl.yaml
@@ -85,6 +85,8 @@ spec:
         {{- end }}
         {{- end }}
         {{- include "cmdb.redis.certVolumeMount" . | nindent 8 }}
+        {{- include "cmdb.mongodb.certVolumeMount" . | nindent 8 }}
+        {{- include "cmdb.mongodb.watch.certVolumeMount" . | nindent 8 }}
       volumes:
       - name: configures
         configMap:
@@ -95,6 +97,8 @@ spec:
       {{- end }}
       {{- end }}
       {{- include "cmdb.redis.certVolume" . | nindent 6 }}
+      {{- include "cmdb.mongodb.certVolume" . | nindent 6 }}
+      {{- include "cmdb.mongodb.watch.certVolume" . | nindent 6}}
       {{- with .Values.adminserver.nodeSelector }}
       nodeSelector:
       {{ toYaml . | nindent 8 }}

--- a/docs/support-file/helm/backend/templates/adminserver/configmap.yaml
+++ b/docs/support-file/helm/backend/templates/adminserver/configmap.yaml
@@ -340,6 +340,15 @@ data:
       #mongo的socket连接的超时时间，以秒为单位，默认10s，最小5s，最大30s。
       socketTimeoutSeconds: {{ .Values.mongodb.externalMongodb.socketTimeoutSeconds }}
       enable: {{ .Values.mongodb.externalMongodb.enabled }}
+      tls:
+        insecureSkipVerify: {{ .Values.mongodb.tls.insecureSkipVerify }}
+      {{- if .Values.mongodbCert.mongodb.ca }}
+        caFile: {{ .Values.certPath }}/{{ .Values.mongodb.tls.caFile }}
+      {{- end }}
+      {{- if and .Values.mongodbCert.mongodb.key .Values.mongodbCert.mongodb.cert }}
+        certFile: {{ .Values.certPath }}/{{ .Values.mongodb.tls.certFile }}
+        keyFile: {{ .Values.certPath }}/{{ .Values.mongodb.tls.keyFile }}
+      {{- end }}
 
     watch:
       host: {{ include "cmdb.mongodb.watch.addr" . | quote }}
@@ -353,6 +362,15 @@ data:
       rsName: {{ .Values.mongodb.watch.rsName }}
       socketTimeoutSeconds: {{ .Values.mongodb.watch.socketTimeoutSeconds }}
       enable: {{ .Values.mongodb.watch.enable }}
+      tls:
+        insecureSkipVerify: {{ .Values.mongodb.watch.tls.insecureSkipVerify }}
+      {{- if .Values.mongodbCert.watch.ca }}
+        caFile: {{ .Values.certPath }}/{{ .Values.mongodb.watch.tls.caFile }}
+      {{- end }}
+      {{- if and .Values.mongodbCert.watch.cert .Values.mongodbCert.watch.key }}
+        keyFile: {{ .Values.certPath }}/{{ .Values.mongodb.watch.tls.keyFile }}
+        certFile: {{ .Values.certPath }}/{{ .Values.mongodb.watch.tls.certFile }}
+      {{- end }}
 
   redis.yaml: |-
     redis:

--- a/docs/support-file/helm/backend/templates/cacheservice/cacheservice-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/cacheservice/cacheservice-dpl.yaml
@@ -89,6 +89,8 @@ spec:
             mountPath: {{ .Values.cacheservice.configDir }}
           {{- end }}
           {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.mongodb.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.mongodb.watch.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.cacheservice.configDir }}
         - name: configures
@@ -96,6 +98,8 @@ spec:
             name: {{ .Release.Name }}-cacheservice-configures
         {{- end }}
         {{- include "cmdb.redis.certVolume" . | nindent 6 }}
+        {{- include "cmdb.mongodb.certVolume" . | nindent 6 }}
+        {{- include "cmdb.mongodb.watch.certVolume" . | nindent 6 }}
 
       {{- with .Values.cacheservice.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/cloudserver/cloudserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/cloudserver/cloudserver-dpl.yaml
@@ -89,12 +89,14 @@ spec:
           - name: configures
             mountPath: {{ .Values.cloudserver.configDir }}
           {{- end }}
+          {{- include "cmdb.mongodb.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.cloudserver.configDir }}
         - name: configures
           configMap:
             name: {{ .Release.Name }}-cloudserver-configures
         {{- end }}
+        {{- include "cmdb.mongodb.certVolume" . | nindent 6 }}
 
       {{- with .Values.cloudserver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/coreservice/coreservice-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/coreservice/coreservice-dpl.yaml
@@ -88,6 +88,7 @@ spec:
             mountPath: {{ .Values.coreservice.configDir }}
           {{- end }}
           {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.mongodb.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.coreservice.configDir }}
         - name: configures
@@ -95,6 +96,7 @@ spec:
             name: {{ .Release.Name }}-coreservice-configures
         {{- end }}
         {{- include "cmdb.redis.certVolume" . | nindent 6 }}
+        {{- include "cmdb.mongodb.certVolume" . | nindent 6 }}
 
       {{- with .Values.coreservice.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/datacollection/datacollection-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/datacollection/datacollection-dpl.yaml
@@ -91,6 +91,7 @@ spec:
           {{- include "cmdb.redis.snapshotCertVolumeMount" . | nindent 10 }}
           {{- include "cmdb.redis.discoverCertVolumeMount" . | nindent 10 }}
           {{- include "cmdb.redis.netCollectCertVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.mongodb.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.datacollection.configDir }}
         - name: configures
@@ -101,6 +102,7 @@ spec:
         {{- include "cmdb.redis.snapshotCertVolume" . | nindent 6 }}
         {{- include "cmdb.redis.discoverCertVolume" . | nindent 6 }}
         {{- include "cmdb.redis.netCollectCertVolume" . | nindent 6 }}
+        {{- include "cmdb.mongodb.certVolume" . | nindent 6 }}
 
       {{- with .Values.datacollection.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/eventserver/eventserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/eventserver/eventserver-dpl.yaml
@@ -92,6 +92,7 @@ spec:
             mountPath: {{ .Values.eventserver.configDir }}
           {{- end }}
           {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.mongodb.certVolumeMount" . | nindent 10 }}
 
       volumes:
         - name: cert
@@ -103,6 +104,7 @@ spec:
             name: {{ .Release.Name }}-eventserver-configures
         {{- end }}
         {{- include "cmdb.redis.certVolume" . | nindent 8 }}
+        {{- include "cmdb.mongodb.certVolume" . | nindent 8 }}
 
       {{- with .Values.eventserver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/mongodb-cert-configmap.yaml
+++ b/docs/support-file/helm/backend/templates/mongodb-cert-configmap.yaml
@@ -1,0 +1,25 @@
+{{- $mongodbTypes := dict "mongodb" "mongodb" "watch" "mongodb-watch" }}
+
+{{- range $mongodbType, $prefix := $mongodbTypes }}
+{{- $certData := index $.Values.mongodbCert $mongodbType }}
+{{- if or $certData.ca $certData.cert $certData.key }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "bk-cmdb.fullname" $ }}-{{ $prefix }}-certs
+data:
+  {{- if $certData.ca }}
+  {{ $prefix }}.ca: {{ $certData.ca | b64dec | quote }}
+  {{- end }}
+  {{- if $certData.cert }}
+  {{ $prefix }}.cert: {{ $certData.cert | b64dec | quote }}
+  {{- end }}
+  {{- if $certData.key }}
+  {{ $prefix }}.key: {{ $certData.key | b64dec | quote }}
+  {{- end }}
+  {{- if and $certData.cert $certData.key }}
+  {{ $prefix }}.pem: {{ printf "%s\n%s" ($certData.cert | b64dec) ($certData.key | b64dec) | quote }}
+  {{- end }}
+---
+{{- end }}
+{{- end }}

--- a/docs/support-file/helm/backend/templates/monstache/monstache-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/monstache/monstache-dpl.yaml
@@ -41,7 +41,7 @@ spec:
         volumeMounts:
           - name: configures
             mountPath: {{ .Values.monstache.configDir }}
-
+          {{- include "cmdb.mongodb.certVolumeMount" . | nindent 10 }}
         {{- if .Values.monstache.resources }}
         resources: {{ toYaml .Values.monstache.resources | nindent 10 }}
         {{- end }}
@@ -53,5 +53,6 @@ spec:
         - name: configures
           configMap:
             name: {{ .Release.Name }}-monstache-configures
+        {{- include "cmdb.mongodb.certVolume" . | nindent 8 }}
 
 {{- end }}

--- a/docs/support-file/helm/backend/templates/taskserver/taskserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/taskserver/taskserver-dpl.yaml
@@ -87,6 +87,7 @@ spec:
             mountPath: {{ .Values.taskserver.configDir }}
           {{- end }}
           {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.mongodb.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.taskserver.configDir }}
         - name: configures
@@ -94,6 +95,7 @@ spec:
             name: {{ .Release.Name }}-taskserver-configures
         {{- end }}
         {{- include "cmdb.redis.certVolume" . | nindent 6 }}
+        {{- include "cmdb.mongodb.certVolume" . | nindent 6 }}
 
       {{- with .Values.taskserver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/values.yaml
+++ b/docs/support-file/helm/backend/values.yaml
@@ -1462,6 +1462,27 @@ mongodb:
     username: cc
     password:
     database: cmdb
+  tls:
+    ## @param mongodb.tls.caFile redis TLS CA file
+    ## Certificate file name, will be combined with certPath
+    ##
+    caFile: "mongodb/mongodb.ca"
+    ## @param mongodb.tls.certFile redis TLS cert file
+    ## Certificate file name, will be combined with certPath
+    ##
+    certFile: "mongodb/mongodb.cert"
+    ## @param mongodb.tls.keyFile redis TLS key file
+    ## Key file name, will be combined with certPath
+    ##
+    keyFile: "mongodb/mongodb.key"
+    ## @param mongodb.tls.pemFile redis TLS pem file
+    ## Combined certificate and key file name, will be combined with certPath
+    ##
+    pemFile: "mongodb/mongodb.pem"
+    ## @param mongodb.tls.insecureSkipVerify mongodb TLS insecure skip verify
+    ##
+    insecureSkipVerify: true
+
   ## @param mongodb.host mongodb host
   ##
   host: mongodb-headless.default.svc.cluster.local
@@ -1530,6 +1551,22 @@ mongodb:
     ## mongo的socket连接的超时时间，以秒为单位，默认10s，最小5s，最大30s。
     ##
     socketTimeoutSeconds: 10
+    tls:
+      ## @param mongodb.watch.tls.caFile redis TLS CA file
+      ## Certificate file name, will be combined with certPath
+      ##
+      caFile: "mongodb-watch/mongodb-watch.ca"
+      ## @param mongodb.watch.tls.certFile redis TLS cert file
+      ## Certificate file name, will be combined with certPath
+      ##
+      certFile: "mongodb-watch/mongodb-watch.cert"
+      ## @param mongodb.watch.tls.keyFile redis TLS key file
+      ## Key file name, will be combined with certPath
+      ##
+      keyFile: "mongodb-watch/mongodb-watch.key"
+      ## @param mongodb.watch.tls.insecureSkipVerify mongodb TLS insecure skip verify
+      ##
+      insecureSkipVerify: true
 
 ## @section redis parameters
 ##
@@ -1949,6 +1986,33 @@ redisCert:
     ##
     cert: ""
     ## @param redisCert.netCollectRedis.key client key for network collect redis connection
+    ## key content encoded in base64
+    ##
+    key: ""
+mongodbCert:
+  mongodb:
+    ## @param mongodbCert.ca CA certificate for mongodb connection
+    ## certificate content encoded in base64
+    ##
+    ca: ""
+    ## @param mongodbCert.cert client certificate mongodb connection
+    ## certificate content encoded in base64
+    ##
+    cert: ""
+    ## @param mongodbCert.key client key for network collect mongodb connection
+    ## key content encoded in base64
+    ##
+    key: ""
+  watch:
+    ## @param mongodbCert.ca CA certificate for mongodb connection
+    ## certificate content encoded in base64
+    ##
+    ca: ""
+    ## @param mongodbCert.cert client certificate mongodb connection
+    ## certificate content encoded in base64
+    ##
+    cert: ""
+    ## @param mongodbCert.key client key for network collect mongodb connection
     ## key content encoded in base64
     ##
     key: ""

--- a/docs/support-file/helm/web/templates/_helpers.tpl
+++ b/docs/support-file/helm/web/templates/_helpers.tpl
@@ -127,3 +127,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
     {{- printf "%s" .Values.bkComponentApiUrl -}}
   {{- end -}}
 {{- end -}}
+
+{{- define "cmdb.mongodb.certVolumeMount" -}}
+{{- if or .Values.mongodbCert.mongodb.cert .Values.mongodbCert.mongodb.key .Values.mongodbCert.mongodb.ca }}
+- name: mongodb-certs
+  mountPath: {{ .Values.certPath }}/mongodb
+{{- end }}
+{{- end -}}
+
+{{- define "cmdb.mongodb.certVolume" -}}
+{{- if or .Values.mongodbCert.mongodb.cert .Values.mongodbCert.mongodb.key .Values.mongodbCert.mongodb.ca }}
+- name: mongodb-certs
+  configMap:
+    name: {{ template "bk-cmdb.fullname" . }}-mongodb-certs
+{{- end }}
+{{- end -}}

--- a/docs/support-file/helm/web/templates/webserver/configmap.yaml
+++ b/docs/support-file/helm/web/templates/webserver/configmap.yaml
@@ -187,6 +187,15 @@ data:
       #mongo的socket连接的超时时间，以秒为单位，默认10s，最小5s，最大30s。
       socketTimeoutSeconds: {{ .Values.mongodb.externalMongodb.socketTimeoutSeconds }}
       enable: {{ .Values.mongodb.externalMongodb.enabled }}
+      tls:
+        insecureSkipVerify: {{ .Values.mongodb.externalMongodb.tls.insecureSkipVerify }}
+        {{- if .Values.mongodb.externalMongodb.tls.caFile }}
+        caFile: {{ .Values.mongodb.externalMongodb.tls.caFile }}
+        {{- end }}
+        {{- if and .Values.mongodb.externalMongodb.tls.certFile .Values.mongodb.externalMongodb.tls.keyFile }}
+        certFile: {{ .Values.mongodb.externalMongodb.tls.certFile }}
+        keyFile: {{ .Values.mongodb.externalMongodb.tls.keyFile }}
+        {{- end }}
 
     redis:
       host: {{ include "cmdb.redis.host" . | quote }}

--- a/docs/support-file/helm/web/templates/webserver/webserver-dpl.yaml
+++ b/docs/support-file/helm/web/templates/webserver/webserver-dpl.yaml
@@ -93,6 +93,7 @@ spec:
           - name: redis-cert
             mountPath: {{ .Values.certPath}}/redis
           {{- end }}
+          {{- include "cmdb.mongodb.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.webserver.configDir }}
         - name: configures
@@ -104,6 +105,7 @@ spec:
           configMap:
             name: "{{ template "bk-cmdb.fullname" $ }}-web-redis-certs"
         {{- end }}
+        {{- include "cmdb.mongodb.certVolume" . | nindent 8 }}
 
       {{- with .Values.webserver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/web/templates/webserver/webserver-mongodb-cert-configmap.yaml
+++ b/docs/support-file/helm/web/templates/webserver/webserver-mongodb-cert-configmap.yaml
@@ -1,0 +1,25 @@
+{{- $mongodbTypes := dict "mongodb" "mongodb" }}
+
+{{- range $mongodbType, $prefix := $mongodbTypes }}
+{{- $certData := index $.Values.mongodbCert $mongodbType }}
+{{- if or $certData.ca $certData.cert $certData.key }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "bk-cmdb.fullname" $ }}-{{ $prefix }}-certs
+data:
+  {{- if $certData.ca }}
+  {{ $prefix }}.ca: {{ $certData.ca | b64dec | quote }}
+  {{- end }}
+  {{- if $certData.cert }}
+  {{ $prefix }}.cert: {{ $certData.cert | b64dec | quote }}
+  {{- end }}
+  {{- if $certData.key }}
+  {{ $prefix }}.key: {{ $certData.key | b64dec | quote }}
+  {{- end }}
+  {{- if and $certData.cert $certData.key }}
+  {{ $prefix }}.pem: {{ printf "%s\n%s" ($certData.cert | b64dec) ($certData.key | b64dec) | quote }}
+  {{- end }}
+---
+{{- end }}
+{{- end }}

--- a/docs/support-file/helm/web/values.yaml
+++ b/docs/support-file/helm/web/values.yaml
@@ -386,6 +386,23 @@ web:
 configAndServiceCenter:
   addr:
 
+## @section mongodbCert parameters
+##
+mongodbCert:
+  mongodb:
+    ## @param mongodbCert.ca CA certificate for mongodb connection
+    ## certificate content encoded in base64
+    ##
+    ca: ""
+    ## @param mongodbCert.cert client certificate mongodb connection
+    ## certificate content encoded in base64
+    ##
+    cert: ""
+    ## @param mongodbCert.key client key for network collect mongodb connection
+    ## key content encoded in base64
+    ##
+    key: ""
+
 ## @section mongodb parameters
 ##
 mongodb:
@@ -453,6 +470,27 @@ mongodb:
     ## mongo的socket连接的超时时间，以秒为单位，默认10s，最小5s，最大30s。
     ##
     socketTimeoutSeconds: 10
+    ## @param mongodb.externalMongodb.tls mongodb tls config
+    tls:
+      ## @param mongodb.externalMongodb.tls.caFile redis TLS CA file
+      ## Certificate file name, will be combined with certPath
+      ##
+      caFile: "mongodb/mongodb.ca"
+      ## @param mongodb.externalMongodb.tls.certFile redis TLS cert file
+      ## Certificate file name, will be combined with certPath
+      ##
+      certFile: "mongodb/mongodb.cert"
+      ## @param mongodb.externalMongodb.tls.keyFile redis TLS key file
+      ## Key file name, will be combined with certPath
+      ##
+      keyFile: "mongodb/mongodb.key"
+      ## @param mongodb.externalMongodb.tls.pemFile redis TLS pem file
+      ## Combined certificate and key file name, will be combined with certPath
+      ##
+      pemFile: "mongodb/mongodb.pem"
+      ## @param mongodb.externalMongodb.tls.insecureSkipVerify mongodb TLS insecure skip verify
+      ##
+      insecureSkipVerify: true
 
 ## @param certPath cert path.
 ##

--- a/src/common/backbone/configcenter/viper.go
+++ b/src/common/backbone/configcenter/viper.go
@@ -312,6 +312,11 @@ func Mongo(prefix string) (mongo.Config, error) {
 		return mongo.Config{}, errors.New("can't find mongo configuration")
 	}
 
+	tlsClientConfig, err := NewTLSClientConfigFromConfig(prefix + ".tls")
+	if err != nil {
+		return mongo.Config{}, err
+	}
+
 	c := mongo.Config{
 		Address:   parser.getString(prefix + ".host"),
 		Port:      parser.getString(prefix + ".port"),
@@ -320,6 +325,7 @@ func Mongo(prefix string) (mongo.Config, error) {
 		Database:  parser.getString(prefix + ".database"),
 		Mechanism: parser.getString(prefix + ".mechanism"),
 		RsName:    parser.getString(prefix + ".rsName"),
+		TLSConf:   &tlsClientConfig,
 	}
 
 	if c.RsName == "" {
@@ -582,6 +588,10 @@ func getKeyValueParser(key string) (*viperParser, error) {
 
 	if redisParser != nil && redisParser.isSet(key) {
 		return redisParser, nil
+	}
+
+	if mongodbParser != nil && mongodbParser.isSet(key) {
+		return mongodbParser, nil
 	}
 
 	return nil, fmt.Errorf("%s key's config not found", key)

--- a/src/storage/dal/mongo/config.go
+++ b/src/storage/dal/mongo/config.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"configcenter/src/common/ssl"
 	"configcenter/src/storage/dal"
 	"configcenter/src/storage/dal/mongo/local"
 )
@@ -57,6 +58,7 @@ type Config struct {
 	RsName        string
 	SocketTimeout int
 	DisableInsert bool
+	TLSConf       *ssl.TLSClientConfig
 }
 
 // BuildURI return mongo uri according to  https://docs.mongodb.com/manual/reference/connection-string/
@@ -85,6 +87,7 @@ func (c Config) GetMongoConf() local.MongoConf {
 		RsName:        c.RsName,
 		SocketTimeout: c.SocketTimeout,
 		DisableInsert: c.DisableInsert,
+		TLS:           c.TLSConf,
 	}
 }
 
@@ -96,6 +99,7 @@ func (c Config) GetMongoClient() (db dal.RDB, err error) {
 		URI:           c.BuildURI(),
 		RsName:        c.RsName,
 		SocketTimeout: c.SocketTimeout,
+		TLS:           c.TLSConf,
 	}
 	db, err = local.NewMgo(mongoConf, time.Minute)
 	if err != nil {

--- a/src/storage/dal/mongo/local/mongo.go
+++ b/src/storage/dal/mongo/local/mongo.go
@@ -26,6 +26,7 @@ import (
 	"configcenter/src/common/blog"
 	"configcenter/src/common/json"
 	"configcenter/src/common/metadata"
+	"configcenter/src/common/ssl"
 	"configcenter/src/common/util"
 	"configcenter/src/common/util/table"
 	"configcenter/src/storage/dal"
@@ -70,6 +71,7 @@ type MongoConf struct {
 	RsName         string
 	SocketTimeout  int
 	DisableInsert  bool
+	TLS            *ssl.TLSClientConfig
 }
 
 // NewMgo returns new RDB
@@ -96,6 +98,13 @@ func NewMgo(config MongoConf, timeout time.Duration) (*Mongo, error) {
 		RetryWrites:     &disableWriteRetry,
 		MaxConnIdleTime: &maxConnIdleTime,
 		AppName:         &appName,
+	}
+	tlsConf, useTLS, err := ssl.NewTLSConfigFromConf(config.TLS)
+	if err != nil {
+		return nil, fmt.Errorf("new tls config failed: %v", err)
+	}
+	if useTLS {
+		conOpt.TLSConfig = tlsConf
 	}
 
 	client, err := mongo.NewClient(options.Client().ApplyURI(config.URI), &conOpt)

--- a/src/storage/stream/stream.go
+++ b/src/storage/stream/stream.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"configcenter/src/apimachinery/discovery"
+	"configcenter/src/common/ssl"
 	"configcenter/src/storage/dal/mongo/local"
 	"configcenter/src/storage/stream/event"
 	"configcenter/src/storage/stream/loop"
@@ -53,6 +54,13 @@ func NewStream(conf local.MongoConf) (Interface, error) {
 		MinPoolSize:    &conf.MaxIdleConns,
 		ConnectTimeout: &timeout,
 		ReplicaSet:     &conf.RsName,
+	}
+	tlsConf, useTLS, err := ssl.NewTLSConfigFromConf(conf.TLS)
+	if err != nil {
+		return nil, err
+	}
+	if useTLS {
+		conOpt.TLSConfig = tlsConf
 	}
 
 	client, err := mongo.NewClient(options.Client().ApplyURI(conf.URI), &conOpt)
@@ -92,6 +100,13 @@ func NewLoopStream(conf local.MongoConf, isMaster discovery.ServiceManageInterfa
 		MinPoolSize:    &conf.MaxIdleConns,
 		ConnectTimeout: &timeout,
 		ReplicaSet:     &conf.RsName,
+	}
+	tlsConf, useTLS, err := ssl.NewTLSConfigFromConf(conf.TLS)
+	if nil != err {
+		return nil, err
+	}
+	if useTLS {
+		conOpt.TLSConfig = tlsConf
 	}
 
 	client, err := mongo.NewClient(options.Client().ApplyURI(conf.URI), &conOpt)


### PR DESCRIPTION
增加cmdb依赖的mongodb支持tls连接，具体修改如下：
- mongodb客户端修改
    - local.mongodb增加TLS配置和初始化TLS操作
    - stream 初始化mongodb客户端过程增加TLS配置Options
- viper.go 增加使用NewTLSClientConfigFromConfig读取mongodb的tls配置
- init.py增加mongodb证书相关参数
- helm chart支持mongodb证书配置
    - deployment 增加证书挂载
    - 增加mongodb证书configmap，其中双向TLS monstache需要在连接字符串中通过一个参数支持同时包含证书和key，所以在configmap中增加了一个文件，为证书和key的合并文件
