### PR TITLE
feat: zookeeper客户端支持tls连接

### DIFF
--- a/docs/support-file/helm/backend/templates/_helpers.tpl
+++ b/docs/support-file/helm/backend/templates/_helpers.tpl
@@ -356,3 +356,32 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
     name: {{ template "bk-cmdb.fullname" . }}-mongodb-watch-certs
 {{- end }}
 {{- end -}}
+
+{{- define  "cmdb.configAndServiceCenter.certVolumeMount" -}}
+{{- if or .Values.zookeeperCert.cert .Values.zookeeperCert.key .Values.zookeeperCert.ca }}
+- name: zookeeper-certs
+  mountPath: {{ .Values.certPath }}/zookeeper
+{{- end }}
+{{- end -}}
+
+{{- define  "cmdb.configAndServiceCenter.certVolume" -}}
+{{- if or .Values.zookeeperCert.cert .Values.zookeeperCert.key .Values.zookeeperCert.ca }}
+- name: zookeeper-certs
+  configMap:
+    name: {{ template "bk-cmdb.fullname" $ }}-zookeeper-certs
+{{- end }}
+{{- end }}
+
+{{- define "cmdb.configAndServiceCenter.certCommand" -}}
+{{- if .Values.zookeeperCert.ca }}
+- --regdiscv-cafile={{ .Values.certPath }}/{{ .Values.configAndServiceCenter.tls.caFile }}
+- --regdiscv-skipverify={{ .Values.configAndServiceCenter.tls.insecureSkipVerify }}
+{{- end }}
+{{- if and .Values.zookeeperCert.cert .Values.zookeeperCert.key }}
+- --regdiscv-certfile={{ .Values.certPath }}/{{ .Values.configAndServiceCenter.tls.certFile }}
+- --regdiscv-keyfile={{ .Values.certPath }}/{{ .Values.configAndServiceCenter.tls.keyFile }}
+{{- end }}
+{{- if .Values.configAndServiceCenter.tls.password }}
+- --regdiscv-certpassword={{ .Values.certPath }}/{{ .Values.configAndServiceCenter.tls.password }}
+{{- end }}
+{{- end -}}

--- a/docs/support-file/helm/backend/templates/adminserver/adminserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/adminserver/adminserver-dpl.yaml
@@ -87,6 +87,7 @@ spec:
         {{- include "cmdb.redis.certVolumeMount" . | nindent 8 }}
         {{- include "cmdb.mongodb.certVolumeMount" . | nindent 8 }}
         {{- include "cmdb.mongodb.watch.certVolumeMount" . | nindent 8 }}
+        {{- include "cmdb.configAndServiceCenter.certVolumeMount" . | nindent 8 }}
       volumes:
       - name: configures
         configMap:
@@ -98,7 +99,8 @@ spec:
       {{- end }}
       {{- include "cmdb.redis.certVolume" . | nindent 6 }}
       {{- include "cmdb.mongodb.certVolume" . | nindent 6 }}
-      {{- include "cmdb.mongodb.watch.certVolume" . | nindent 6}}
+      {{- include "cmdb.mongodb.watch.certVolume" . | nindent 6 }}
+      {{- include "cmdb.configAndServiceCenter.certVolume" . | nindent 6 }}
       {{- with .Values.adminserver.nodeSelector }}
       nodeSelector:
       {{ toYaml . | nindent 8 }}

--- a/docs/support-file/helm/backend/templates/adminserver/configmap.yaml
+++ b/docs/support-file/helm/backend/templates/adminserver/configmap.yaml
@@ -304,11 +304,31 @@ data:
       addrs: {{ include "cmdb.configAndServiceCenter.addr" . | quote }}
       usr:
       pwd:
+      tls:
+        insecureSkipVerify: {{ .Values.configAndServiceCenter.tls.insecureSkipVerify }}
+        password: {{ .Values.configAndServiceCenter.tls.password }}
+        {{- if .Values.zookeeperCert.ca }}
+        caFile: {{ .Values.certPath }}/{{ .Values.configAndServiceCenter.tls.caFile }}
+        {{- end }}
+        {{- if and .Values.zookeeperCert.cert .Values.zookeeperCert.cert }}
+        certFile: {{ .Values.certPath }}/{{ .Values.configAndServiceCenter.tls.certFile }}
+        keyFile: {{ .Values.certPath }}/{{ .Values.configAndServiceCenter.tls.keyFile }}
+        {{- end }}
 
     registerServer:
       addrs: {{ include "cmdb.configAndServiceCenter.addr" . | quote }}
       usr:
       pwd:
+      tls:
+        insecureSkipVerify: {{ .Values.configAndServiceCenter.tls.insecureSkipVerify }}
+        password: {{ .Values.configAndServiceCenter.tls.password }}
+        {{- if .Values.zookeeperCert.ca }}
+        caFile: {{ .Values.certPath }}/{{ .Values.configAndServiceCenter.tls.caFile }}
+        {{- end }}
+        {{- if and .Values.zookeeperCert.cert .Values.zookeeperCert.cert }}
+        certFile: {{ .Values.certPath }}/{{ .Values.configAndServiceCenter.tls.certFile }}
+        keyFile: {{ .Values.certPath }}/{{ .Values.configAndServiceCenter.tls.keyFile }}
+        {{- end }}
 
     confs:
       dir: {{ .Values.adminserver.configDir }}

--- a/docs/support-file/helm/backend/templates/apiserver/apiserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/apiserver/apiserver-dpl.yaml
@@ -48,6 +48,7 @@ spec:
         - --logtostderr={{ .Values.apiserver.command.logToStdErr }}
         - "--enable-auth"
         - {{ .Values.iam.auth.enabled | quote }}
+        {{- include "cmdb.configAndServiceCenter.certCommand" . | nindent 8 }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -89,6 +90,7 @@ spec:
             mountPath: {{ .Values.apiserver.configDir }}
           {{- end }}
           {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.configAndServiceCenter.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.apiserver.configDir }}
         - name: configures
@@ -97,6 +99,7 @@ spec:
         {{- end }}
 
       {{- include "cmdb.redis.certVolume" . | nindent 6 }}
+      {{- include "cmdb.configAndServiceCenter.certVolume" . | nindent 6 }}
       {{- with .Values.apiserver.nodeSelector }}
       nodeSelector:
       {{ toYaml . | nindent 8 }}

--- a/docs/support-file/helm/backend/templates/authserver/authserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/authserver/authserver-dpl.yaml
@@ -48,6 +48,7 @@ spec:
         - --logtostderr={{ .Values.authserver.command.logToStdErr }}
         - "--enable-auth"
         - {{ .Values.iam.auth.enabled | quote }}
+        {{- include "cmdb.configAndServiceCenter.certCommand" . | nindent 8 }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -88,12 +89,14 @@ spec:
           - name: configures
             mountPath: {{ .Values.authserver.configDir }}
           {{- end }}
+          {{- include "cmdb.configAndServiceCenter.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.authserver.configDir }}
         - name: configures
           configMap:
             name: {{ .Release.Name }}-authserver-configures
         {{- end }}
+        {{- include "cmdb.configAndServiceCenter.certVolume" . | nindent 8 }}
 
       {{- with .Values.authserver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/cacheservice/cacheservice-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/cacheservice/cacheservice-dpl.yaml
@@ -48,6 +48,8 @@ spec:
         - --logtostderr={{ .Values.cacheservice.command.logToStdErr }}
         - "--enable-auth"
         - {{ .Values.iam.auth.enabled | quote }}
+        {{- include "cmdb.configAndServiceCenter.certCommand" . | nindent 8 }}
+
         livenessProbe:
           httpGet:
             path: /healthz
@@ -91,6 +93,7 @@ spec:
           {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
           {{- include "cmdb.mongodb.certVolumeMount" . | nindent 10 }}
           {{- include "cmdb.mongodb.watch.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.configAndServiceCenter.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.cacheservice.configDir }}
         - name: configures
@@ -100,6 +103,7 @@ spec:
         {{- include "cmdb.redis.certVolume" . | nindent 6 }}
         {{- include "cmdb.mongodb.certVolume" . | nindent 6 }}
         {{- include "cmdb.mongodb.watch.certVolume" . | nindent 6 }}
+        {{- include "cmdb.configAndServiceCenter.certVolume" . | nindent 6 }}
 
       {{- with .Values.cacheservice.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/cloudserver/cloudserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/cloudserver/cloudserver-dpl.yaml
@@ -49,6 +49,7 @@ spec:
         - --logtostderr={{ .Values.cloudserver.command.logToStdErr }}
         - "--enable-auth"
         - {{ .Values.iam.auth.enabled | quote }}
+        {{- include "cmdb.configAndServiceCenter.certCommand" . | nindent 8 }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -90,6 +91,7 @@ spec:
             mountPath: {{ .Values.cloudserver.configDir }}
           {{- end }}
           {{- include "cmdb.mongodb.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.configAndServiceCenter.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.cloudserver.configDir }}
         - name: configures
@@ -97,6 +99,7 @@ spec:
             name: {{ .Release.Name }}-cloudserver-configures
         {{- end }}
         {{- include "cmdb.mongodb.certVolume" . | nindent 6 }}
+        {{- include "cmdb.configAndServiceCenter.certVolume" . | nindent 6 }}
 
       {{- with .Values.cloudserver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/coreservice/coreservice-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/coreservice/coreservice-dpl.yaml
@@ -47,6 +47,7 @@ spec:
         - --v={{ .Values.coreservice.command.logLevel }}
         - --logtostderr={{ .Values.coreservice.command.logToStdErr }}
         - --disable-insertion={{ .Values.coreservice.command.disableInsertion }}
+        {{- include "cmdb.configAndServiceCenter.certCommand" . | nindent 8 }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -89,6 +90,7 @@ spec:
           {{- end }}
           {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
           {{- include "cmdb.mongodb.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.configAndServiceCenter.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.coreservice.configDir }}
         - name: configures
@@ -97,6 +99,7 @@ spec:
         {{- end }}
         {{- include "cmdb.redis.certVolume" . | nindent 6 }}
         {{- include "cmdb.mongodb.certVolume" . | nindent 6 }}
+        {{- include "cmdb.configAndServiceCenter.certVolume" . | nindent 6 }}
 
       {{- with .Values.coreservice.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/datacollection/datacollection-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/datacollection/datacollection-dpl.yaml
@@ -48,6 +48,7 @@ spec:
         - --logtostderr={{ .Values.datacollection.command.logToStdErr }}
         - "--enable-auth"
         - {{ .Values.iam.auth.enabled | quote }}
+        {{- include "cmdb.configAndServiceCenter.certCommand" . | nindent 8 }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -92,6 +93,7 @@ spec:
           {{- include "cmdb.redis.discoverCertVolumeMount" . | nindent 10 }}
           {{- include "cmdb.redis.netCollectCertVolumeMount" . | nindent 10 }}
           {{- include "cmdb.mongodb.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.configAndServiceCenter.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.datacollection.configDir }}
         - name: configures
@@ -103,6 +105,7 @@ spec:
         {{- include "cmdb.redis.discoverCertVolume" . | nindent 6 }}
         {{- include "cmdb.redis.netCollectCertVolume" . | nindent 6 }}
         {{- include "cmdb.mongodb.certVolume" . | nindent 6 }}
+        {{- include "cmdb.configAndServiceCenter.certVolume" . | nindent 6 }}
 
       {{- with .Values.datacollection.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/eventserver/eventserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/eventserver/eventserver-dpl.yaml
@@ -48,6 +48,7 @@ spec:
         - --logtostderr={{ .Values.eventserver.command.logToStdErr }}
         - "--enable-auth"
         - {{ .Values.iam.auth.enabled | quote }}
+        {{- include "cmdb.configAndServiceCenter.certCommand" . | nindent 8 }}
 
         livenessProbe:
           httpGet:
@@ -93,6 +94,7 @@ spec:
           {{- end }}
           {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
           {{- include "cmdb.mongodb.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.configAndServiceCenter.certVolumeMount" . | nindent 10 }}
 
       volumes:
         - name: cert
@@ -105,6 +107,7 @@ spec:
         {{- end }}
         {{- include "cmdb.redis.certVolume" . | nindent 8 }}
         {{- include "cmdb.mongodb.certVolume" . | nindent 8 }}
+        {{- include "cmdb.configAndServiceCenter.certVolume" . | nindent 8 }}
 
       {{- with .Values.eventserver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/hostserver/hostserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/hostserver/hostserver-dpl.yaml
@@ -48,6 +48,7 @@ spec:
         - --logtostderr={{ .Values.hostserver.command.logToStdErr }}
         - "--enable-auth"
         - {{ .Values.iam.auth.enabled | quote }}
+        {{- include "cmdb.configAndServiceCenter.certCommand" . | nindent 8 }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -89,6 +90,7 @@ spec:
             mountPath: {{ .Values.hostserver.configDir }}
           {{- end }}
           {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.configAndServiceCenter.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.hostserver.configDir }}
         - name: configures
@@ -96,6 +98,7 @@ spec:
             name: {{ .Release.Name }}-hostserver-configures
         {{- end }}
         {{- include "cmdb.redis.certVolume" . | nindent 6 }}
+        {{- include "cmdb.configAndServiceCenter.certVolume" . | nindent 6 }}
 
       {{- with .Values.hostserver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/operationserver/operationserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/operationserver/operationserver-dpl.yaml
@@ -48,6 +48,7 @@ spec:
         - --logtostderr={{ .Values.operationserver.command.logToStdErr }}
         - "--enable-auth"
         - {{ .Values.iam.auth.enabled | quote }}
+        {{- include "cmdb.configAndServiceCenter.certCommand" . | nindent 8 }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -88,12 +89,14 @@ spec:
           - name: configures
             mountPath: {{ .Values.operationserver.configDir }}
           {{- end }}
+          {{- include "cmdb.configAndServiceCenter.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.operationserver.configDir }}
         - name: configures
           configMap:
             name: {{ .Release.Name }}-operationserver-configures
         {{- end }}
+        {{- include "cmdb.configAndServiceCenter.certVolume" . | nindent 8 }}
 
       {{- with .Values.operationserver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/procserver/procserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/procserver/procserver-dpl.yaml
@@ -48,6 +48,7 @@ spec:
         - --logtostderr={{ .Values.procserver.command.logToStdErr }}
         - "--enable-auth"
         - {{ .Values.iam.auth.enabled | quote }}
+        {{- include "cmdb.configAndServiceCenter.certCommand" . | nindent 8 }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -88,12 +89,14 @@ spec:
           - name: configures
             mountPath: {{ .Values.procserver.configDir }}
           {{- end }}
+          {{- include "cmdb.configAndServiceCenter.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.procserver.configDir }}
         - name: configures
           configMap:
             name: {{ .Release.Name }}-procserver-configures
         {{- end }}
+        {{- include "cmdb.configAndServiceCenter.certVolume" . | nindent 8 }}
 
       {{- with .Values.procserver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/synchronizeserver/synchronizeserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/synchronizeserver/synchronizeserver-dpl.yaml
@@ -48,6 +48,7 @@ spec:
         - --logtostderr={{ .Values.synchronizeserver.command.logToStdErr }}
         - "--enable-auth"
         - {{ .Values.iam.auth.enabled | quote }}
+        {{- include "cmdb.configAndServiceCenter.certCommand" . | nindent 8 }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -89,6 +90,7 @@ spec:
             mountPath: {{ .Values.synchronizeserver.configDir }}
           {{- end }}
           {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.configAndServiceCenter.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.synchronizeserver.configDir }}
         - name: configures
@@ -96,6 +98,7 @@ spec:
             name: {{ .Release.Name }}-synchronizeserver-configures
         {{- end }}
         {{- include "cmdb.redis.certVolume" . | nindent 6 }}
+        {{- include "cmdb.configAndServiceCenter.certVolume" . | nindent 6 }}
 
       {{- with .Values.synchronizeserver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/taskserver/taskserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/taskserver/taskserver-dpl.yaml
@@ -46,6 +46,7 @@ spec:
         {{- end }}
         - --v={{ .Values.taskserver.command.logLevel }}
         - --logtostderr={{ .Values.taskserver.command.logToStdErr }}
+        {{- include "cmdb.configAndServiceCenter.certCommand" . | nindent 8 }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -88,6 +89,7 @@ spec:
           {{- end }}
           {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
           {{- include "cmdb.mongodb.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.configAndServiceCenter.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.taskserver.configDir }}
         - name: configures
@@ -96,6 +98,7 @@ spec:
         {{- end }}
         {{- include "cmdb.redis.certVolume" . | nindent 6 }}
         {{- include "cmdb.mongodb.certVolume" . | nindent 6 }}
+        {{- include "cmdb.configAndServiceCenter.certVolume" . | nindent 6 }}
 
       {{- with .Values.taskserver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/toposerver/toposerver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/toposerver/toposerver-dpl.yaml
@@ -48,6 +48,7 @@ spec:
         - --logtostderr={{ .Values.toposerver.command.logToStdErr }}
         - "--enable-auth"
         - {{ .Values.iam.auth.enabled | quote }}
+        {{- include "cmdb.configAndServiceCenter.certCommand" . | nindent 8 }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -89,6 +90,7 @@ spec:
             mountPath: {{ .Values.toposerver.configDir }}
           {{- end }}
           {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.configAndServiceCenter.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.toposerver.configDir }}
         - name: configures
@@ -96,6 +98,7 @@ spec:
             name: {{ .Release.Name }}-toposerver-configures
         {{- end }}
         {{- include "cmdb.redis.certVolume" . | nindent 6 }}
+        {{- include "cmdb.configAndServiceCenter.certVolume" . | nindent 6 }}
 
       {{- with .Values.toposerver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/zookeeper-cert-configmap.yaml
+++ b/docs/support-file/helm/backend/templates/zookeeper-cert-configmap.yaml
@@ -1,0 +1,16 @@
+{{- if or .Values.zookeeperCert.cert .Values.zookeeperCert.key .Values.zookeeperCert.ca -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "bk-cmdb.fullname" $ }}-zookeeper-certs
+data:
+  {{- if .Values.zookeeperCert.ca }}
+  zk.ca: {{ .Values.zookeeperCert.ca | b64dec | quote }}
+  {{- end }}
+  {{- if .Values.zookeeperCert.cert }}
+  zk.cert: {{ .Values.zookeeperCert.cert | b64dec | quote }}
+  {{- end }}
+  {{- if .Values.zookeeperCert.key }}
+  zk.key: {{ .Values.zookeeperCert.key | b64dec | quote }}
+  {{- end }}
+{{- end -}}

--- a/docs/support-file/helm/backend/values.yaml
+++ b/docs/support-file/helm/backend/values.yaml
@@ -1429,8 +1429,14 @@ zookeeper:
 
 ## @section bk-cmdb config and service center parameters
 ##
-# configAndServiceCenter:
-#   addr:
+configAndServiceCenter:
+  addr:
+  tls:
+    insecureSkipVerify: true
+    caFile: "zookeeper/zk.ca"
+    certFile: "zookeeper/zk.cert"
+    keyFile: "zookeeper/zk.key"
+    password:
 
 ## @section mongodb parameters
 ##
@@ -2016,3 +2022,7 @@ mongodbCert:
     ## key content encoded in base64
     ##
     key: ""
+zookeeperCert:
+  ca: ""
+  cert: ""
+  key: ""

--- a/docs/support-file/helm/web/templates/_helpers.tpl
+++ b/docs/support-file/helm/web/templates/_helpers.tpl
@@ -142,3 +142,32 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
     name: {{ template "bk-cmdb.fullname" . }}-mongodb-certs
 {{- end }}
 {{- end -}}
+
+{{- define  "cmdb.configAndServiceCenter.certVolumeMount" -}}
+{{- if or .Values.zookeeperCert.cert .Values.zookeeperCert.key .Values.zookeeperCert.ca }}
+- name: zookeeper-certs
+  mountPath: {{ .Values.certPath }}/zookeeper
+{{- end }}
+{{- end -}}
+
+{{- define  "cmdb.configAndServiceCenter.certVolume" -}}
+{{- if or .Values.zookeeperCert.cert .Values.zookeeperCert.key .Values.zookeeperCert.ca }}
+- name: zookeeper-certs
+  configMap:
+    name: {{ template "bk-cmdb.fullname" $ }}-zookeeper-certs
+{{- end }}
+{{- end }}
+
+{{- define "cmdb.configAndServiceCenter.certCommand" -}}
+{{- if .Values.zookeeperCert.ca }}
+- --regdiscv-cafile={{ .Values.certPath }}/{{ .Values.configAndServiceCenter.tls.caFile }}
+- --regdiscv-skipverify={{ .Values.configAndServiceCenter.tls.insecureSkipVerify }}
+{{- end }}
+{{- if and .Values.zookeeperCert.cert .Values.zookeeperCert.key }}
+- --regdiscv-certfile={{ .Values.certPath }}/{{ .Values.configAndServiceCenter.tls.certFile }}
+- --regdiscv-keyfile={{ .Values.certPath }}/{{ .Values.configAndServiceCenter.tls.keyFile }}
+{{- end }}
+{{- if .Values.configAndServiceCenter.tls.password }}
+- --regdiscv-certpassword={{ .Values.certPath }}/{{ .Values.configAndServiceCenter.tls.password }}
+{{- end }}
+{{- end -}}

--- a/docs/support-file/helm/web/templates/webserver/webserver-dpl.yaml
+++ b/docs/support-file/helm/web/templates/webserver/webserver-dpl.yaml
@@ -49,6 +49,7 @@ spec:
         - --regdiscv={{ .Values.configAndServiceCenter.addr }}
         - --v={{ .Values.webserver.command.logLevel }}
         - --logtostderr={{ .Values.webserver.command.logToStdErr }}
+        {{ include "cmdb.configAndServiceCenter.certCommand" . | nindent 8 }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -94,6 +95,7 @@ spec:
             mountPath: {{ .Values.certPath}}/redis
           {{- end }}
           {{- include "cmdb.mongodb.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.configAndServiceCenter.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.webserver.configDir }}
         - name: configures
@@ -106,6 +108,7 @@ spec:
             name: "{{ template "bk-cmdb.fullname" $ }}-web-redis-certs"
         {{- end }}
         {{- include "cmdb.mongodb.certVolume" . | nindent 8 }}
+        {{- include "cmdb.configAndServiceCenter.certVolume" . | nindent 8 }}
 
       {{- with .Values.webserver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/web/templates/webserver/webserver-zookeeper-cert-configmap.yaml
+++ b/docs/support-file/helm/web/templates/webserver/webserver-zookeeper-cert-configmap.yaml
@@ -1,0 +1,16 @@
+{{- if or .Values.zookeeperCert.cert .Values.zookeeperCert.key .Values.zookeeperCert.ca -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "bk-cmdb.fullname" $ }}-zookeeper-certs
+data:
+  {{- if .Values.zookeeperCert.ca }}
+  zk.ca: {{ .Values.zookeeperCert.ca | b64dec | quote }}
+  {{- end }}
+  {{- if .Values.zookeeperCert.cert }}
+  zk.cert: {{ .Values.zookeeperCert.ca | b64dec | quote }}
+  {{- end }}
+  {{- if .Values.zookeeperCert.key }}
+  zk.key: {{ .Values.zookeeperCert.ca | b64dec | quote }}
+  {{- end }}
+{{- end -}}

--- a/docs/support-file/helm/web/values.yaml
+++ b/docs/support-file/helm/web/values.yaml
@@ -385,6 +385,12 @@ web:
 ##
 configAndServiceCenter:
   addr:
+  tls:
+    insecureSkipVerify: true
+    caFile: "zookeeper/zk.ca"
+    certFile: "zookeeper/zk.cert"
+    keyFile: "zookeeper/zk.key"
+    password:
 
 ## @section mongodbCert parameters
 ##
@@ -603,3 +609,8 @@ bkLogConfig:
   std:
     enabled: false
     dataId: 1
+
+zookeeperCert:
+  ca: ""
+  cert: ""
+  key: ""

--- a/scripts/init.py
+++ b/scripts/init.py
@@ -20,7 +20,8 @@ def mkdir_p(path):
         else: raise
 
 def generate_config_file(
-        rd_server_v, db_name_v, redis_ip_v, redis_port_v,
+        rd_server_v, rd_cafile_v, rd_certfile_v, rd_keyfile_v, rd_skipverify_v, rd_certpassword_v,
+        db_name_v, redis_ip_v, redis_port_v,
         redis_pass_v, sentinel_pass_v, redis_certfile_v, redis_keyfile_v, redis_cafile_v, redis_skipverify_v,
         mongo_ip_v, mongo_port_v, mongo_user_v, mongo_pass_v, mongo_certfile_v, mongo_keyfile_v, mongo_cafile_v, mongo_skipverify_v, rs_name, user_info,
         cc_url_v, paas_url_v, full_text_search, es_url_v, es_user_v, es_pass_v,es_shard_num_v,es_replica_num_v, auth_address, auth_app_code,
@@ -57,6 +58,11 @@ def generate_config_file(
         agent_url=paas_url_v,
         configures_dir=output,
         rd_server=rd_server_v,
+        rd_cafile=rd_cafile_v,
+        rd_certfile=rd_certfile_v,
+        rd_keyfile=rd_keyfile_v,
+        rd_skipverify=rd_skipverify_v,
+        rd_certpassword=rd_certpassword_v,
         auth_address=auth_address,
         auth_app_code=auth_app_code,
         auth_app_secret=auth_app_secret,
@@ -801,11 +807,35 @@ configServer:
   addrs: $rd_server
   usr:
   pwd:
+  # ZooKeeper tls配置信息
+  tls:
+    # CA证书文件路径
+    caFile: "$rd_cafile"
+    # 证书文件路径
+    certFile: "$rd_certfile"
+    # 密钥文件路径
+    keyFile: "$rd_keyfile"
+    # 是否跳过证书验证
+    insecureSkipVerify: $rd_skipverify
+    # 证书密码
+    password: $rd_certpassword
 # 注册中心
 registerServer:
   addrs: $rd_server
   usr:
   pwd:
+  # ZooKeeper tls配置信息
+  tls:
+    # CA证书文件路径
+    caFile: "$rd_cafile"
+    # 证书文件路径
+    certFile: "$rd_certfile"
+    # 密钥文件路径
+    keyFile: "$rd_keyfile"
+    # 是否跳过证书验证
+    insecureSkipVerify: $rd_skipverify
+    # 证书密码
+    password: $rd_certpassword
 # 指定configures的路径，通过这个路径找到其他的配置文件
 confs:
   dir: $configures_dir
@@ -829,7 +859,7 @@ dataid:
     with open(output + "migrate.yaml", 'w') as tmp_file:
         tmp_file.write(result)
 
-def update_start_script(rd_server, server_ports, enable_auth, log_level, register_ip, enable_cryptor):
+def update_start_script(rd_server, server_ports, enable_auth, log_level, register_ip, enable_cryptor, rd_cafile, rd_certfile, rd_keyfile, rd_skipverify, rd_certpassword):
     list_dirs = os.walk(os.getcwd()+"/")
     for root, dirs, _ in list_dirs:
         for d in dirs:
@@ -867,6 +897,19 @@ def update_start_script(rd_server, server_ports, enable_auth, log_level, registe
                      extend_flag += ' --enable_cryptor=%s ' % enable_cryptor
                 if register_ip != '':
                     extend_flag += ' --register-ip=%s ' % register_ip
+
+                if d != "cmdb_adminserver":
+                    if rd_cafile != '':
+                        extend_flag += ' --regdiscv-cafile=%s ' % rd_cafile
+                    if rd_certfile != '':
+                        extend_flag += ' --regdiscv-certfile=%s ' % rd_certfile
+                    if rd_keyfile != '':
+                        extend_flag += ' --regdiscv-keyfile=%s ' % rd_keyfile
+                    if rd_skipverify != '':
+                        extend_flag += ' --regdiscv-skipverify=%s ' % rd_skipverify
+                    if rd_certpassword != '':
+                        extend_flag += " --regdiscv-certpassword=%s " % rd_certpassword
+
                 filedata = filedata.replace('extend_flag_placeholder', extend_flag)
 
                 filedata = filedata.replace('log_level_placeholder', log_level)
@@ -923,6 +966,11 @@ def main(argv):
     secrets_token = ''
     secrets_project = ''
     secrets_env = ''
+    rd_cafile = ''
+    rd_certfile = ''
+    rd_keyfile = ''
+    rd_skipverify = 'true'
+    rd_certpassword = ''
 
     server_ports = {
         "cmdb_adminserver": 60004,
@@ -951,93 +999,104 @@ def main(argv):
         "blueking_paas_url=", "listen_port=", "es_url=", "es_user=", "es_pass=", "es_shard_num=","es_replica_num=","auth_address=",
         "auth_app_code=", "auth_app_secret=", "auth_enabled=",
         "auth_scheme=", "auth_sync_workers=", "auth_sync_interval_minutes=", "full_text_search=", "log_level=", "register_ip=",
-        "enable_cryptor=", "secret_key_url=", "secrets_addrs=", "secrets_token=", "secrets_project=", "secrets_env="
+        "enable_cryptor=", "secret_key_url=", "secrets_addrs=", "secrets_token=", "secrets_project=", "secrets_env=",
+        "discovery_cafile=", "discovery_certfile=", "discovery_keyfile=", "discovery_skipverify=", "discovery_certpassword="
     ]
     usage = '''
     usage:
-      --discovery          <discovery>            the ZooKeeper server address, eg:127.0.0.1:2181
-      --database           <database>             the database name, default cmdb
-      --redis_ip           <redis_ip>             the redis ip, eg:127.0.0.1
-      --redis_port         <redis_port>           the redis port, default:6379
-      --redis_pass         <redis_pass>           the redis user password
-      --sentinel_pass      <sentinel_pass>        the redis sentinel password
-      --redis_certfile     <redis_certfile>       the redis cert file path
-      --redis_keyfile      <redis_keyfile>        the redis key file path
-      --redis_cafile       <redis_cafile>         the redis ca cert file path
-      --redis_skipverify   <redis_skipverify>     the redis skip verify
-      --mongo_ip           <mongo_ip>             the mongo ip ,eg:127.0.0.1
-      --mongo_port         <mongo_port>           the mongo port, eg:27017
-      --mongo_user         <mongo_user>           the mongo user name, default:cc
-      --mongo_pass         <mongo_pass>           the mongo password
-      --mongo_certfile     <mongo_certfile>       the mongo cert file path
-      --mongo_keyfile      <mongo_keyfile>        the mongo key file path
-      --mongo_cafile       <mongo_cafile>         the mongo ca cert file path
-      --mongo_skipverify   <mongo_skipverify>     the mongo skip verify
-      --rs_name            <rs_name>              the mongo replica set name, default: rs0
-      --blueking_cmdb_url  <blueking_cmdb_url>    the cmdb site url, eg: http://127.0.0.1:8088 or http://bk.tencent.com
-      --blueking_paas_url  <blueking_paas_url>    the blueking paas url, eg: http://127.0.0.1:8088 or http://bk.tencent.com
-      --listen_port        <listen_port>          the cmdb_webserver listen port, should be the port as same as -c <blueking_cmdb_url> specified, default:8083
-      --auth_scheme        <auth_scheme>          auth scheme, ex: internal, iam
-      --auth_enabled       <auth_enabled>         iam auth enabled, true or false
-      --auth_address       <auth_address>         iam address
-      --auth_app_code      <auth_app_code>        app code for iam, default bk_cmdb
-      --auth_app_secret    <auth_app_secret>      app code for iam
-      --full_text_search   <full_text_search>     full text search on or off
-      --es_url             <es_url>               the es listen url, see in es dir config/elasticsearch.yml, (network.host, http.port), default: http://127.0.0.1:9200
-      --es_user            <es_user>              the es user name
-      --es_pass            <es_pass>              the es password
-      --es_shard_num       <es_shard_num>         the es sharding num
-      --es_replica_num     <es_replica_num>       the es es_replica_num
-      --log_level          <log_level>            log level to start cmdb process, default: 3
-      --register_ip        <register_ip>          the ip address registered on zookeeper, it can be domain
-      --user_info          <user_info>            the system user info, user and password are combined by semicolon, multiple users are separated by comma. eg: user1:password1,user2:password2
-      --enable_cryptor     <enable_cryptor>       enable cryptor,true or false, default is false
-      --secret_key_url     <secret_key_url>       the url to get secret_key which used to encrypt and decrypt cloud account
-      --secrets_addrs      <secrets_addrs>        secrets_addrs, the addrs of bk-secrets service, start with http:// or https://
-      --secrets_token      <secrets_token>        secrets_token , as a header param for sending the api request to bk-secrets service
-      --secrets_project    <secrets_project>      secrets_project, as a header param for sending the api request to bk-secrets service
-      --secrets_env        <secrets_env>          secrets_env, as a header param for sending the api request to bk-secrets service
+      --discovery               <discovery>               the ZooKeeper server address, eg:127.0.0.1:2181
+      --database                <database>                the database name, default cmdb
+      --redis_ip                <redis_ip>                the redis ip, eg:127.0.0.1
+      --redis_port              <redis_port>              the redis port, default:6379
+      --redis_pass              <redis_pass>              the redis user password
+      --sentinel_pass           <sentinel_pass>           the redis sentinel password
+      --redis_certfile          <redis_certfile>          the redis cert file path
+      --redis_keyfile           <redis_keyfile>           the redis key file path
+      --redis_cafile            <redis_cafile>            the redis ca cert file path
+      --redis_skipverify        <redis_skipverify>        the redis skip verify
+      --mongo_ip                <mongo_ip>                the mongo ip ,eg:127.0.0.1
+      --mongo_port              <mongo_port>              the mongo port, eg:27017
+      --mongo_user              <mongo_user>              the mongo user name, default:cc
+      --mongo_pass              <mongo_pass>              the mongo password
+      --mongo_certfile          <mongo_certfile>          the mongo cert file path
+      --mongo_keyfile           <mongo_keyfile>           the mongo key file path
+      --mongo_cafile            <mongo_cafile>            the mongo ca cert file path
+      --mongo_skipverify        <mongo_skipverify>        the mongo skip verify
+      --rs_name                 <rs_name>                 the mongo replica set name, default: rs0
+      --blueking_cmdb_url       <blueking_cmdb_url>       the cmdb site url, eg: http://127.0.0.1:8088 or http://bk.tencent.com
+      --blueking_paas_url       <blueking_paas_url>       the blueking paas url, eg: http://127.0.0.1:8088 or http://bk.tencent.com
+      --listen_port             <listen_port>             the cmdb_webserver listen port, should be the port as same as -c <blueking_cmdb_url> specified, default:8083
+      --auth_scheme             <auth_scheme>             auth scheme, ex: internal, iam
+      --auth_enabled            <auth_enabled>            iam auth enabled, true or false
+      --auth_address            <auth_address>            iam address
+      --auth_app_code           <auth_app_code>           app code for iam, default bk_cmdb
+      --auth_app_secret         <auth_app_secret>         app code for iam
+      --full_text_search        <full_text_search>        full text search on or off
+      --es_url                  <es_url>                  the es listen url, see in es dir config/elasticsearch.yml, (network.host, http.port), default: http://127.0.0.1:9200
+      --es_user                 <es_user>                 the es user name
+      --es_pass                 <es_pass>                 the es password
+      --es_shard_num            <es_shard_num>            the es sharding num
+      --es_replica_num          <es_replica_num>          the es es_replica_num
+      --log_level               <log_level>               log level to start cmdb process, default: 3
+      --register_ip             <register_ip>             the ip address registered on zookeeper, it can be domain
+      --user_info               <user_info>               the system user info, user and password are combined by semicolon, multiple users are separated by comma. eg: user1:password1,user2:password2
+      --enable_cryptor          <enable_cryptor>          enable cryptor,true or false, default is false
+      --secret_key_url          <secret_key_url>          the url to get secret_key which used to encrypt and decrypt cloud account
+      --secrets_addrs           <secrets_addrs>           secrets_addrs, the addrs of bk-secrets service, start with http:// or https://
+      --secrets_token           <secrets_token>           secrets_token , as a header param for sending the api request to bk-secrets service
+      --secrets_project         <secrets_project>         secrets_project, as a header param for sending the api request to bk-secrets service
+      --secrets_env             <secrets_env>             secrets_env, as a header param for sending the api request to bk-secrets service
+      --discovery_cafile        <discovery_cafile>        CA file for ZooKeeper TLS connection
+      --discovery_certfile      <discovery_certfile>      cert file for ZooKeeper TLS connection
+      --discovery_keyfile       <discovery_keyfile>       key file for ZooKeeper TLS connection
+      --discovery_skipverify    <discovery_skipverify>    whether to skip verify ZooKeeper TLS connection, true or false, default true
+      --discovery_certpassword  <discovery_certpassword>  password for ZooKeeper TLS connection
 
     demo:
     python init.py  \\
-      --discovery          127.0.0.1:2181 \\
-      --database           cmdb \\
-      --redis_ip           127.0.0.1 \\
-      --redis_port         6379 \\
-      --redis_pass         1111 \\
-      --sentinel_pass      2222 \\
-      --redis_certfile     ./redis.cert \\
-      --redis_keyfile      ./redis.key \\
-      --redis_cafile       ./redis-ca.crt \\
-      --redis_skipverify   true \\
-      --mongo_ip           127.0.0.1 \\
-      --mongo_port         27017 \\
-      --mongo_user         cc \\
-      --mongo_pass         cc \\
-      --mongo_certfile     ./mongo.cert \\
-      --mongo_keyfile      ./mongo.key \\
-      --mongo_cafile       ./mongo-ca.crt \\
-      --mongo_skipverify   true \\
-      --rs_name            rs0 \\
-      --blueking_cmdb_url  http://127.0.0.1:8080/ \\
-      --blueking_paas_url  http://paas.domain.com \\
-      --listen_port        8080 \\
-      --auth_scheme        internal \\
-      --auth_enabled       false \\
-      --auth_address       https://iam.domain.com/ \\
-      --auth_app_code      bk_cmdb \\
-      --auth_app_secret    xxxxxxx \\
-      --auth_sync_workers  1 \\
-      --auth_sync_interval_minutes  45 \\
-      --full_text_search   off \\
-      --es_url             http://127.0.0.1:9200 \\
-      --es_user            cc \\
-      --es_pass            cc \\
-      --es_shard_num       1 \\
-      --es_replica_num     1 \\
-      --log_level          3 \\
-      --register_ip        cmdb.domain.com \\
-      --user_info          user1:password1,user2:password2
+      --discovery               127.0.0.1:2181 \\
+      --discovery_cafile        ./zk-ca.crt \\
+      --discovery_certfile      ./zk.cert \\
+      --discovery_keyfile       ./zk.key \\
+      --discovery_skipverify    true \\
+      --discovery_certpassword  password \\
+      --database                cmdb \\
+      --redis_ip                127.0.0.1 \\
+      --redis_port              6379 \\
+      --redis_pass              1111 \\
+      --sentinel_pass           2222 \\
+      --redis_certfile          ./redis.cert \\
+      --redis_keyfile           ./redis.key \\
+      --redis_cafile            ./redis-ca.crt \\
+      --redis_skipverify        true \\
+      --mongo_ip                127.0.0.1 \\
+      --mongo_port              27017 \\
+      --mongo_user              cc \\
+      --mongo_pass              cc \\
+      --mongo_certfile          ./mongo.cert \\
+      --mongo_keyfile           ./mongo.key \\
+      --mongo_cafile            ./mongo-ca.crt \\
+      --mongo_skipverify        true \\
+      --rs_name                 rs0 \\
+      --blueking_cmdb_url       http://127.0.0.1:8080/ \\
+      --blueking_paas_url       http://paas.domain.com \\
+      --listen_port             8080 \\
+      --auth_scheme             internal \\
+      --auth_enabled            false \\
+      --auth_address            https://iam.domain.com/ \\
+      --auth_app_code           bk_cmdb \\
+      --auth_app_secret         xxxxxxx \\
+      --auth_sync_workers       1 \\
+      --auth_sync_interval_     minutes  45 \\
+      --full_text_search        off \\
+      --es_url                  http://127.0.0.1:9200 \\
+      --es_user                 cc \\
+      --es_pass                 cc \\
+      --es_shard_num            1 \\
+      --es_replica_num          1 \\
+      --log_level               3 \\
+      --register_ip             cmdb.domain.com \\
+      --user_info               user1:password1,user2:password2
     '''
     try:
         opts, _ = getopt.getopt(argv, "hd:D:r:p:x:s:m:P:X:S:u:U:a:l:es:v", arr)
@@ -1058,6 +1117,21 @@ def main(argv):
         elif opt in ("-d", "--discovery"):
             rd_server = arg
             print('rd_server:', rd_server)
+        elif opt in("--discovery_cafile",):
+            rd_cafile = arg
+            print('rd_cafile:', rd_cafile)
+        elif opt in("--discovery_certfile",):
+            rd_certfile = arg
+            print('rd_certfile:', rd_certfile)
+        elif opt in("--discovery_keyfile",):
+            rd_keyfile = arg
+            print('rd_keyfile:', rd_keyfile)
+        elif opt in("--discovery_skipverify",):
+            rd_skipverify = arg
+            print('rd_skipverify:', rd_skipverify)
+        elif opt in("--discovery_certpassword"):
+            rd_certpassword = arg
+            print('rd_certpassword:', rd_certpassword)
         elif opt in ("-D", "--database"):
             db_name = arg
             print('database:', db_name)
@@ -1301,9 +1375,15 @@ def main(argv):
         secrets_token_v = secrets_token,
         secrets_project_v = secrets_project,
         secrets_env_v = secrets_env,
+        rd_cafile_v=rd_cafile,
+        rd_certfile_v=rd_certfile,
+        rd_keyfile_v=rd_keyfile,
+        rd_skipverify_v=rd_skipverify,
+        rd_certpassword_v=rd_certpassword,
         **auth
     )
-    update_start_script(rd_server, server_ports, auth['auth_enabled'], log_level, register_ip, enable_cryptor)
+    update_start_script(rd_server, server_ports, auth['auth_enabled'], log_level, register_ip, enable_cryptor, 
+                       rd_cafile, rd_certfile, rd_keyfile, rd_skipverify, rd_certpassword)
     print('initial configurations success, configs could be found at cmdb_adminserver/configures')
     print('initial monstache config success, configs could be found at monstache/etc')
 

--- a/src/apiserver/app/server.go
+++ b/src/apiserver/app/server.go
@@ -43,7 +43,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	input := &backbone.BackboneParameter{
 		ConfigUpdate: apiSvr.onApiServerConfigUpdate,
 		ConfigPath:   op.ServConf.ExConfig,
-		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover},
+		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover, TLSConfig: op.ServConf.GetTLSClientConf()},
 		SrvInfo:      svrInfo,
 	}
 

--- a/src/common/backbone/backbone.go
+++ b/src/common/backbone/backbone.go
@@ -57,10 +57,11 @@ type BackboneParameter struct {
 	SrvRegdiscv
 }
 
-func newSvcManagerClient(ctx context.Context, svcManagerAddr string) (*zk.ZkClient, error) {
+func newSvcManagerClient(ctx context.Context, svcManagerAddr string,
+	tlsConfig *ssl.TLSClientConfig) (*zk.ZkClient, error) {
 	var err error
 	for retry := 0; retry < maxRetry; retry++ {
-		client := zk.NewZkClient(svcManagerAddr, 40*time.Second)
+		client := zk.NewZkClient(svcManagerAddr, 40*time.Second, tlsConfig)
 		if err = client.Start(); err != nil {
 			blog.Errorf("connect regdiscv [%s] failed: %v", svcManagerAddr, err)
 			time.Sleep(time.Second * 2)
@@ -162,7 +163,7 @@ func NewBackbone(ctx context.Context, input *BackboneParameter) (*Engine, error)
 	}
 
 	if !input.Disable {
-		client, err := newSvcManagerClient(ctx, input.Regdiscv)
+		client, err := newSvcManagerClient(ctx, input.Regdiscv, input.TLSConfig)
 		if err != nil {
 			return nil, fmt.Errorf("connect regdiscv [%s] failed: %v", input.Regdiscv, err)
 		}
@@ -289,6 +290,8 @@ type SrvRegdiscv struct {
 	Regdiscv string
 	// Disable disable service registration discovery
 	Disable bool
+	// TLS config
+	TLSConfig *ssl.TLSClientConfig
 }
 
 // Discovery return discovery

--- a/src/common/backbone/service_mange/zk/zk.go
+++ b/src/common/backbone/service_mange/zk/zk.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"configcenter/src/common/ssl"
 	"configcenter/src/common/zkclient"
 )
 
@@ -31,10 +32,10 @@ type ZkClient struct {
 }
 
 // NewZkClient create a object of ZkClient
-func NewZkClient(zkAddress string, timeOut time.Duration) *ZkClient {
+func NewZkClient(zkAddress string, timeOut time.Duration, tlsConfig *ssl.TLSClientConfig) *ZkClient {
 	zkAddresses := strings.Split(zkAddress, ",")
 	return &ZkClient{
-		zkCli:          zkclient.NewZkClient(zkAddresses),
+		zkCli:          zkclient.NewZkClient(zkAddresses, tlsConfig),
 		sessionTimeOut: timeOut,
 	}
 }

--- a/src/common/ssl/type.go
+++ b/src/common/ssl/type.go
@@ -46,7 +46,7 @@ func NewTLSConfigFromConf(cfg *TLSClientConfig) (*tls.Config, bool, error) {
 		var err error
 		if len(cfg.CertFile) != 0 && len(cfg.KeyFile) != 0 {
 			// if CertFile and KeyFile are both configured, then use mutual TLS authentication
-			tlsConf, err = ClientTLSConfVerity(cfg.CAFile, cfg.CertFile, cfg.KeyFile, "")
+			tlsConf, err = ClientTLSConfVerity(cfg.CAFile, cfg.CertFile, cfg.KeyFile, cfg.Password)
 		} else {
 			// otherwise, only CAFile is configured, use one-way TLS authentication, only verify server certificate
 			tlsConf, err = ClientTslConfVerityServer(cfg.CAFile)

--- a/src/common/zkclient/zkclient.go
+++ b/src/common/zkclient/zkclient.go
@@ -156,8 +156,6 @@ func (z *ZkClient) ConnectEx(sessionTimeOut time.Duration) error {
 	}
 
 	var c *zk.Conn
-	var err error
-
 	tlsConfig, useTLS, err := ssl.NewTLSConfigFromConf(z.zkTLS)
 	if err != nil {
 		return fmt.Errorf("failed to create TLS config: %v", err)
@@ -170,7 +168,6 @@ func (z *ZkClient) ConnectEx(sessionTimeOut time.Duration) error {
 	} else {
 		c, _, err = zk.Connect(z.ZkHost, sessionTimeOut)
 	}
-
 	if err != nil {
 		return err
 	}

--- a/src/common/zkclient/zkclient.go
+++ b/src/common/zkclient/zkclient.go
@@ -14,13 +14,17 @@
 package zkclient
 
 import (
+	"crypto/tls"
 	// "bcs/bcs-common/common/blog"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"sync"
 	"time"
+
+	"configcenter/src/common/ssl"
 
 	"github.com/go-zookeeper/zk"
 )
@@ -116,17 +120,19 @@ type ZkClient struct {
 	ZkHost       []string
 	ZkConn       *zk.Conn
 	zkAcl        []zk.ACL
+	zkTLS        *ssl.TLSClientConfig
 	zkConnClosed bool
 	sync.Mutex
 	closeLock sync.Mutex
 }
 
 // NewZkClient TODO
-func NewZkClient(host []string) *ZkClient {
+func NewZkClient(host []string, tlsConf *ssl.TLSClientConfig) *ZkClient {
 	c := ZkClient{
 		ZkHost: host[:],
 		ZkConn: nil,
 		zkAcl:  zk.DigestACL(zk.PermAll, AUTH_USER, AUTH_PWD),
+		zkTLS:  tlsConf,
 	}
 
 	return &c
@@ -149,7 +155,22 @@ func (z *ZkClient) ConnectEx(sessionTimeOut time.Duration) error {
 		z.Close()
 	}
 
-	c, _, err := zk.Connect(z.ZkHost, sessionTimeOut)
+	var c *zk.Conn
+	var err error
+
+	tlsConfig, useTLS, err := ssl.NewTLSConfigFromConf(z.zkTLS)
+	if err != nil {
+		return fmt.Errorf("failed to create TLS config: %v", err)
+	}
+	if useTLS {
+		tlsDialer := zk.WithDialer(func(network, address string, timeout time.Duration) (net.Conn, error) {
+			return tls.Dial(network, address, tlsConfig)
+		})
+		c, _, err = zk.Connect(z.ZkHost, sessionTimeOut, tlsDialer)
+	} else {
+		c, _, err = zk.Connect(z.ZkHost, sessionTimeOut)
+	}
+
 	if err != nil {
 		return err
 	}

--- a/src/common/zkclient/zkclient_test.go
+++ b/src/common/zkclient/zkclient_test.go
@@ -17,11 +17,21 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"configcenter/src/common/ssl"
+)
+
+var (
+	certFile           = ""
+	keyFile            = ""
+	caFile             = ""
+	password           = ""
+	insecureSkipVerify = true
 )
 
 func TestDataValue(t *testing.T) {
 	fmt.Println("TEST Data Value")
-	zkClient := NewZkClient([]string{"127.0.0.1:2181"})
+	zkClient := NewZkClient([]string{"127.0.0.1:2181"}, nil)
 
 	defer zkClient.Close()
 
@@ -73,7 +83,7 @@ func TestZkLock(t *testing.T) {
 func Test_WatchChildren(t *testing.T) {
 	t.Log("----- start test WatchChildren -----")
 
-	zkClient := NewZkClient([]string{"127.0.0.1:2181"})
+	zkClient := NewZkClient([]string{"127.0.0.1:2181"}, nil)
 
 	err := zkClient.Connect()
 	if err != nil {
@@ -117,4 +127,47 @@ func Test_WatchChildren(t *testing.T) {
 
 	t.Logf("----- end test WatchChildren -----")
 
+}
+
+func TestDataValueWithTLS(t *testing.T) {
+	fmt.Println("TEST Data Value With TLS")
+	zkClient := NewZkClient([]string{"127.0.0.1:2281"}, &ssl.TLSClientConfig{
+		InsecureSkipVerify: insecureSkipVerify,
+		CertFile:           certFile,
+		KeyFile:            keyFile,
+		CAFile:             caFile,
+		Password:           password,
+	})
+
+	defer zkClient.Close()
+
+	err := zkClient.Connect()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	if err = zkClient.Create("/data1", []byte("DATA")); err != nil {
+		fmt.Println(err)
+	}
+
+	result, err := zkClient.Get("/data1")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println(result)
+
+	if err = zkClient.Create("/data1/ip/act", []byte("act")); err != nil {
+		fmt.Println(err)
+	}
+
+	result, err = zkClient.Get("/data1/ip/act")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println(result)
 }

--- a/src/scene_server/admin_server/app/options/options.go
+++ b/src/scene_server/admin_server/app/options/options.go
@@ -17,6 +17,7 @@ import (
 	"configcenter/src/ac/iam"
 	"configcenter/src/common/auth"
 	"configcenter/src/common/core/cc/config"
+	"configcenter/src/common/ssl"
 	"configcenter/src/storage/dal/kafka"
 	"configcenter/src/storage/dal/mongo"
 	"configcenter/src/storage/dal/redis"
@@ -96,6 +97,7 @@ type ConfConfig struct {
 // RegisterConfig TODO
 type RegisterConfig struct {
 	Address string
+	TLS     ssl.TLSClientConfig
 }
 
 // ShardingTableConfig TODO

--- a/src/scene_server/admin_server/app/server.go
+++ b/src/scene_server/admin_server/app/server.go
@@ -24,6 +24,7 @@ import (
 	"configcenter/src/common/blog"
 	"configcenter/src/common/errors"
 	"configcenter/src/common/resource/esb"
+	"configcenter/src/common/ssl"
 	"configcenter/src/common/types"
 	"configcenter/src/scene_server/admin_server/app/options"
 	"configcenter/src/scene_server/admin_server/configures"
@@ -139,6 +140,11 @@ func parseSeverConfig(ctx context.Context, op *options.ServerOption) (*MigrateSe
 	process.Config.Language.Res, _ = cc.String("language.res")
 	process.Config.Configures.Dir, _ = cc.String("confs.dir")
 	process.Config.Register.Address, _ = cc.String("registerServer.addrs")
+	process.Config.Register.TLS.CAFile, _ = cc.String("registerServer.tls.caFile")
+	process.Config.Register.TLS.InsecureSkipVerify, _ = cc.Bool("registerServer.tls.insecureSkipVerify")
+	process.Config.Register.TLS.Password, _ = cc.String("registerServer.tls.password")
+	process.Config.Register.TLS.CertFile, _ = cc.String("registerServer.tls.certFile")
+	process.Config.Register.TLS.KeyFile, _ = cc.String("registerServer.tls.keyFile")
 	snapDataID, _ := cc.Int("hostsnap.dataID")
 	migrateWay, _ := cc.String("dataid.migrateWay")
 	process.Config.DataIdMigrateWay = options.MigrateWay(migrateWay)
@@ -205,8 +211,14 @@ func parseSeverConfig(ctx context.Context, op *options.ServerOption) (*MigrateSe
 	input := &backbone.BackboneParameter{
 		ConfigUpdate: process.onMigrateConfigUpdate,
 		ConfigPath:   op.ServConf.ExConfig,
-		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: process.Config.Register.Address},
-		SrvInfo:      svrInfo,
+		SrvRegdiscv: backbone.SrvRegdiscv{Regdiscv: process.Config.Register.Address, TLSConfig: &ssl.TLSClientConfig{
+			InsecureSkipVerify: process.Config.Register.TLS.InsecureSkipVerify,
+			CertFile:           process.Config.Register.TLS.CertFile,
+			KeyFile:            process.Config.Register.TLS.KeyFile,
+			CAFile:             process.Config.Register.TLS.CAFile,
+			Password:           process.Config.Register.TLS.Password,
+		}},
+		SrvInfo: svrInfo,
 	}
 	engine, err := backbone.NewBackbone(ctx, input)
 	if err != nil {

--- a/src/scene_server/admin_server/app/server.go
+++ b/src/scene_server/admin_server/app/server.go
@@ -24,7 +24,6 @@ import (
 	"configcenter/src/common/blog"
 	"configcenter/src/common/errors"
 	"configcenter/src/common/resource/esb"
-	"configcenter/src/common/ssl"
 	"configcenter/src/common/types"
 	"configcenter/src/scene_server/admin_server/app/options"
 	"configcenter/src/scene_server/admin_server/configures"
@@ -140,11 +139,7 @@ func parseSeverConfig(ctx context.Context, op *options.ServerOption) (*MigrateSe
 	process.Config.Language.Res, _ = cc.String("language.res")
 	process.Config.Configures.Dir, _ = cc.String("confs.dir")
 	process.Config.Register.Address, _ = cc.String("registerServer.addrs")
-	process.Config.Register.TLS.CAFile, _ = cc.String("registerServer.tls.caFile")
-	process.Config.Register.TLS.InsecureSkipVerify, _ = cc.Bool("registerServer.tls.insecureSkipVerify")
-	process.Config.Register.TLS.Password, _ = cc.String("registerServer.tls.password")
-	process.Config.Register.TLS.CertFile, _ = cc.String("registerServer.tls.certFile")
-	process.Config.Register.TLS.KeyFile, _ = cc.String("registerServer.tls.keyFile")
+	process.Config.Register.TLS, _ = cc.NewTLSClientConfigFromConfig("registerServer.tls")
 	snapDataID, _ := cc.Int("hostsnap.dataID")
 	migrateWay, _ := cc.String("dataid.migrateWay")
 	process.Config.DataIdMigrateWay = options.MigrateWay(migrateWay)
@@ -211,13 +206,10 @@ func parseSeverConfig(ctx context.Context, op *options.ServerOption) (*MigrateSe
 	input := &backbone.BackboneParameter{
 		ConfigUpdate: process.onMigrateConfigUpdate,
 		ConfigPath:   op.ServConf.ExConfig,
-		SrvRegdiscv: backbone.SrvRegdiscv{Regdiscv: process.Config.Register.Address, TLSConfig: &ssl.TLSClientConfig{
-			InsecureSkipVerify: process.Config.Register.TLS.InsecureSkipVerify,
-			CertFile:           process.Config.Register.TLS.CertFile,
-			KeyFile:            process.Config.Register.TLS.KeyFile,
-			CAFile:             process.Config.Register.TLS.CAFile,
-			Password:           process.Config.Register.TLS.Password,
-		}},
+		SrvRegdiscv: backbone.SrvRegdiscv{
+			Regdiscv:  process.Config.Register.Address,
+			TLSConfig: &process.Config.Register.TLS,
+		},
 		SrvInfo: svrInfo,
 	}
 	engine, err := backbone.NewBackbone(ctx, input)

--- a/src/scene_server/auth_server/app/server.go
+++ b/src/scene_server/auth_server/app/server.go
@@ -45,7 +45,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	input := &backbone.BackboneParameter{
 		ConfigUpdate: authServer.onAuthConfigUpdate,
 		ConfigPath:   op.ServConf.ExConfig,
-		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover},
+		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover, TLSConfig: op.ServConf.GetTLSClientConf()},
 		SrvInfo:      svrInfo,
 	}
 	engine, err := backbone.NewBackbone(ctx, input)

--- a/src/scene_server/cloud_server/app/server.go
+++ b/src/scene_server/cloud_server/app/server.go
@@ -47,7 +47,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	input := &backbone.BackboneParameter{
 		ConfigUpdate: process.onCloudConfigUpdate,
 		ConfigPath:   op.ServConf.ExConfig,
-		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover},
+		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover, TLSConfig: op.ServConf.GetTLSClientConf()},
 		SrvInfo:      svrInfo,
 	}
 	engine, err := backbone.NewBackbone(ctx, input)

--- a/src/scene_server/datacollection/app/server.go
+++ b/src/scene_server/datacollection/app/server.go
@@ -171,7 +171,7 @@ func NewDataCollection(ctx context.Context, op *options.ServerOption) (*DataColl
 	engine, err := backbone.NewBackbone(ctx, &backbone.BackboneParameter{
 		ConfigUpdate: newDataCollection.OnHostConfigUpdate,
 		ConfigPath:   op.ServConf.ExConfig,
-		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover},
+		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover, TLSConfig: op.ServConf.GetTLSClientConf()},
 		SrvInfo:      svrInfo,
 	})
 	if err != nil {

--- a/src/scene_server/event_server/app/server.go
+++ b/src/scene_server/event_server/app/server.go
@@ -86,7 +86,7 @@ func NewEventServer(ctx context.Context, op *options.ServerOption) (*EventServer
 	engine, err := backbone.NewBackbone(ctx, &backbone.BackboneParameter{
 		ConfigUpdate: newEventServer.OnHostConfigUpdate,
 		ConfigPath:   op.ServConf.ExConfig,
-		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover},
+		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover, TLSConfig: op.ServConf.GetTLSClientConf()},
 		SrvInfo:      svrInfo,
 	})
 	if err != nil {

--- a/src/scene_server/host_server/app/server.go
+++ b/src/scene_server/host_server/app/server.go
@@ -46,7 +46,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	hostSrv := new(HostServer)
 
 	input := &backbone.BackboneParameter{
-		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover},
+		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover, TLSConfig: op.ServConf.GetTLSClientConf()},
 		ConfigPath:   op.ServConf.ExConfig,
 		ConfigUpdate: hostSrv.onHostConfigUpdate,
 		SrvInfo:      svrInfo,

--- a/src/scene_server/operation_server/app/server.go
+++ b/src/scene_server/operation_server/app/server.go
@@ -41,7 +41,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	input := &backbone.BackboneParameter{
 		ConfigUpdate: operationSvr.OnOperationConfigUpdate,
 		ConfigPath:   op.ServConf.ExConfig,
-		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover},
+		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover, TLSConfig: op.ServConf.GetTLSClientConf()},
 		SrvInfo:      svrInfo,
 	}
 	engine, err := backbone.NewBackbone(ctx, input)

--- a/src/scene_server/proc_server/app/server.go
+++ b/src/scene_server/proc_server/app/server.go
@@ -43,7 +43,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	input := &backbone.BackboneParameter{
 		ConfigUpdate: procSvr.OnProcessConfigUpdate,
 		ConfigPath:   op.ServConf.ExConfig,
-		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover},
+		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover, TLSConfig: op.ServConf.GetTLSClientConf()},
 		SrvInfo:      svrInfo,
 	}
 	engine, err := backbone.NewBackbone(ctx, input)

--- a/src/scene_server/synchronize_server/app/server.go
+++ b/src/scene_server/synchronize_server/app/server.go
@@ -42,7 +42,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 		synchronizeClientConfig: make(chan synchronizeUtil.SychronizeConfig, 10),
 	}
 	input := &backbone.BackboneParameter{
-		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover},
+		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover, TLSConfig: op.ServConf.GetTLSClientConf()},
 		ConfigPath:   op.ServConf.ExConfig,
 		ConfigUpdate: synchronSrv.onSynchronizeServerConfigUpdate,
 		SrvInfo:      svrInfo,

--- a/src/scene_server/task_server/app/server.go
+++ b/src/scene_server/task_server/app/server.go
@@ -43,7 +43,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	taskSrv := new(TaskServer)
 
 	input := &backbone.BackboneParameter{
-		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover},
+		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover, TLSConfig: op.ServConf.GetTLSClientConf()},
 		ConfigPath:   op.ServConf.ExConfig,
 		ConfigUpdate: taskSrv.onHostConfigUpdate,
 		SrvInfo:      svrInfo,

--- a/src/scene_server/topo_server/app/server.go
+++ b/src/scene_server/topo_server/app/server.go
@@ -68,7 +68,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	server.Service = new(service.Service)
 
 	input := &backbone.BackboneParameter{
-		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover},
+		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover, TLSConfig: op.ServConf.GetTLSClientConf()},
 		ConfigPath:   op.ServConf.ExConfig,
 		ConfigUpdate: server.onTopoConfigUpdate,
 		SrvInfo:      svrInfo,

--- a/src/source_controller/cacheservice/app/server.go
+++ b/src/source_controller/cacheservice/app/server.go
@@ -59,7 +59,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	input := &backbone.BackboneParameter{
 		ConfigUpdate: cacheSvr.onCacheServiceConfigUpdate,
 		ConfigPath:   op.ServConf.ExConfig,
-		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover},
+		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover, TLSConfig: op.ServConf.GetTLSClientConf()},
 		SrvInfo:      svrInfo,
 	}
 

--- a/src/source_controller/coreservice/app/server.go
+++ b/src/source_controller/coreservice/app/server.go
@@ -59,7 +59,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	input := &backbone.BackboneParameter{
 		ConfigUpdate: coreSvr.onCoreServiceConfigUpdate,
 		ConfigPath:   op.ServConf.ExConfig,
-		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover},
+		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover, TLSConfig: op.ServConf.GetTLSClientConf()},
 		SrvInfo:      svrInfo,
 	}
 

--- a/src/source_controller/transfer-service/app/server.go
+++ b/src/source_controller/transfer-service/app/server.go
@@ -65,7 +65,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	input := &backbone.BackboneParameter{
 		ConfigUpdate: svr.onConfigUpdate,
 		ConfigPath:   op.ServConf.ExConfig,
-		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover},
+		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover, TLSConfig: op.ServConf.GetTLSClientConf()},
 		SrvInfo:      svrInfo,
 	}
 

--- a/src/test/test.go
+++ b/src/test/test.go
@@ -79,7 +79,7 @@ func init() {
 	fmt.Println("before suit")
 	js, _ := json.MarshalIndent(tConfig, "", "    ")
 	fmt.Printf("test config: %s\n", run.SetRed(string(js)))
-	client := zk.NewZkClient(tConfig.ZkAddr, 40*time.Second)
+	client := zk.NewZkClient(tConfig.ZkAddr, 40*time.Second, nil)
 	var err error
 	mongoConfig := local.MongoConf{
 		MaxOpenConns: mongo.DefaultMaxOpenConns,

--- a/src/tools/cmdb_ctl/cmd/auth.go
+++ b/src/tools/cmdb_ctl/cmd/auth.go
@@ -101,7 +101,7 @@ func newAuthService(c *authConf) (*authService, error) {
 		return nil, errors.New("resource must be set via resource flag or resource file specified by rsc-file flag")
 	}
 
-	client := zk.NewZkClient(config.Conf.ZkAddr, 40*time.Second)
+	client := zk.NewZkClient(config.Conf.ZkAddr, 40*time.Second, &config.Conf.ZkTLS)
 	if err := client.Start(); err != nil {
 		return nil, fmt.Errorf("connect regdiscv [%s] failed: %v", config.Conf.ZkAddr, err)
 	}

--- a/src/tools/cmdb_ctl/cmd/limiter.go
+++ b/src/tools/cmdb_ctl/cmd/limiter.go
@@ -149,7 +149,7 @@ func runSetRule(c *limiterConf) error {
 		return err
 	}
 
-	zk, err := config.NewZkService(config.Conf.ZkAddr)
+	zk, err := config.NewZkService(config.Conf.ZkAddr, &config.Conf.ZkTLS)
 	if err != nil {
 		return err
 	}
@@ -186,7 +186,7 @@ func runGetRules(c *limiterConf) error {
 	if c.rulenames == "" {
 		return fmt.Errorf("rulenames must be set")
 	}
-	zk, err := config.NewZkService(config.Conf.ZkAddr)
+	zk, err := config.NewZkService(config.Conf.ZkAddr, &config.Conf.ZkTLS)
 	if err != nil {
 		return err
 	}
@@ -213,7 +213,7 @@ func runDelRules(c *limiterConf) error {
 	if c.rulenames == "" {
 		return fmt.Errorf("rulenames must be set")
 	}
-	zk, err := config.NewZkService(config.Conf.ZkAddr)
+	zk, err := config.NewZkService(config.Conf.ZkAddr, &config.Conf.ZkTLS)
 	if err != nil {
 		return err
 	}
@@ -231,7 +231,7 @@ func runDelRules(c *limiterConf) error {
 }
 
 func runListRules(c *limiterConf) error {
-	zk, err := config.NewZkService(config.Conf.ZkAddr)
+	zk, err := config.NewZkService(config.Conf.ZkAddr, &config.Conf.ZkTLS)
 	if err != nil {
 		return err
 	}

--- a/src/tools/cmdb_ctl/cmd/log.go
+++ b/src/tools/cmdb_ctl/cmd/log.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 
+	"configcenter/src/common/ssl"
 	"configcenter/src/common/types"
 	"configcenter/src/tools/cmdb_ctl/app/config"
 
@@ -64,11 +65,11 @@ type logService struct {
 	addrport []string
 }
 
-func newLogService(zkaddr string, addrport string) (*logService, error) {
+func newLogService(zkaddr string, zkTLS *ssl.TLSClientConfig, addrport string) (*logService, error) {
 	if addrport == "" {
 		return nil, errors.New("addrport must set via flag or environment variable")
 	}
-	service, err := config.NewZkService(zkaddr)
+	service, err := config.NewZkService(zkaddr, zkTLS)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +87,7 @@ func runLog(c *logConf) error {
 		return fmt.Errorf("can't set log level to v and default at the same time")
 	}
 
-	srv, err := newLogService(config.Conf.ZkAddr, c.addrPort)
+	srv, err := newLogService(config.Conf.ZkAddr, &config.Conf.ZkTLS, c.addrPort)
 	if err != nil {
 		return err
 	}

--- a/src/tools/cmdb_ctl/cmd/snapshot.go
+++ b/src/tools/cmdb_ctl/cmd/snapshot.go
@@ -20,6 +20,7 @@ import (
 
 	"configcenter/src/common"
 	cc "configcenter/src/common/backbone/configcenter"
+	"configcenter/src/common/ssl"
 	"configcenter/src/common/types"
 	ccRedis "configcenter/src/storage/dal/redis"
 	"configcenter/src/tools/cmdb_ctl/app/config"
@@ -63,8 +64,8 @@ type snapshotCheckService struct {
 	config  map[string]string
 }
 
-func newSnapshotCheckService(zkaddr string, bizID int) (*snapshotCheckService, error) {
-	service, err := config.NewZkService(zkaddr)
+func newSnapshotCheckService(zkaddr string, tlsConfig *ssl.TLSClientConfig, bizID int) (*snapshotCheckService, error) {
+	service, err := config.NewZkService(zkaddr, tlsConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +76,7 @@ func newSnapshotCheckService(zkaddr string, bizID int) (*snapshotCheckService, e
 }
 
 func runSnapshotCheck(c *snapshotCheckConf) error {
-	srv, err := newSnapshotCheckService(config.Conf.ZkAddr, c.bizID)
+	srv, err := newSnapshotCheckService(config.Conf.ZkAddr, &config.Conf.ZkTLS, c.bizID)
 	if err != nil {
 		return err
 	}

--- a/src/tools/cmdb_ctl/cmd/watch.go
+++ b/src/tools/cmdb_ctl/cmd/watch.go
@@ -109,7 +109,7 @@ func runDecodeCursor(c *watchConf) error {
 }
 
 func runStartFromWatch(c *watchConf) error {
-	zk, err := config.NewZkService(config.Conf.ZkAddr)
+	zk, err := config.NewZkService(config.Conf.ZkAddr, &config.Conf.ZkTLS)
 	if err != nil {
 		fmt.Printf("new zk client failed, err: %v\n", err)
 		return err

--- a/src/tools/cmdb_ctl/cmd/zk.go
+++ b/src/tools/cmdb_ctl/cmd/zk.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 
+	"configcenter/src/common/ssl"
 	"configcenter/src/tools/cmdb_ctl/app/config"
 
 	"github.com/spf13/cobra"
@@ -99,11 +100,11 @@ type zkService struct {
 	path    string
 }
 
-func newZkService(zkaddr string, path string) (*zkService, error) {
+func newZkService(zkaddr string, tlsConfig *ssl.TLSClientConfig, path string) (*zkService, error) {
 	if path == "" {
 		return nil, errors.New("zk-path must be set")
 	}
-	service, err := config.NewZkService(zkaddr)
+	service, err := config.NewZkService(zkaddr, tlsConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +115,7 @@ func newZkService(zkaddr string, path string) (*zkService, error) {
 }
 
 func runZkLsCmd(c *zkConf) error {
-	srv, err := newZkService(config.Conf.ZkAddr, c.path)
+	srv, err := newZkService(config.Conf.ZkAddr, &config.Conf.ZkTLS, c.path)
 	if err != nil {
 		return err
 	}
@@ -129,7 +130,7 @@ func runZkLsCmd(c *zkConf) error {
 }
 
 func runZkGetCmd(c *zkConf) error {
-	srv, err := newZkService(config.Conf.ZkAddr, c.path)
+	srv, err := newZkService(config.Conf.ZkAddr, &config.Conf.ZkTLS, c.path)
 	if err != nil {
 		return err
 	}
@@ -148,7 +149,7 @@ func runZkGetCmd(c *zkConf) error {
 }
 
 func runZkDelCmd(c *zkConf) error {
-	srv, err := newZkService(config.Conf.ZkAddr, c.path)
+	srv, err := newZkService(config.Conf.ZkAddr, &config.Conf.ZkTLS, c.path)
 	if err != nil {
 		return err
 	}
@@ -156,7 +157,7 @@ func runZkDelCmd(c *zkConf) error {
 }
 
 func runZkSetCmd(c *zkConf, value string) error {
-	srv, err := newZkService(config.Conf.ZkAddr, c.path)
+	srv, err := newZkService(config.Conf.ZkAddr, &config.Conf.ZkTLS, c.path)
 	if err != nil {
 		return err
 	}

--- a/src/web_server/app/server.go
+++ b/src/web_server/app/server.go
@@ -54,7 +54,7 @@ func Run(ctx context.Context, cancel context.CancelFunc, op *options.ServerOptio
 	input := &backbone.BackboneParameter{
 		ConfigUpdate: webSvr.onServerConfigUpdate,
 		ConfigPath:   op.ServConf.ExConfig,
-		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover},
+		SrvRegdiscv:  backbone.SrvRegdiscv{Regdiscv: op.ServConf.RegDiscover, TLSConfig: op.ServConf.GetTLSClientConf()},
 		SrvInfo:      svrInfo,
 	}
 	if op.DeploymentMethod == common.BluekingDeployment {


### PR DESCRIPTION
修改如下：
- zk客户端修改
  - 增加TLS配置
  - 初始化客户端时根据是否使用TLS，用不同的方法初始化
- CCAPIConfig 增加 tls 配置和读取
- 各个服务的server初始化过程中增加tls配置
- 二进制部署初始化配置脚本init.py增加tls配置
- helm chart 增加 tls 配置