### PR TITLE
feat: elasticsearch客户端支持tls连接

### DIFF
--- a/docs/apidoc/apigw/definition.yaml
+++ b/docs/apidoc/apigw/definition.yaml
@@ -168,6 +168,7 @@ grant_permissions:
       - find_host_topo_relation
       - search_module
       - get_biz_brief_cache_topo
+      - list_hosts_without_biz
       - find_host_biz_relations
       - resource_watch
   - bk_app_code: {{ environ.BK_MONITOR_APP_CODE }}

--- a/docs/support-file/helm/backend/templates/_helpers.tpl
+++ b/docs/support-file/helm/backend/templates/_helpers.tpl
@@ -385,3 +385,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 - --regdiscv-certpassword={{ .Values.certPath }}/{{ .Values.configAndServiceCenter.tls.password }}
 {{- end }}
 {{- end -}}
+
+{{- define "cmdb.es.certVolumeMount" -}}
+{{- if or .Values.esCert.ca .Values.esCert.cert .Values.esCert.key }}
+- name: es-certs
+  mountPath: {{ .Values.certPath }}/elasticsearch
+{{- end }}
+{{- end -}}
+
+{{- define "cmdb.es.certVolume" -}}
+{{- if or .Values.esCert.ca .Values.esCert.cert .Values.esCert.key }}
+- name: es-certs
+  configMap:
+    name: {{ template "bk-cmdb.fullname" . }}-elasticsearch-certs
+{{- end }}
+{{- end -}}

--- a/docs/support-file/helm/backend/templates/_helpers.tpl
+++ b/docs/support-file/helm/backend/templates/_helpers.tpl
@@ -326,6 +326,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end }}
 {{- end -}}
 
+{{- define "cmdb.imagePullSecrets" -}}
+{{- if .Values.image.pullSecretName }}
+imagePullSecrets:
+- name: {{ .Values.image.pullSecretName }}
+{{- end }}
+{{- end -}}
 
 {{- define "cmdb.mongodb.certVolumeMount" -}}
 {{- if or .Values.mongodbCert.mongodb.cert .Values.mongodbCert.mongodb.key .Values.mongodbCert.mongodb.ca }}

--- a/docs/support-file/helm/backend/templates/adminserver/adminserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/adminserver/adminserver-dpl.yaml
@@ -26,8 +26,7 @@ spec:
         {{ toYaml .Values.adminserver.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: adminserver
         image: {{ .Values.image.registry }}/{{ .Values.adminserver.image.repository }}:v{{ default .Chart.AppVersion .Values.adminserver.image.tag }}

--- a/docs/support-file/helm/backend/templates/adminserver/configmap.yaml
+++ b/docs/support-file/helm/backend/templates/adminserver/configmap.yaml
@@ -22,6 +22,16 @@ data:
       usr: {{ .Values.common.es.usr }}
       #密码
       pwd: {{ .Values.common.es.pwd }}
+      #tls
+      tls:
+        {{- if and .Values.esCert.cert .Values.esCert.key }}
+        certFile: {{ .Values.certPath }}/{{ .Values.common.es.tls.certFile }}
+        keyFile: {{ .Values.certPath }}/{{ .Values.common.es.tls.keyFile }}
+        {{- end }}
+        {{- if and .Values.esCert.ca }}
+        caFile: {{ .Values.certPath }}/{{ .Values.common.es.tls.caFile }}
+        {{- end }}
+        insecureSkipVerify: {{ .Values.common.es.tls.insecureSkipVerify }}
     # esb配置
     esb:
       addr: {{ .Values.bkComponentApiUrl }}

--- a/docs/support-file/helm/backend/templates/apiserver/apiserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/apiserver/apiserver-dpl.yaml
@@ -26,8 +26,7 @@ spec:
         {{ toYaml .Values.apiserver.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: apiserver
         image: {{ .Values.image.registry }}/{{ .Values.apiserver.image.repository }}:v{{ default .Chart.AppVersion .Values.apiserver.image.tag }}

--- a/docs/support-file/helm/backend/templates/authserver/authserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/authserver/authserver-dpl.yaml
@@ -26,8 +26,7 @@ spec:
         {{ toYaml .Values.authserver.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: authserver
         image: {{ .Values.image.registry }}/{{ .Values.authserver.image.repository }}:v{{ default .Chart.AppVersion .Values.authserver.image.tag }}

--- a/docs/support-file/helm/backend/templates/cacheservice/cacheservice-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/cacheservice/cacheservice-dpl.yaml
@@ -26,8 +26,7 @@ spec:
         {{ toYaml .Values.cacheservice.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: cacheservice
         image: {{ .Values.image.registry }}/{{ .Values.cacheservice.image.repository }}:v{{ default .Chart.AppVersion .Values.cacheservice.image.tag }}

--- a/docs/support-file/helm/backend/templates/cloudserver/cloudserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/cloudserver/cloudserver-dpl.yaml
@@ -26,8 +26,7 @@ spec:
         {{ toYaml .Values.cloudserver.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: cloudserver
         image: {{ .Values.image.registry }}/{{ .Values.cloudserver.image.repository }}:v{{ default .Chart.AppVersion .Values.cloudserver.image.tag }}

--- a/docs/support-file/helm/backend/templates/coreservice/coreservice-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/coreservice/coreservice-dpl.yaml
@@ -26,8 +26,7 @@ spec:
         {{ toYaml .Values.coreservice.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: coreservice
         image: {{ .Values.image.registry }}/{{ .Values.coreservice.image.repository }}:v{{ default .Chart.AppVersion .Values.coreservice.image.tag }}

--- a/docs/support-file/helm/backend/templates/datacollection/datacollection-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/datacollection/datacollection-dpl.yaml
@@ -26,8 +26,7 @@ spec:
         {{ toYaml .Values.datacollection.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: datacollection
         image: {{ .Values.image.registry }}/{{ .Values.datacollection.image.repository }}:v{{ default .Chart.AppVersion .Values.datacollection.image.tag }}

--- a/docs/support-file/helm/backend/templates/elasticsearch-cert-configmap.yaml
+++ b/docs/support-file/helm/backend/templates/elasticsearch-cert-configmap.yaml
@@ -1,0 +1,16 @@
+{{- if or .Values.esCert.ca .Values.esCert.cert .Values.esCert.key }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "bk-cmdb.fullname" $ }}-elasticsearch-certs
+data:
+  {{- if .Values.esCert.ca }}
+  es.ca: {{ .Values.esCert.ca | b64dec | quote }}
+  {{- end }}
+  {{- if .Values.esCert.cert }}
+  es.cert: {{ .Values.esCert.cert | b64dec | quote }}
+  {{- end }}
+  {{- if .Values.esCert.key }}
+  es.key: {{ .Values.esCert.key | b64dec | quote }}
+  {{- end}}
+{{- end }}

--- a/docs/support-file/helm/backend/templates/eventserver/eventserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/eventserver/eventserver-dpl.yaml
@@ -26,8 +26,7 @@ spec:
         {{ toYaml .Values.eventserver.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: eventserver
         image: {{ .Values.image.registry }}/{{ .Values.eventserver.image.repository }}:v{{ default .Chart.AppVersion .Values.eventserver.image.tag }}

--- a/docs/support-file/helm/backend/templates/hostserver/hostserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/hostserver/hostserver-dpl.yaml
@@ -26,8 +26,7 @@ spec:
         {{ toYaml .Values.hostserver.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: hostserver
         image: {{ .Values.image.registry }}/{{ .Values.hostserver.image.repository }}:v{{ default .Chart.AppVersion .Values.hostserver.image.tag }}

--- a/docs/support-file/helm/backend/templates/job/apigw-job.yaml
+++ b/docs/support-file/helm/backend/templates/job/apigw-job.yaml
@@ -12,8 +12,7 @@ spec:
   parallelism: 1
   template:
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - command:
         - bash

--- a/docs/support-file/helm/backend/templates/job/auth-job.yaml
+++ b/docs/support-file/helm/backend/templates/job/auth-job.yaml
@@ -18,8 +18,7 @@ spec:
   parallelism: 1
   template:
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: cmdb-auth-modelregister
         image: {{ template "cmdb.basicImagesAddress" . }}

--- a/docs/support-file/helm/backend/templates/job/bootstrap-job.yaml
+++ b/docs/support-file/helm/backend/templates/job/bootstrap-job.yaml
@@ -12,8 +12,7 @@ spec:
   parallelism: 1
   template:
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       initContainers:
         - name: check-admin
           image: {{ template "cmdb.basicImagesAddress" . }}

--- a/docs/support-file/helm/backend/templates/job/migrate-dataid-job.yaml
+++ b/docs/support-file/helm/backend/templates/job/migrate-dataid-job.yaml
@@ -17,8 +17,7 @@ spec:
   parallelism: 1
   template:
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: cmdb-migratedataid
         image: {{ template "cmdb.basicImagesAddress" . }}

--- a/docs/support-file/helm/backend/templates/job/migrate-db-job.yaml
+++ b/docs/support-file/helm/backend/templates/job/migrate-db-job.yaml
@@ -17,8 +17,7 @@ spec:
   parallelism: 1
   template:
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: cmdb-migrate
         image: {{ template "cmdb.basicImagesAddress" . }}

--- a/docs/support-file/helm/backend/templates/job/migrate-old-dataid-job.yaml
+++ b/docs/support-file/helm/backend/templates/job/migrate-old-dataid-job.yaml
@@ -17,8 +17,7 @@ spec:
   parallelism: 1
   template:
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: cmdb-migrateolddataid
         image: {{ template "cmdb.basicImagesAddress" . }}

--- a/docs/support-file/helm/backend/templates/monstache/configmap.yaml
+++ b/docs/support-file/helm/backend/templates/monstache/configmap.yaml
@@ -29,6 +29,16 @@ data:
     # resume mode
     resume = false
 
+    elasticsearch-validate-pem-file = {{ not .Values.common.es.tls.insecureSkipVerify }}
+    {{- if .Values.esCert.ca }}
+    elasticsearch-pem-file = "{{ .Values.certPath }}/{{ .Values.common.es.tls.caFile }}"
+    {{- end }}
+    {{- if and .Values.esCert.cert .Values.esCert.key }}
+    [elasticsearch-pki-auth]
+    cert-file = "{{ .Values.certPath }}/{{ .Values.common.es.tls.certFile }}"
+    key-file = "{{ .Values.certPath }}/{{ .Values.common.es.tls.keyFile }}"
+    {{- end }}
+
   extra.toml: |-
     elasticsearch-shard-num = {{ .Values.monstache.elasticsearchShardNum | quote }}
     elasticsearch-replica-num = {{ .Values.monstache.elasticsearchReplicaNum | quote }}

--- a/docs/support-file/helm/backend/templates/monstache/monstache-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/monstache/monstache-dpl.yaml
@@ -26,8 +26,7 @@ spec:
         {{ toYaml .Values.monstache.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: monstache
         image: {{ .Values.image.registry }}/{{ .Values.monstache.image.repository }}:{{ .Values.monstache.image.tag }}

--- a/docs/support-file/helm/backend/templates/monstache/monstache-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/monstache/monstache-dpl.yaml
@@ -42,6 +42,7 @@ spec:
           - name: configures
             mountPath: {{ .Values.monstache.configDir }}
           {{- include "cmdb.mongodb.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.es.certVolumeMount" . | nindent 10 }}
         {{- if .Values.monstache.resources }}
         resources: {{ toYaml .Values.monstache.resources | nindent 10 }}
         {{- end }}
@@ -54,5 +55,6 @@ spec:
           configMap:
             name: {{ .Release.Name }}-monstache-configures
         {{- include "cmdb.mongodb.certVolume" . | nindent 8 }}
+        {{- include "cmdb.es.certVolume" . | nindent 8 }}
 
 {{- end }}

--- a/docs/support-file/helm/backend/templates/operationserver/operationserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/operationserver/operationserver-dpl.yaml
@@ -26,8 +26,7 @@ spec:
         {{ toYaml .Values.operationserver.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: operationserver
         image: {{ .Values.image.registry }}/{{ .Values.operationserver.image.repository }}:v{{ default .Chart.AppVersion .Values.operationserver.image.tag }}

--- a/docs/support-file/helm/backend/templates/procserver/procserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/procserver/procserver-dpl.yaml
@@ -26,8 +26,7 @@ spec:
         {{ toYaml .Values.procserver.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: procserver
         image: {{ .Values.image.registry }}/{{ .Values.procserver.image.repository }}:v{{ default .Chart.AppVersion .Values.procserver.image.tag }}

--- a/docs/support-file/helm/backend/templates/synchronizeserver/synchronizeserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/synchronizeserver/synchronizeserver-dpl.yaml
@@ -26,8 +26,7 @@ spec:
         {{ toYaml .Values.synchronizeserver.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: synchronizeserver
         image: {{ .Values.image.registry }}/{{ .Values.synchronizeserver.image.repository }}:v{{ default .Chart.AppVersion .Values.synchronizeserver.image.tag }}

--- a/docs/support-file/helm/backend/templates/taskserver/taskserver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/taskserver/taskserver-dpl.yaml
@@ -26,8 +26,7 @@ spec:
         {{ toYaml .Values.taskserver.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: taskserver
         image: {{ .Values.image.registry }}/{{ .Values.taskserver.image.repository }}:v{{ default .Chart.AppVersion .Values.taskserver.image.tag }}

--- a/docs/support-file/helm/backend/templates/toposerver/toposerver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/toposerver/toposerver-dpl.yaml
@@ -91,6 +91,7 @@ spec:
           {{- end }}
           {{- include "cmdb.redis.certVolumeMount" . | nindent 10 }}
           {{- include "cmdb.configAndServiceCenter.certVolumeMount" . | nindent 10 }}
+          {{- include "cmdb.es.certVolumeMount" . | nindent 10 }}
       volumes:
         {{- if .Values.toposerver.configDir }}
         - name: configures
@@ -99,6 +100,7 @@ spec:
         {{- end }}
         {{- include "cmdb.redis.certVolume" . | nindent 6 }}
         {{- include "cmdb.configAndServiceCenter.certVolume" . | nindent 6 }}
+        {{- include "cmdb.es.certVolume" . | nindent 6 }}
 
       {{- with .Values.toposerver.nodeSelector }}
       nodeSelector:

--- a/docs/support-file/helm/backend/templates/toposerver/toposerver-dpl.yaml
+++ b/docs/support-file/helm/backend/templates/toposerver/toposerver-dpl.yaml
@@ -26,8 +26,7 @@ spec:
         {{ toYaml .Values.toposerver.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecretName }}
+      {{- include "cmdb.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: toposerver
         image: {{ .Values.image.registry }}/{{ .Values.toposerver.image.repository }}:v{{ default .Chart.AppVersion .Values.toposerver.image.tag }}

--- a/docs/support-file/helm/backend/values.yaml
+++ b/docs/support-file/helm/backend/values.yaml
@@ -1108,6 +1108,11 @@ common:
     url:
     usr:
     pwd:
+    tls:
+      certFile: "elasticsearch/es.cert"
+      keyFile: "elasticsearch/es.key"
+      caFile: "elasticsearch/es.ca"
+      insecureSkipVerify: true
   #auth_server专属配置
   authServer:
     #开发商ID
@@ -2023,6 +2028,10 @@ mongodbCert:
     ##
     key: ""
 zookeeperCert:
+  ca: ""
+  cert: ""
+  key: ""
+esCert:
   ca: ""
   cert: ""
   key: ""

--- a/src/thirdparty/elasticsearch/esclient.go
+++ b/src/thirdparty/elasticsearch/esclient.go
@@ -2,7 +2,6 @@ package elasticsearch
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -30,19 +29,14 @@ func NewEsClient(esConf EsConfig) (*elastic.Client, error) {
 	client := &elastic.Client{}
 	var err error
 	if strings.HasPrefix(esConf.EsUrl, "https://") {
-		tlsConfig := new(tls.Config)
-		tlsConfig.InsecureSkipVerify = esConf.TLSClientConfig.InsecureSkipVerify
-		if !tlsConfig.InsecureSkipVerify && len(esConf.TLSClientConfig.CAFile) != 0 && len(esConf.TLSClientConfig.CertFile) != 0 && len(esConf.TLSClientConfig.KeyFile) != 0 {
-			var err error
-			tlsConfig, err = ssl.ClientTLSConfVerity(esConf.TLSClientConfig.CAFile, esConf.TLSClientConfig.CertFile,
-				esConf.TLSClientConfig.KeyFile, esConf.TLSClientConfig.Password)
-			if err != nil {
-				return nil, err
-			}
-		}
 		// if use https tls or else, config httpClient first
-		tr := &http.Transport{
-			TLSClientConfig: tlsConfig,
+		tr := &http.Transport{}
+		tlsConf, useTLS, err := ssl.NewTLSConfigFromConf(&esConf.TLSClientConfig)
+		if err != nil {
+			return nil, err
+		}
+		if useTLS {
+			tr.TLSClientConfig = tlsConf
 		}
 		httpClient.Transport = tr
 		client, err = elastic.NewClient(
@@ -145,6 +139,6 @@ func ParseConfigFromKV(prefix string, configMap map[string]string) (EsConfig, er
 		EsPassword:     pwd,
 	}
 	var err error
-	conf.TLSClientConfig, err = cc.NewTLSClientConfigFromConfig(prefix)
+	conf.TLSClientConfig, err = cc.NewTLSClientConfigFromConfig(prefix + ".tls")
 	return conf, err
 }


### PR DESCRIPTION
修改如下：
- es客户端增加读取 tls 配置
- init.py增加解析es的tls路径等参数
- chart包修改
- 修复不使用pullSecertName时二次部署报错
- apigw 注册 HCM 增加 list_hosts_without_biz