### PR TITLE
chore: 添加@babel/runtime依赖并且配置之后安装的新包默认使用固定版本

### DIFF
--- a/src/ui/.npmrc
+++ b/src/ui/.npmrc
@@ -1,2 +1,3 @@
 package-lock=false
 legacy-peer-deps=true
+save-exact=true

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -16,6 +16,7 @@
     "lint-fix": "eslint --fix --ext .js,.vue ./src"
   },
   "dependencies": {
+    "@babel/runtime": "^7.27.1",
     "@blueking/bkui-library": "^0.0.0-beta.6",
     "@blueking/functional-dependency": "^0.0.1-beta.10",
     "@blueking/login-modal": "^1.0.0",


### PR DESCRIPTION
### 修复的问题：
- 缺少@babel/runtime相关依赖导致的编译错误
