### PR TITLE
fix: 项目列表多出一个项目图标字段

### DIFF
--- a/src/ui/src/magicbox/index.js
+++ b/src/ui/src/magicbox/index.js
@@ -48,26 +48,30 @@ Vue.use(magicbox, {
 export const $error = (message, delay = 3000) => magicbox.bkMessage({
   message,
   delay,
-  theme: 'error'
+  theme: 'error',
+  ellipsisLine: 0
 })
 
 export const $success = (message, delay = 3000) => magicbox.bkMessage({
   message,
   delay,
-  theme: 'success'
+  theme: 'success',
+  ellipsisLine: 0
 })
 
 export const $info = (message, delay = 3000) => magicbox.bkMessage({
   message,
   delay,
-  theme: 'primary'
+  theme: 'primary',
+  ellipsisLine: 0
 })
 
 export const $warn = (message, delay = 3000) => magicbox.bkMessage({
   message,
   delay,
   theme: 'warning',
-  hasCloseIcon: true
+  hasCloseIcon: true,
+  ellipsisLine: 0
 })
 
 export const $bkInfo = magicbox.bkInfoBox

--- a/src/ui/src/views/business-topology/service-instance/instance/dialog/label-dialog-content.vue
+++ b/src/ui/src/views/business-topology/service-instance/instance/dialog/label-dialog-content.vue
@@ -18,6 +18,7 @@
           <input class="cmdb-form-input" type="text"
             ref="tagKey"
             :data-vv-name="'key-' + index"
+            data-vv-validate-on="change"
             v-validate="getValidateRules(index, 'key')"
             v-model="label.key"
             :placeholder="`Key: ${$validator.dictionary.getMessage($i18n.locale, 'instanceTagKey')}`">
@@ -27,6 +28,7 @@
         <div class="label-value" :class="{ 'is-error': errors.has('value-' + index) }">
           <input class="cmdb-form-input" type="text"
             :data-vv-name="'value-' + index"
+            data-vv-validate-on="change"
             v-validate="getValidateRules(index, 'value')"
             v-model="label.value"
             :placeholder="`Value: ${$validator.dictionary.getMessage($i18n.locale, 'instanceTagValue')}`">

--- a/src/ui/src/views/project/index.vue
+++ b/src/ui/src/views/project/index.vue
@@ -551,6 +551,8 @@
           const headerProperties = this.$tools.getHeaderProperties(this.properties, customColumns, this.columnsConfig.disabledColumns)
           resolve(headerProperties)
         }).then((properties) => {
+          // 在没有设置过项目列的时候，会显示出项目图标字段
+          properties = properties.filter(item => item.bk_property_id !== 'bk_project_icon')
           this.updateTableHeader(properties)
           this.columnsConfig.selected = properties.map(property => property.bk_property_id)
         })


### PR DESCRIPTION
### 修复的问题：
- 项目列表多出一个项目图标字段
- 集群模板-英文状态下更新模版属性后“同步功能”不支持点击跳转了
- 服务实例-批量编辑标签时没有及时触发校验规则 