### PR TITLE
fix:修复创建模型attrs时空指针报错 --bug=149096159 【CMDB】导入模型报错空指针

### DIFF
--- a/src/source_controller/coreservice/core/model/attribute.go
+++ b/src/source_controller/coreservice/core/model/attribute.go
@@ -192,7 +192,9 @@ func (m *modelAttribute) CreateModelAttributes(kit *rest.Kit, objID string, inpu
 		if (!inputParam.FromTemplate && attr.TemplateID != 0) || (inputParam.FromTemplate && attr.TemplateID == 0) {
 			blog.Errorf("scene parameter invalid, attr: %+v, from template: %v rid: %s", attr,
 				inputParam.FromTemplate, kit.Rid)
-			addExceptionFunc(int64(attrIdx), err, &attr)
+			msg := fmt.Sprintf("fromTemplate(%v) does not match templateID(%v)",
+				inputParam.FromTemplate, attr.TemplateID)
+			addExceptionFunc(int64(attrIdx), kit.CCError.CCErrorf(common.CCErrCommParamsIsInvalid, msg), &attr)
 		}
 
 		if attr.IsPre && attr.PropertyID == common.BKInstNameField {


### PR DESCRIPTION
### 修复的问题：
- 批量导入模型操作,特性情况下 
即满足 if (!inputParam.FromTemplate && attr.TemplateID != 0) || (inputParam.FromTemplate && attr.TemplateID == 0) { 条件时，
err 为nil ，err.Error() 发生空指针问题
### 修复方法：
修改nil的err为 kit.CCError.CCErrorf+错误提示
