### PR TITLE
fix:searchHost validCondValueType字段校验问题--bug=150330928 【CMDB】host_sea…

### DIFF
--- a/src/scene_server/host_server/logics/hostsearch.go
+++ b/src/scene_server/host_server/logics/hostsearch.go
@@ -378,6 +378,10 @@ func init() {
 }
 
 func (sh *searchHost) validCondValueType(attrType string, value interface{}) error {
+	if value == nil {
+		blog.V(4).Infof("condition item field %s value is nil", attrType)
+		return nil
+	}
 	switch attrType {
 	case common.FieldTypeInt, common.FieldTypeFloat, common.FieldTypeOrganization:
 		if !util.IsNumeric(value) {


### PR DESCRIPTION
### 修复的问题：
_searchHost_ validCondValueType
修复字段值为nil, host_search_resource接口报错问题
方案：
添加 if value == nil 判断

