### PR TITLE
V3.14.x FieldTypeList类型转换

### DIFF
--- a/src/common/metadata/attribute.go
+++ b/src/common/metadata/attribute.go
@@ -1653,9 +1653,13 @@ func (attribute Attribute) PrettyValue(ctx context.Context, val interface{}) (st
 		if !ok {
 			return "", fmt.Errorf("invalid value type for %s, value: %+v", fieldType, val)
 		}
-
-		listOption, ok := attribute.Option.([]interface{})
-		if false == ok {
+		var listOption []interface{}
+		switch attributeOption := attribute.Option.(type) {
+		case primitive.A:
+			listOption = []interface{}(attributeOption)
+		case []interface{}:
+			listOption = attributeOption
+		default:
 			return "", fmt.Errorf("parse options for list type failed, option not slice type, option: %+v",
 				attribute.Option)
 		}


### PR DESCRIPTION
### 修复的问题：
- attribute.Option 为any 实际为primitive.A(type A []interface{}）
- attribute.Option.([]interface{}) 无法直接进行类型转换
### 修复方案
- attribute.Option--> primitive.A-->[]interface{}