### PR TITLE
将用户管理返回的用户时区注入到前端页面

### DIFF
--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -1419,6 +1419,8 @@ const (
 	WEBSessionAvatarUrlKey = "avatar_url"
 	// WEBSessionMultiTenantKey multi tenant session key
 	WEBSessionMultiTenantKey = "multitenant"
+	// WEBSessionTimeZoneKey time zone session key
+	WEBSessionTimeZoneKey = "time_zone"
 
 	// LoginSystemMultiTenantTrue login system multi tenant flag
 	LoginSystemMultiTenantTrue = "1"

--- a/src/common/metadata/webserver.go
+++ b/src/common/metadata/webserver.go
@@ -47,6 +47,7 @@ type LoginUserInfo struct {
 	Language     string                       `json:"-"`
 	AvatarUrl    string                       `json:"avatar_url"`
 	MultiTenant  bool                         `json:"multi_tenant"`
+	TimeZone     string                       `json:"time_zone"`
 }
 
 // LoginPluginInfo login user plugin info

--- a/src/web_server/middleware/user/plugins/method/blueking/userinfo.go
+++ b/src/web_server/middleware/user/plugins/method/blueking/userinfo.go
@@ -78,6 +78,7 @@ func (m *user) LoginUser(c *gin.Context, config options.Config, isMultiOwner boo
 			BkToken:   bkToken,
 			TenantUin: userInfo.TenantID,
 			Language:  userInfo.Language,
+			TimeZone:  userInfo.TimeZone,
 		}
 		break
 	}

--- a/src/web_server/middleware/user/public.go
+++ b/src/web_server/middleware/user/public.go
@@ -86,6 +86,7 @@ func (m *publicUser) LoginUser(c *gin.Context) bool {
 	} else {
 		session.Set(common.WEBSessionMultiTenantKey, common.LoginSystemMultiTenantFalse)
 	}
+	session.Set(common.WEBSessionTimeZoneKey, userInfo.TimeZone)
 
 	if err := session.Save(); err != nil {
 		blog.Warnf("save session failed, err: %s, rid: %s", err.Error(), rid)

--- a/src/web_server/service/index.go
+++ b/src/web_server/service/index.go
@@ -31,6 +31,7 @@ func (s *Service) Index(c *gin.Context) {
 	session := sessions.Default(c)
 	userName, _ := session.Get(common.WEBSessionUinKey).(string)
 	tenantID, _ := session.Get(common.WEBSessionTenantUinKey).(string)
+	timeZone, _ := session.Get(common.WEBSessionTimeZoneKey).(string)
 
 	pageConf := gin.H{
 		"site":                  s.Config.Site.DomainUrl,
@@ -49,6 +50,7 @@ func (s *Service) Index(c *gin.Context) {
 		"enableNotification":    s.Config.EnableNotification,
 		"bkSharedResUrl":        s.Config.Site.BkSharedResUrl,
 		"enableMultiTenantMode": s.Config.EnableMultiTenantMode,
+		"timeZone":              timeZone,
 	}
 
 	if s.Config.Site.PaasDomainUrl != "" {


### PR DESCRIPTION
### 新加的功能:
- 将用户管理返回的用户时区注入到前端页面
