### PR TITLE
fix: 业务集主机批量复制 "管控区域ID: IP” ，复制出无效信息

### DIFF
--- a/src/ui/src/components/model-manage/field-group/field-detail/index.vue
+++ b/src/ui/src/components/model-manage/field-group/field-detail/index.vue
@@ -536,6 +536,11 @@
           this.fieldInfo.default = this.isNullOrUndefinedOrEmpty(this.fieldInfo.default) ? '' : Number(this.fieldInfo.default)
         }
 
+        // 将布尔类型的默认值改成default
+        if (PROPERTY_TYPES.BOOL === this.fieldInfo.bk_property_type) {
+          this.fieldInfo.default = this.fieldInfo.option
+        }
+
         // 配置流程直接抛出事件并退出，在流程中自行处理
         if (this.isSettingScene) {
           this.$emit('confirm', this.field.id, this.fieldInfo)

--- a/src/ui/src/views/business-set-topology/children/host-list/options.vue
+++ b/src/ui/src/views/business-set-topology/children/host-list/options.vue
@@ -40,16 +40,13 @@
   import FilterStore from '@/components/filters/store'
   import FilterUtils from '@/components/filters/utils'
   import { BUILTIN_MODELS } from '@/dictionary/model-constants.js'
+  import { IPWithCloudSymbol, IPWithCloudFields, IPv6WithCloudSymbol, IPv46WithCloudSymbol, IPv64WithCloudSymbol } from '@/dictionary/ip-with-cloud-symbol'
+  import { isEmptyPropertyValue } from '@/utils/tools'
 
   export default {
     components: {
       FilterCollection,
       FilterFastSearch,
-    },
-    data() {
-      return {
-        IPWithCloudSymbol: Symbol('IPWithCloud')
-      }
     },
     computed: {
       ...mapGetters('userCustom', ['usercustom']),
@@ -68,15 +65,15 @@
         return !!this.selection.length
       },
       clipboardList() {
-        const IPWithCloud = FilterUtils.defineProperty({
-          id: this.IPWithCloudSymbol,
-          bk_obj_id: BUILTIN_MODELS.HOST,
-          bk_property_id: this.IPWithCloudSymbol,
-          bk_property_name: `${this.$t('管控区域')}ID:IP`,
+        const IPWithClouds = Object.keys(IPWithCloudFields).map(key => FilterUtils.defineProperty({
+          id: key,
+          bk_obj_id: 'host',
+          bk_property_id: key,
+          bk_property_name: IPWithCloudFields[key],
           bk_property_type: 'singlechar'
-        })
+        }))
         const clipboardList = this.$parent.tableHeader.slice()
-        clipboardList.splice(1, 0, IPWithCloud)
+        clipboardList.splice(3, 0, ...IPWithClouds)
         return clipboardList
       },
       tableHeaderPropertyIdList() {
@@ -91,11 +88,34 @@
         const copyText = this.selection.map((data) => {
           const modelId = property.bk_obj_id
           const modelData = data[modelId]
-          if (property.id === this.IPWithCloudSymbol) {
+
+          const IPWithCloudKeys = Object.keys(IPWithCloudFields)
+          if (IPWithCloudKeys.includes(property.id)) {
             const cloud = this.$tools.getPropertyCopyValue(modelData.bk_cloud_id, 'foreignkey')
             const ip = this.$tools.getPropertyCopyValue(modelData.bk_host_innerip, 'singlechar')
-            return `${cloud}:${ip}`
+            const ipv6 = this.$tools.getPropertyCopyValue(modelData.bk_host_innerip_v6, 'singlechar')
+            const isEmptyIPv4Value = isEmptyPropertyValue(modelData.bk_host_innerip)
+            const isEmptyIPv6Value = isEmptyPropertyValue(modelData.bk_host_innerip_v6)
+            if (property.id === IPWithCloudSymbol) {
+              return `${cloud}:${ip}`
+            }
+            if (property.id === IPv6WithCloudSymbol) {
+              return `${cloud}:[${ipv6}]`
+            }
+            if (property.id === IPv46WithCloudSymbol) {
+              if (!isEmptyIPv4Value || isEmptyIPv6Value) {
+                return `${cloud}:${ip}`
+              }
+              return `${cloud}:[${ipv6}]`
+            }
+            if (property.id === IPv64WithCloudSymbol) {
+              if (isEmptyIPv4Value || !isEmptyIPv6Value) {
+                return `${cloud}:[${ipv6}]`
+              }
+              return `${cloud}:${ip}`
+            }
           }
+
           const propertyId = property.bk_property_id
           if (Array.isArray(modelData)) {
             const value = modelData.map(item => this.$tools.getPropertyCopyValue(item[propertyId], property))

--- a/src/ui/src/views/business-topology/host/host-selector-new/host-selector-topology.vue
+++ b/src/ui/src/views/business-topology/host/host-selector-new/host-selector-topology.vue
@@ -290,6 +290,14 @@
         this.currentNode = node
         const result = await this.searchHost(node)
         this.hostList = result.info
+        this.setNodeCount(this.findNode(node.parent, [...node.children]))
+      },
+      findNode(node, data) {
+        while (node.parent) {
+          data.push(...node.children)
+          return this.findNode(node.parent, data)
+        }
+        return data
       },
       async handleHostPaginationChange() {
         const result = await this.searchHost(this.currentNode)

--- a/src/ui/src/views/business-topology/service-instance/common/host-selector.vue
+++ b/src/ui/src/views/business-topology/service-instance/common/host-selector.vue
@@ -104,6 +104,7 @@
   import hostSearchService from '@/service/host/search'
   import debounce from 'lodash.debounce'
   import { foreignkey } from '@/filters/formatter.js'
+  import isIP from 'validator/es/lib/isIP'
   export default {
     filters: {
       foreignkey
@@ -223,13 +224,17 @@
         }
       },
       getParams() {
+        const isIPV6 = isIP(this.keyword, 6)
+        const ipParams = {
+          [isIPV6 ? 'ipv6' : 'ip']: {
+            data: this.keyword ? [this.keyword] : [],
+            exact: isIPV6 ? 1 : 0, // 0:模糊 1:精确  IPV6目前后端只支持精准匹配
+            flag: 'bk_host_innerip|bk_host_outerip'
+          }
+        }
         const params = {
           bk_biz_id: this.bizId,
-          ip: {
-            data: this.keyword ? [this.keyword] : [],
-            exact: 0, // 模糊
-            flag: 'bk_host_innerip|bk_host_outerip'
-          },
+          ...ipParams,
           condition: [
             {
               bk_obj_id: 'host',

--- a/src/ui/src/views/dynamic-group/index.vue
+++ b/src/ui/src/views/dynamic-group/index.vue
@@ -148,7 +148,7 @@
           }
         }
         this.filter.forEach((item) => {
-          const itemValue = item.value?.split(',')
+          const itemValue = item.value?.split(/,|;|\n|\s/)
           const value = itemValue?.length > 1 ? {
             $in: itemValue
           } : itemValue[0]

--- a/src/ui/src/views/model-manage/children/model-details/index.vue
+++ b/src/ui/src/views/model-manage/children/model-details/index.vue
@@ -308,7 +308,8 @@
     MENU_MODEL_MANAGEMENT,
     MENU_RESOURCE_INSTANCE,
     MENU_MODEL_FIELD_TEMPLATE,
-    MENU_MODEL_FIELD_TEMPLATE_SYNC_MODEL
+    MENU_MODEL_FIELD_TEMPLATE_SYNC_MODEL,
+    MENU_RESOURCE_COLLECTION
   } from '@/dictionary/menu-symbol'
   import { BUILTIN_MODEL_RESOURCE_MENUS, BUILTIN_MODELS } from '@/dictionary/model-constants.js'
   import EditableField from '@/components/ui/details/editable-field.vue'
@@ -373,6 +374,7 @@
       }
     },
     computed: {
+      ...mapGetters('userCustom', ['usercustom']),
       ...mapGetters([
         'supplierAccount',
         'userName'
@@ -684,6 +686,10 @@
           bk_obj_id: this.activeModel.bk_obj_id
         })
         this.updateActiveModel()
+        if (ispaused) {
+          // 停用了调用更新收藏模型的接口
+          this.updateModelCollection()
+        }
       },
       async deleteModel() {
         if (this.isMainLineModel) {
@@ -707,7 +713,18 @@
           this.$routerActions.redirect({ name: MENU_MODEL_MANAGEMENT })
         }
         this.$success(this.$t('删除成功'))
+        this.updateModelCollection()
         this.$http.cancel('post_searchClassificationsObjects')
+      },
+      // 停用或者删除模型后，如果该模型被收藏了，则取消收藏
+      updateModelCollection() {
+        const oldCollection = this.usercustom[MENU_RESOURCE_COLLECTION] || []
+        // 如果之前没收藏则返回，收藏了则取消收藏
+        const hasCollection = oldCollection.filter(id => id === this.activeModel.bk_obj_id)
+        if (!hasCollection.length) return
+        this.$store.dispatch('userCustom/saveUsercustom', {
+          [MENU_RESOURCE_COLLECTION]: oldCollection.filter(id => id !== this.activeModel.bk_obj_id)
+        })
       },
       handleGoInstance() {
         const model = this.activeModel

--- a/src/ui/src/views/operation/index.vue
+++ b/src/ui/src/views/operation/index.vue
@@ -374,8 +374,10 @@
             // eslint-disable-next-line no-plusplus
             if (item.count === 0) zeroList++
             if (data.chart_type === 'pie') {
-              content.labels.push(item.id)
-              if (item.count !== 0) content.values.push(item.count)
+              if (item.count !== 0) {
+                content.labels.push(item.id)
+                content.values.push(item.count)
+              }
             } else {
               const color = '#3A84FF'
               content.marker.color.push(color)


### PR DESCRIPTION
### 新加的功能:
- xxxx
### 优化的功能:
- xxxx
### 修复的问题：
- 业务集主机批量复制 "管控区域ID: IP” ，复制出无效信息
- 业务拓扑-新增主机到模块-搜索框-模型count不全
-  模型默认停用后仍在 收藏导航栏显示 
-  动态分组搜索分隔符优化 
-  主机操作系统类型统计指标中，图例取值错误
- 服务实例添加主机时使用IPv6搜索报错
- 业务拓扑中自定义字段bool字段默认值无效