### PR TITLE
V3.14.x 修复xlsx表格DDE问题

### DIFF
--- a/pkg/excel/style.go
+++ b/pkg/excel/style.go
@@ -25,10 +25,12 @@ type Style struct {
 	Fill   *Fill
 	Border []Border
 	Font   *Font
+	NumFmt int
 }
 
 func (s *Style) convert() (*excelize.Style, error) {
 	style := new(excelize.Style)
+	style.NumFmt = s.NumFmt
 	if s.Fill != nil {
 		fill, err := s.Fill.convert()
 		if err != nil {

--- a/src/web_server/service/excel/core/field_func.go
+++ b/src/web_server/service/excel/core/field_func.go
@@ -563,3 +563,15 @@ func getUserListStr(userList []string) []string {
 
 	return userListStr
 }
+
+// HandleDDE Add a prefix of ' to the characters '=', '+', '-', '@' to disrupt the Excel DDE formula
+func HandleDDE(str string) string {
+	realStr := strings.TrimSpace(str)
+	if len(realStr) > 0 {
+		switch realStr[0] {
+		case '=', '+', '-', '@':
+			realStr = `'` + realStr
+		}
+	}
+	return realStr
+}

--- a/src/web_server/service/excel/operator/inst/exporter/inst_func.go
+++ b/src/web_server/service/excel/operator/inst/exporter/inst_func.go
@@ -36,12 +36,26 @@ var handleSpecialInstFieldFuncMap = make(map[string]handleInstFieldFunc)
 func init() {
 	handleInstFieldFuncMap[common.FieldTypeInt] = getHandleIntFieldFunc()
 	handleInstFieldFuncMap[common.FieldTypeFloat] = getHandleFloatFieldFunc()
+	handleInstFieldFuncMap[common.FieldTypeSingleChar] = getHandleCharFieldFunc()
+	handleInstFieldFuncMap[common.FieldTypeLongChar] = getHandleCharFieldFunc()
 	handleInstFieldFuncMap[common.FieldTypeEnum] = getHandleEnumFieldFunc()
 	handleInstFieldFuncMap[common.FieldTypeEnumMulti] = getHandleEnumMultiFieldFunc()
 	handleInstFieldFuncMap[common.FieldTypeBool] = getHandleBoolFieldFunc()
 	handleInstFieldFuncMap[common.FieldTypeInnerTable] = getHandleTableFieldFunc()
 
 	handleSpecialInstFieldFuncMap[common.BKCloudIDField] = getHandleInstCloudAreaFunc()
+}
+func getHandleCharFieldFunc() handleInstFieldFunc {
+	return func(e *Exporter, property *core.ColProp, val interface{}) ([][]excel.Cell, error) {
+		if val == nil {
+			return [][]excel.Cell{getRowWithOneCell()}, nil
+		}
+
+		strVal := util.GetStrByInterface(val)
+		strVal = core.HandleDDE(strVal)
+		handleFunc := getDefaultHandleFieldFunc()
+		return handleFunc(e, property, strVal)
+	}
 }
 
 func getHandleInstFieldFunc(property *core.ColProp) handleInstFieldFunc {
@@ -231,13 +245,13 @@ func getHandleTableFieldFunc() handleInstFieldFunc {
 
 func getDefaultHandleFieldFunc() handleInstFieldFunc {
 	return func(e *Exporter, property *core.ColProp, val interface{}) ([][]excel.Cell, error) {
-		var styleID int
+		style := normalField
 		if property.NotEditable {
-			var err error
-			styleID, err = e.styleCreator.getStyle(noEditField)
-			if err != nil {
-				return nil, err
-			}
+			style = noEditField
+		}
+		styleID, err := e.styleCreator.getStyle(style, property.PropertyType)
+		if err != nil {
+			return nil, err
 		}
 
 		result := make([][]excel.Cell, singleCellLen)

--- a/src/web_server/service/excel/operator/inst/exporter/property_func.go
+++ b/src/web_server/service/excel/operator/inst/exporter/property_func.go
@@ -147,11 +147,11 @@ func getHandleBoolTypeFunc() handleColPropFunc {
 
 func getHandleTableTypeFunc() handleColPropFunc {
 	return func(t *TmplOp, property *core.ColProp) ([][]excel.Cell, error) {
-		nameStyle, err := t.styleCreator.getStyle(firstRow)
+		nameStyle, err := t.styleCreator.getStyle(firstRow, property.PropertyType)
 		if err != nil {
 			return nil, err
 		}
-		headerStyle, err := t.styleCreator.getStyle(generalHeader)
+		headerStyle, err := t.styleCreator.getStyle(generalHeader, property.PropertyType)
 		if err != nil {
 			return nil, err
 		}
@@ -160,7 +160,8 @@ func getHandleTableTypeFunc() handleColPropFunc {
 		propertyType := core.GetTypeAliasName(ccLang, property.PropertyType)
 
 		result := make([][]excel.Cell, core.InstHeaderLen)
-		result[core.NameRowIdx] = append(result[core.NameRowIdx], excel.Cell{Value: property.Name, StyleID: nameStyle})
+		result[core.NameRowIdx] = append(result[core.NameRowIdx], excel.Cell{Value: core.HandleDDE(property.Name),
+			StyleID: nameStyle})
 		result[core.TypeRowIdx] = append(result[core.TypeRowIdx],
 			excel.Cell{Value: propertyType, StyleID: headerStyle})
 		result[core.IDRowIdx] = append(result[core.IDRowIdx], excel.Cell{Value: property.ID, StyleID: headerStyle})
@@ -204,7 +205,7 @@ func getHandleTableTypeFunc() handleColPropFunc {
 			result[core.TableIDRowIdx] = append(result[core.TableIDRowIdx], properyResult[core.IDRowIdx]...)
 		}
 
-		tableHeaderStyle, err := t.styleCreator.getStyle(tableHeader)
+		tableHeaderStyle, err := t.styleCreator.getStyle(tableHeader, property.PropertyType)
 		if err != nil {
 			return nil, err
 		}
@@ -228,11 +229,11 @@ func getDefaultHandleTypeFunc() handleColPropFunc {
 			headerStyleType = noEditHeader
 		}
 
-		nameStyle, err := t.styleCreator.getStyle(nameStyleType)
+		nameStyle, err := t.styleCreator.getStyle(nameStyleType, property.PropertyType)
 		if err != nil {
 			return nil, err
 		}
-		headerStyle, err := t.styleCreator.getStyle(headerStyleType)
+		headerStyle, err := t.styleCreator.getStyle(headerStyleType, property.PropertyType)
 		if err != nil {
 			return nil, err
 		}
@@ -241,7 +242,8 @@ func getDefaultHandleTypeFunc() handleColPropFunc {
 		propertyType := core.GetTypeAliasName(ccLang, property.PropertyType)
 
 		result := make([][]excel.Cell, core.InstHeaderLen)
-		result[core.NameRowIdx] = append(result[core.NameRowIdx], excel.Cell{Value: property.Name, StyleID: nameStyle})
+		result[core.NameRowIdx] = append(result[core.NameRowIdx],
+			excel.Cell{Value: core.HandleDDE(property.Name), StyleID: nameStyle})
 		result[core.TypeRowIdx] = append(result[core.TypeRowIdx], excel.Cell{Value: propertyType, StyleID: headerStyle})
 		result[core.IDRowIdx] = append(result[core.IDRowIdx], excel.Cell{Value: property.ID, StyleID: headerStyle})
 

--- a/src/web_server/service/excel/operator/inst/exporter/property_func.go
+++ b/src/web_server/service/excel/operator/inst/exporter/property_func.go
@@ -136,7 +136,7 @@ func getHandleBoolTypeFunc() handleColPropFunc {
 			return nil, err
 		}
 		if err = t.GetExcel().AddValidation(t.GetObjID(),
-			&excel.ValidationParam{Type: excel.Bool, Sqref: sqref, Option: property.Name}); err != nil {
+			&excel.ValidationParam{Type: excel.Bool, Sqref: sqref}); err != nil {
 			return nil, err
 		}
 

--- a/src/web_server/service/excel/operator/inst/exporter/style.go
+++ b/src/web_server/service/excel/operator/inst/exporter/style.go
@@ -18,6 +18,7 @@ package exporter
 
 import (
 	"configcenter/pkg/excel"
+	"configcenter/src/common"
 )
 
 type styleType string
@@ -37,6 +38,8 @@ const (
 	noEditField styleType = "noEditField"
 	// example 例子数据的单元格类型
 	example styleType = "example"
+	// normalField 普通数据单元格类型
+	normalField styleType = "normal"
 
 	requiredFieldColor = "#FF0000"
 	noEditHeaderColor  = "fabf8f"
@@ -63,14 +66,48 @@ func init() {
 	createStyleFuncMap[generalHeader] = getGeneralHeaderStyleFunc()
 	createStyleFuncMap[tableHeader] = getTableHeaderStyleFunc()
 	createStyleFuncMap[example] = getExampleStyleFunc()
+	createStyleFuncMap[normalField] = getNormalStyleFunc()
 }
 
-type createStyleFunc func(s *styleCreator) (int, error)
+type createStyleFunc func(s *styleCreator, numFmt int) (int, error)
+
+// handlePropertyTypeNumFmt propType->excel code
+func handlePropertyTypeNumFmt(propType string) int {
+	switch propType {
+	case common.FieldTypeInt:
+		return 1
+	case common.FieldTypeFloat:
+		return 2
+	case common.FieldTypeLongChar, common.FieldTypeSingleChar:
+		return 49
+	case common.FieldTypeInnerTable,
+		common.FieldTypeEnum,
+		common.FieldTypeEnumMulti,
+		common.FieldTypeBool:
+		return 0
+	default:
+		return 0
+	}
+}
 
 func getNoEditHeaderStyleFunc() createStyleFunc {
-	return func(s *styleCreator) (int, error) {
+	return func(s *styleCreator, numFmt int) (int, error) {
 		style := &excel.Style{Fill: &excel.Fill{Type: "pattern", Color: []string{noEditHeaderColor}, Pattern: 1},
-			Border: generalBorder}
+			Border: generalBorder, NumFmt: numFmt}
+
+		result, err := s.excel.NewStyle(style)
+		if err != nil {
+			return 0, err
+		}
+
+		return result, nil
+	}
+}
+
+func getNormalStyleFunc() createStyleFunc {
+	return func(s *styleCreator, numFmt int) (int, error) {
+		style := &excel.Style{Fill: &excel.Fill{Type: "pattern", Color: []string{}, Pattern: 1},
+			Border: generalBorder, NumFmt: numFmt}
 
 		result, err := s.excel.NewStyle(style)
 		if err != nil {
@@ -82,9 +119,9 @@ func getNoEditHeaderStyleFunc() createStyleFunc {
 }
 
 func getNoEditFieldStyleFunc() createStyleFunc {
-	return func(s *styleCreator) (int, error) {
+	return func(s *styleCreator, numFmt int) (int, error) {
 		style := &excel.Style{Fill: &excel.Fill{Type: excel.Pattern, Color: []string{noEditFieldColor}, Pattern: 1},
-			Border: generalBorder}
+			Border: generalBorder, NumFmt: numFmt}
 
 		result, err := s.excel.NewStyle(style)
 		if err != nil {
@@ -96,9 +133,9 @@ func getNoEditFieldStyleFunc() createStyleFunc {
 }
 
 func getFirstRowStyleFunc() createStyleFunc {
-	return func(s *styleCreator) (int, error) {
+	return func(s *styleCreator, numFmt int) (int, error) {
 		style := &excel.Style{Fill: &excel.Fill{Type: excel.Pattern, Color: []string{firstRowColor}, Pattern: 1},
-			Border: generalBorder}
+			Border: generalBorder, NumFmt: numFmt}
 
 		result, err := s.excel.NewStyle(style)
 		if err != nil {
@@ -110,9 +147,9 @@ func getFirstRowStyleFunc() createStyleFunc {
 }
 
 func getGeneralHeaderStyleFunc() createStyleFunc {
-	return func(s *styleCreator) (int, error) {
+	return func(s *styleCreator, numFmt int) (int, error) {
 		style := &excel.Style{Fill: &excel.Fill{Type: excel.Pattern, Color: []string{generalHeaderColor}, Pattern: 1},
-			Border: generalBorder}
+			Border: generalBorder, NumFmt: numFmt}
 
 		result, err := s.excel.NewStyle(style)
 		if err != nil {
@@ -124,9 +161,9 @@ func getGeneralHeaderStyleFunc() createStyleFunc {
 }
 
 func getTableHeaderStyleFunc() createStyleFunc {
-	return func(s *styleCreator) (int, error) {
+	return func(s *styleCreator, numFmt int) (int, error) {
 		style := &excel.Style{Fill: &excel.Fill{Type: excel.Pattern, Color: []string{tableHeaderColor}, Pattern: 1},
-			Border: generalBorder}
+			Border: generalBorder, NumFmt: numFmt}
 
 		result, err := s.excel.NewStyle(style)
 		if err != nil {
@@ -138,9 +175,9 @@ func getTableHeaderStyleFunc() createStyleFunc {
 }
 
 func getExampleStyleFunc() createStyleFunc {
-	return func(s *styleCreator) (int, error) {
+	return func(s *styleCreator, numFmt int) (int, error) {
 		style := &excel.Style{Fill: &excel.Fill{Type: excel.Pattern, Color: []string{exampleColor}, Pattern: 1},
-			Border: generalBorder}
+			Border: generalBorder, NumFmt: numFmt}
 
 		result, err := s.excel.NewStyle(style)
 		if err != nil {
@@ -152,9 +189,9 @@ func getExampleStyleFunc() createStyleFunc {
 }
 
 func getRequiredFieldStyleFunc() createStyleFunc {
-	return func(s *styleCreator) (int, error) {
+	return func(s *styleCreator, numFmt int) (int, error) {
 		style := &excel.Style{Fill: &excel.Fill{Type: excel.Pattern, Color: []string{firstRowColor}, Pattern: 1},
-			Border: generalBorder, Font: &excel.Font{Color: requiredFieldColor}}
+			Border: generalBorder, Font: &excel.Font{Color: requiredFieldColor}, NumFmt: numFmt}
 
 		result, err := s.excel.NewStyle(style)
 		if err != nil {
@@ -192,12 +229,17 @@ func setExcel(excel *excel.Excel) styleOperatorFunc {
 	}
 }
 
-func (s *styleCreator) getStyle(style styleType) (int, error) {
+func (s *styleCreator) getStyle(style styleType, propTypes ...string) (int, error) {
 	result, ok := s.styleMap[style]
 	if !ok {
 		styleFunc := createStyleFuncMap[style]
 		var err error
-		result, err = styleFunc(s)
+		var propType string
+		if len(propTypes) > 0 {
+			propType = propTypes[0]
+		}
+		numFmt := handlePropertyTypeNumFmt(propType)
+		result, err = styleFunc(s, numFmt)
 		if err != nil {
 			return 0, err
 		}

--- a/src/web_server/service/excel/operator/model/operator.go
+++ b/src/web_server/service/excel/operator/model/operator.go
@@ -216,8 +216,12 @@ func (op *Operator) setExcelData() error {
 				data[rowIdx][idx].Value = string(value)
 				continue
 			}
-
-			data[rowIdx][idx].Value = cell
+			switch value := cell.(type) {
+			case string:
+				data[rowIdx][idx].Value = core.HandleDDE(value)
+			default:
+				data[rowIdx][idx].Value = cell
+			}
 		}
 	}
 


### PR DESCRIPTION
### 修复的问题：
- 导出Excel xlsx表格DDE问题
###方案
1.xlsx 根据字段类型指定单元格格式
2.特殊字符 '=', '+', '-', '@' 前添加 '