### PR TITLE
fix:修复通过日期字段查询模型实例 --bug=148529573 【CMDB】模型通过日期字段查询报错

### DIFF
--- a/pkg/filter/operator.go
+++ b/pkg/filter/operator.go
@@ -702,6 +702,11 @@ func (o DatetimeLessOp) ToMgo(field string, value interface{}) (map[string]inter
 		return nil, errors.New("field is empty")
 	}
 
+	if util.IsDate(value) {
+		return mapstr.MapStr{
+			field: map[string]interface{}{common.BKDBLT: value},
+		}, nil
+	}
 	v, err := util.ConvToTime(value)
 	if err != nil {
 		return nil, fmt.Errorf("convert value to time failed, err: %v", err)
@@ -744,6 +749,11 @@ func (o DatetimeLessOrEqualOp) ToMgo(field string, value interface{}) (map[strin
 		return nil, errors.New("field is empty")
 	}
 
+	if util.IsDate(value) {
+		return mapstr.MapStr{
+			field: map[string]interface{}{common.BKDBLTE: value},
+		}, nil
+	}
 	v, err := util.ConvToTime(value)
 	if err != nil {
 		return nil, fmt.Errorf("convert value to time failed, err: %v", err)
@@ -787,6 +797,11 @@ func (o DatetimeGreaterOp) ToMgo(field string, value interface{}) (map[string]in
 		return nil, errors.New("field is empty")
 	}
 
+	if util.IsDate(value) {
+		return mapstr.MapStr{
+			field: map[string]interface{}{common.BKDBGT: value},
+		}, nil
+	}
 	v, err := util.ConvToTime(value)
 	if err != nil {
 		return nil, fmt.Errorf("convert value to time failed, err: %v", err)
@@ -829,6 +844,11 @@ func (o DatetimeGreaterOrEqualOp) ToMgo(field string, value interface{}) (map[st
 		return nil, errors.New("field is empty")
 	}
 
+	if util.IsDate(value) {
+		return mapstr.MapStr{
+			field: map[string]interface{}{common.BKDBGTE: value},
+		}, nil
+	}
 	v, err := util.ConvToTime(value)
 	if err != nil {
 		return nil, fmt.Errorf("convert value to time failed, err: %v", err)

--- a/src/common/util/struti.go
+++ b/src/common/util/struti.go
@@ -29,7 +29,6 @@ const (
 	charPattern    = `^[a-zA-Z]*$`
 	numCharPattern = `^[a-zA-Z0-9]*$`
 	// mailPattern     = `^[a-z0-9A-Z]+([\-_\.][a-z0-9A-Z]+)*@([a-z0-9A-Z]+(-[a-z0-9A-Z]+)*\.)+[a-zA-Z]{2,4}$`
-	datePattern              = `^[0-9]{4}[\-]{1}[0-9]{2}[\-]{1}[0-9]{2}$`
 	dateTimePattern          = `^[0-9]{4}[\-]{1}[0-9]{2}[\-]{1}[0-9]{2}[\s]{1}[0-9]{2}[\:]{1}[0-9]{2}[\:]{1}[0-9]{2}$`
 	timeWithLocationPattern  = `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$`
 	timeWithShortZonePattern = `^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:?\d{2})$`
@@ -44,7 +43,6 @@ var (
 	charRegexp    = regexp.MustCompile(charPattern)
 	numCharRegexp = regexp.MustCompile(numCharPattern)
 	// mailRegexp        = regexp.MustCompile(mailPattern)
-	dateRegexp              = regexp.MustCompile(datePattern)
 	dateTimeRegexp          = regexp.MustCompile(dateTimePattern)
 	timeWithLocationRegexp  = regexp.MustCompile(timeWithLocationPattern)
 	timeWithShortZoneRegexp = regexp.MustCompile(timeWithShortZonePattern)
@@ -77,7 +75,10 @@ func IsDate(sInput interface{}) bool {
 		if len(val) == 0 {
 			return false
 		}
-		return dateRegexp.MatchString(val)
+		if _, err := time.Parse(time.DateOnly, val); err == nil {
+			return true
+		}
+		return false
 	default:
 		return false
 	}

--- a/src/common/valid/valid.go
+++ b/src/common/valid/valid.go
@@ -96,6 +96,10 @@ func ValidateDatetimeType(value interface{}) error {
 		return nil
 	}
 
+	if util.IsDate(value) {
+		return nil
+	}
+
 	// string type with time format is supported
 	if _, ok := util.IsTime(value); ok {
 		return nil

--- a/src/common/valid/valid_test.go
+++ b/src/common/valid/valid_test.go
@@ -18,6 +18,7 @@ package valid
 
 import (
 	"testing"
+	"time"
 
 	"configcenter/src/common"
 )
@@ -43,6 +44,31 @@ func TestIsInnerObject(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsInnerObject(tt.args.objID); got != tt.want {
 				t.Errorf("IsInnerObject() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateDatetimeType(t *testing.T) {
+	type args struct {
+		timeStr any
+	}
+	now := time.Now()
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"illegal date", args{"2024-00-00"}, true}, //should err
+		{"DateOnly", args{now.Format(time.DateOnly)}, false},
+		{"DateTime", args{now.Format(time.DateTime)}, false},
+		{"RFC3339", args{now.Format(time.RFC3339)}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateDatetimeType(tt.args.timeStr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateDatetimeType() = %v:%v", tt.args, err)
 			}
 		})
 	}


### PR DESCRIPTION
### 修复的问题：
- 模型->通过日期字段查询 过滤校验失败
### 修复的方式：
- 放开IsTime，ValidateDatetimeType 限制
- mongo查询参数，区分dataOnly与其它，前者直接使用string参数，后者走go time.Time转换逻辑