### PR TITLE
fix:修复启停模型操作审计日志显示操作类型错误 --bug=150549647 【CMDB】启停模型操作审计日志为修改操作

### DIFF
--- a/src/scene_server/topo_server/logics/model/object.go
+++ b/src/scene_server/topo_server/logics/model/object.go
@@ -586,7 +586,19 @@ func (o *object) UpdateObject(kit *rest.Kit, data mapstr.MapStr, id int64) error
 
 	// generate audit log of object attribute group.
 	audit := auditlog.NewObjectAuditLog(o.clientSet.CoreService())
-	generateAuditParameter := auditlog.NewGenerateAuditCommonParameter(kit, metadata.AuditUpdate).
+	auditAction := metadata.AuditUpdate
+	if data.Exists(metadata.ModelFieldIsPaused) {
+		isPaused, err := data.Bool(metadata.ModelFieldIsPaused)
+		if err != nil {
+			return err
+		}
+		if isPaused {
+			auditAction = metadata.AuditPause
+		} else {
+			auditAction = metadata.AuditResume
+		}
+	}
+	generateAuditParameter := auditlog.NewGenerateAuditCommonParameter(kit, auditAction).
 		WithUpdateFields(data)
 	auditLog, err := audit.GenerateAuditLog(generateAuditParameter, obj.ID, nil)
 	if err != nil {


### PR DESCRIPTION
### 修复的问题：
启停模型-->审计日志显示->操作类型为更新
启停操作 为 更新操作 的子集

### 修复方法：
- 优先判断是否有修改字段 "bk_ispaused"，用于区分 启/停 模型操作
- 若无该字段，为原有操作 更新操作
