### PR TITLE
fix:修复运行统计-实例统计 统计数据错误 --bug=151173040

### DIFF
--- a/src/source_controller/coreservice/core/operation/operation.go
+++ b/src/source_controller/coreservice/core/operation/operation.go
@@ -225,7 +225,7 @@ func getCountGroupByField(kit *rest.Kit, inputParam metadata.ChartConfig) ([]met
 		return groupCountArr, nil
 	}
 
-	instCount, err = mongodb.Client().Table(common.GetObjectInstTableName(inputParam.ObjID, kit.SupplierAccount)).
+	instCount, err = mongodb.Client().Table(common.GetInstTableName(inputParam.ObjID, kit.SupplierAccount)).
 		Find(cond).Count(kit.Ctx)
 
 	if err != nil {
@@ -239,13 +239,12 @@ func getCountGroupByField(kit *rest.Kit, inputParam metadata.ChartConfig) ([]met
 			{common.BKDBMatch: M{common.BKDBAND: []M{
 				{inputParam.Field: M{common.BKDBExists: true}},
 				{inputParam.Field: M{common.BKDBNE: nil}},
-				{common.BKObjIDField: inputParam.ObjID},
 			}}},
 			{common.BKDBGroup: M{"_id": groupField, "count": M{common.BKDBSum: 1}}},
 		}
 
 		err := mongodb.Client().
-			Table(common.GetObjectInstTableName(inputParam.ObjID, kit.SupplierAccount)).
+			Table(common.GetInstTableName(inputParam.ObjID, kit.SupplierAccount)).
 			AggregateAll(kit.Ctx, pipeline, &groupCountArr)
 
 		if err != nil {


### PR DESCRIPTION

### 修复的问题：
- 运营分析-运营统计-实例统计，新增实例统计图表查询数据为空
- -修复方案：修改 objID->表名映射错误，mongo pipeline查询条件
