### PR TITLE
fix: 字段模版同步唯一校验没有获取最新数据 

### DIFF
--- a/src/ui/src/views/business-topology/children/topology-tree.vue
+++ b/src/ui/src/views/business-topology/children/topology-tree.vue
@@ -276,6 +276,8 @@
           }
         }
 
+        // 如果直接通过子节点无法找到当前树节点，则通过其父节点查找
+        // 为了解决当从pod详情列表点击拓扑跳转回业务拓扑页面时偶现找不到子节点而产生的接口报错问题
         if (queryTopoPathArray.length) {
           let node = ''
           for (let i = queryTopoPathArray.length;i > 0; i--) {

--- a/src/ui/src/views/business-topology/children/topology-tree.vue
+++ b/src/ui/src/views/business-topology/children/topology-tree.vue
@@ -267,6 +267,7 @@
       getDefaultNode() {
         // 选中指定的节点
         const queryNodeId = RouterQuery.get('node', '')
+        const queryTopoPathArray = RouterQuery.get('topo_path', '').split(',')
         if (queryNodeId) {
           // 未加载的容器节点会找不到，导致无法复原节点的选中，暂无理想的解决方式
           const node = this.$refs.tree.getNodeById(queryNodeId)
@@ -274,6 +275,17 @@
             return node
           }
         }
+
+        if (queryTopoPathArray.length) {
+          let node = ''
+          for (let i = queryTopoPathArray.length;i > 0; i--) {
+            node = this.$refs.tree.getNodeById(queryTopoPathArray[i - 1])
+            if (node) {
+              return node
+            }
+          }
+        }
+
         // 从其他页面跳转过来需要筛选节点，例如：删除集群模板中的服务模板
         const keyword = RouterQuery.get('keyword', '')
         if (keyword) {

--- a/src/ui/src/views/field-template/details-unique.vue
+++ b/src/ui/src/views/field-template/details-unique.vue
@@ -35,7 +35,7 @@
   watchEffect(async () => {
     const fieldData = await fieldTemplateService.getFieldList({
       bk_template_id: props.templateId
-    }, { requestId: DETAILS_FIELDLIST_REQUEST_ID, fromCache: true })
+    }, { requestId: DETAILS_FIELDLIST_REQUEST_ID, fromCache: false })
     fieldList.value = fieldData?.info || []
   })
 

--- a/src/ui/src/views/host-apply/children/property-config-table.vue
+++ b/src/ui/src/views/host-apply/children/property-config-table.vue
@@ -106,6 +106,7 @@
       <template slot-scope="{ row }">
         <div class="form-element-content">
           <property-form-element
+            :key="row.id"
             :property="row"
             v-bk-tooltips.top="{
               disabled: !row.placeholder || $tools.isIconTipProperty(row.bk_property_type),


### PR DESCRIPTION
### 修复的问题：
- fix: 字段模版同步唯一校验没有获取最新数据
- fix: 编辑主机自动应用时取消已选择的属性字段，‘下一步’按钮变成置灰了不能点击