### PR TITLE
fix: increase AttributeOptionArrayMaxLength from 200 to 500

### DIFF
--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -1559,8 +1559,8 @@ const (
 	AttributeUnitMaxLength = 20
 	// AttributeOptionValueMaxLength TODO
 	AttributeOptionValueMaxLength = 128
-	// AttributeOptionArrayMaxLength TODO
-	AttributeOptionArrayMaxLength = 200
+	// AttributeOptionArrayMaxLength is the max number of options allowed for enum/list type attribute fields.
+	AttributeOptionArrayMaxLength = 500
 	// ServiceCategoryMaxLength TODO
 	ServiceCategoryMaxLength = 128
 )


### PR DESCRIPTION
### 修复的问题：
- 修复枚举类型(enum/enum-multi/list/enum-quote)字段选项数量硬编码限制为200，不满足实际业务场景需求的问题，将上限调整为500 (#8567)