### PR TITLE
dep:升级mongo-driver --story=132861809 MongoDB Go Driver的CVE-2026-2303漏洞修复

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,9 +46,9 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.398
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v1.0.398
 	github.com/tidwall/gjson v1.14.1
-	github.com/xdg-go/scram v1.1.1
+	github.com/xdg-go/scram v1.1.2
 	github.com/xuri/excelize/v2 v2.7.1
-	go.mongodb.org/mongo-driver v1.9.1
+	go.mongodb.org/mongo-driver v1.17.9
 	go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.44.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.44.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.44.0
@@ -103,7 +103,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/joyt/godate v0.0.0-20150226210126-7151572574a7 // indirect
-	github.com/klauspost/compress v1.15.9 // indirect
+	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
@@ -112,6 +112,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
@@ -132,10 +133,10 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
-	github.com/xdg-go/stringprep v1.0.3 // indirect
+	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/xuri/efp v0.0.0-20220603152613-6918739fd470 // indirect
 	github.com/xuri/nfp v0.0.0-20220409054826-5e722a1d9e22 // indirect
-	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
+	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.17.0 // indirect
 	go.opentelemetry.io/otel/metric v1.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -356,6 +356,8 @@ github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47e
 github.com/klauspost/compress v1.15.0/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.9 h1:wKRjX6JRtDdrE9qwa4b/Cip7ACOshUI4smpCQanqjSY=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
+github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
@@ -404,6 +406,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
+github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/mozillazg/go-pinyin v0.20.0 h1:BtR3DsxpApHfKReaPO1fCqF4pThRwH9uwvXzm+GnMFQ=
 github.com/mozillazg/go-pinyin v0.20.0/go.mod h1:iR4EnMMRXkfpFVV5FMi4FNB6wGq9NV6uDWbUuPhP4Yc=
 github.com/mssola/user_agent v0.5.3 h1:lBRPML9mdFuIZgI2cmlQ+atbpJdLdeVl2IDodjBR578=
@@ -552,9 +556,13 @@ github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
 github.com/xdg-go/scram v1.1.1 h1:VOMT+81stJgXW3CpHyqHN3AXDYIMsx56mEFrB37Mb/E=
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
+github.com/xdg-go/scram v1.1.2 h1:FHX5I5B4i4hKRVRBCFRxq1iQRej7WO3hhBuJf+UUySY=
+github.com/xdg-go/scram v1.1.2/go.mod h1:RT/sEzTbU5y00aCK8UOx6R7YryM0iF1N2MOmC3kKLN4=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=
 github.com/xdg-go/stringprep v1.0.3 h1:kdwGpVNwPFtjs98xCGkHjQtGKh86rDcRZN17QEMCOIs=
 github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
+github.com/xdg-go/stringprep v1.0.4 h1:XLI/Ng3O1Atzq0oBs3TWm+5ZVgkq2aqdlvP9JtoZ6c8=
+github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
 github.com/xuri/efp v0.0.0-20220603152613-6918739fd470 h1:6932x8ltq1w4utjmfMPVj09jdMlkY0aiA6+Skbtl3/c=
 github.com/xuri/efp v0.0.0-20220603152613-6918739fd470/go.mod h1:ybY/Jr0T0GTCnYjKqmdwxyxn2BQf2RcQIIvex5QldPI=
 github.com/xuri/excelize/v2 v2.7.1 h1:gm8q0UCAyaTt3MEF5wWMjVdmthm2EHAWesGSKS9tdVI=
@@ -563,6 +571,8 @@ github.com/xuri/nfp v0.0.0-20220409054826-5e722a1d9e22 h1:OAmKAfT06//esDdpi/DZ8Q
 github.com/xuri/nfp v0.0.0-20220409054826-5e722a1d9e22/go.mod h1:WwHg+CVyzlv/TX9xqBFXEZAuxOPxn2k1GNHwG41IIUQ=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d h1:splanxYIlg+5LfHAM6xpdFEAYOk8iySO56hMFq6uLyA=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
+github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
+github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -573,6 +583,8 @@ github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64 h1:5mLPGnFdSsevFRF
 github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.mongodb.org/mongo-driver v1.9.1 h1:m078y9v7sBItkt1aaoe2YlvWEXcD263e1a4E1fBrJ1c=
 go.mongodb.org/mongo-driver v1.9.1/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
+go.mongodb.org/mongo-driver v1.17.9 h1:IexDdCuuNJ3BHrELgBlyaH9p60JXAvdzWR128q+U5tU=
+go.mongodb.org/mongo-driver v1.17.9/go.mod h1:LlOhpH5NUEfhxcAwG0UEkMqwYcc4JU18gtCdGudk/tQ=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -822,6 +834,7 @@ golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/text v0.31.0 h1:aC8ghyu4JhP8VojJ2lEHBnochRno1sgL6nEi9WGFGMM=

--- a/src/common/metadata/host.go
+++ b/src/common/metadata/host.go
@@ -19,11 +19,12 @@ import (
 
 	"configcenter/src/common"
 	"configcenter/src/common/blog"
+
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsoncodec"
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
-	"go.mongodb.org/mongo-driver/x/bsonx"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
@@ -34,7 +35,7 @@ type HostMapStr map[string]interface{}
 // UnmarshalBSON TODO
 func (h *HostMapStr) UnmarshalBSON(b []byte) error {
 	if h == nil {
-		return bsonx.ErrNilDocument
+		return mongo.ErrNilDocument
 	}
 	elements, err := bsoncore.Document(b).Elements()
 	if err != nil {
@@ -142,7 +143,7 @@ type StringArrayToString string
 // UnmarshalBSONValue TODO
 func (s *StringArrayToString) UnmarshalBSONValue(typo bsontype.Type, raw []byte) error {
 	if s == nil {
-		return bsonx.ErrNilDocument
+		return mongo.ErrNilDocument
 	}
 	value := bsoncore.Value{
 		Type: typo,

--- a/src/common/metadata/time.go
+++ b/src/common/metadata/time.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
-	"go.mongodb.org/mongo-driver/x/bsonx"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 // Time TODO
@@ -83,7 +83,7 @@ func (t *Time) UnmarshalJSON(data []byte) error {
 
 // MarshalBSONValue implements bson.MarshalBSON interface
 func (t Time) MarshalBSONValue() (bsontype.Type, []byte, error) {
-	return bsonx.Time(t.Time).MarshalBSONValue()
+	return bson.TypeDateTime, bsoncore.AppendTime(nil, t.Time), nil
 }
 
 // UnmarshalBSONValue implements bson.UnmarshalBSONValue interface

--- a/src/common/time/time.go
+++ b/src/common/time/time.go
@@ -22,7 +22,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
-	"go.mongodb.org/mongo-driver/x/bsonx"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 // Time TODO
@@ -55,7 +55,7 @@ func (t *Time) UnmarshalJSON(data []byte) error {
 
 // MarshalBSONValue implements bson.MarshalBSON interface
 func (t Time) MarshalBSONValue() (bsontype.Type, []byte, error) {
-	return bsonx.Time(t.Time).MarshalBSONValue()
+	return bson.TypeDateTime, bsoncore.AppendTime(nil, t.Time), nil
 }
 
 // UnmarshalBSONValue implements bson.UnmarshalBSONValue interface

--- a/src/source_controller/cacheservice/event/identifier/converter.go
+++ b/src/source_controller/cacheservice/event/identifier/converter.go
@@ -22,9 +22,10 @@ import (
 	"configcenter/src/common/mapstr"
 	"configcenter/src/common/util"
 	"configcenter/src/storage/stream/types"
+
 	"github.com/tidwall/gjson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/x/bsonx"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 var needCareHostFields = []string{
@@ -41,13 +42,13 @@ var needCareHostFields = []string{
 // host events arrange policy:
 // 1. do not care delete events, cause if the host is already dropped, then it's identifier event is meaningless.
 // 2. if event's ChangeDesc contains fields as follows, then we care about it, otherwise we can drop this events
-//    - bk_host_id
-//    - bk_os_type
-//    - bk_cloud_id
-//    - bk_host_innerip
-//    if ChangeDesc is empty, then we assume this events is need to be care.
-// 3. aggregate multiple same host's event to one event, so that we can decrease the amount of host identity. because
-//    we only care about which host is changed, one event is enough for us.
+//   - bk_host_id
+//   - bk_os_type
+//   - bk_cloud_id
+//   - bk_host_innerip
+//     if ChangeDesc is empty, then we assume this events is need to be care.
+//  3. aggregate multiple same host's event to one event, so that we can decrease the amount of host identity. because
+//     we only care about which host is changed, one event is enough for us.
 func (f *hostIdentity) rearrangeHostEvents(es []*types.Event, rid string) []*types.Event {
 
 	hitEvents := make([]*types.Event, 0)
@@ -164,7 +165,7 @@ func (f *hostIdentity) rearrangeHostRelationEvents(es []*types.Event, rid string
 		"coll": common.BKTableNameModuleHostConfig,
 	}
 
-	docs := make([]bsonx.Doc, 0)
+	docs := make([]bsoncore.Document, 0)
 	err := f.ccDB.Table(common.BKTableNameDelArchive).Find(filter).All(context.Background(), &docs)
 	if err != nil {
 		f.metrics.CollectMongoError()
@@ -400,7 +401,7 @@ func (f *hostIdentity) getDeletedProcessHosts(startUnix int64, oids []string, ri
 		"coll": common.BKTableNameBaseProcess,
 	}
 
-	docs := make([]bsonx.Doc, 0)
+	docs := make([]bsoncore.Document, 0)
 	err := f.ccDB.Table(common.BKTableNameDelArchive).Find(filter).Fields("detail").All(context.Background(), &docs)
 	if err != nil {
 		f.metrics.CollectMongoError()

--- a/src/storage/dal/mongo/local/mongo.go
+++ b/src/storage/dal/mongo/local/mongo.go
@@ -38,7 +38,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
-	"go.mongodb.org/mongo-driver/x/bsonx"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
 )
 
@@ -235,7 +235,7 @@ func (c *Mongo) updateIDGenSeqID(ctx context.Context, typ idgen.IDGenType, id ui
 func checkMongodbVersion(db string, client *mongo.Client) error {
 	serverStatus, err := client.Database(db).RunCommand(
 		context.Background(),
-		bsonx.Doc{{"serverStatus", bsonx.Int32(1)}},
+		bson.D{{"serverStatus", 1}},
 	).DecodeBytes()
 	if err != nil {
 		return err
@@ -753,6 +753,23 @@ func (c *Collection) DeleteMany(ctx context.Context, filter types.Filter) (uint6
 	return deleteCount, err
 }
 
+// deleteField 从 bsoncore.Document 中移除指定字段，返回 bson.D
+func deleteField(raw bsoncore.Document, field string) bson.D {
+	result := make(bson.D, 0)
+	elements, err := raw.Elements()
+	if err != nil {
+		return result
+	}
+	for _, elem := range elements {
+		if elem.Key() != field {
+			result = append(result, bson.E{
+				Key:   elem.Key(),
+				Value: elem.Value(),
+			})
+		}
+	}
+	return result
+}
 func (c *Collection) tryArchiveDeletedDoc(ctx context.Context, filter types.Filter) error {
 	delArchiveTable, exists := table.GetDelArchiveTable(c.collName)
 	if !exists {
@@ -771,7 +788,7 @@ func (c *Collection) tryArchiveDeletedDoc(ctx context.Context, filter types.Filt
 		findOpts = &options.FindOptions{Projection: projection}
 	}
 
-	docs := make([]bsonx.Doc, 0)
+	docs := make([]bsoncore.Document, 0)
 	cursor, err := c.dbc.Database(c.dbname).Collection(c.collName).Find(ctx, filter, findOpts)
 	if err != nil {
 		return err
@@ -789,7 +806,7 @@ func (c *Collection) tryArchiveDeletedDoc(ctx context.Context, filter types.Filt
 	for idx, doc := range docs {
 		archives[idx] = metadata.DeleteArchive{
 			Oid:    doc.Lookup("_id").ObjectID().Hex(),
-			Detail: doc.Delete("_id"),
+			Detail: deleteField(doc, "_id"),
 			Time:   time.Now(),
 			Coll:   c.collName,
 		}

--- a/src/storage/dal/mongo/local/mongo_test.go
+++ b/src/storage/dal/mongo/local/mongo_test.go
@@ -25,9 +25,9 @@ import (
 	"configcenter/src/common/util"
 	"configcenter/src/storage/dal/types"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/uuid"
 )
 
 func BenchmarkLocalCUD(b *testing.B) {
@@ -42,7 +42,7 @@ func BenchmarkLocalCUD(b *testing.B) {
 
 	header := http.Header{}
 	header.Set(common.BKHTTPCCRequestID, "xxxxx")
-	sessionID, _ := uuid.New()
+	sessionID := uuid.New().String()
 	ctx := context.WithValue(context.Background(), common.TransactionTimeoutHeader, sessionID[:])
 	ctx = context.WithValue(ctx, common.TransactionTimeoutHeader, time.Second)
 	tablename := "tmptest"

--- a/src/storage/dal/mongo/local/txn_manager.go
+++ b/src/storage/dal/mongo/local/txn_manager.go
@@ -27,8 +27,8 @@ import (
 	"configcenter/src/common/metadata"
 	"configcenter/src/storage/dal/redis"
 
+	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/uuid"
 )
 
 const (
@@ -295,7 +295,7 @@ func (t *TxnManager) GetTxnError(sessionID sessionKey) TxnErrorType {
 // GenSessionID TODO
 func GenSessionID() (string, error) {
 	// mongodb driver used this as it's mongodb session id, and we use it too.
-	id, err := uuid.New()
+	id, err := uuid.NewUUID()
 	if err != nil {
 		return "", err
 	}

--- a/src/storage/stream/types/types.go
+++ b/src/storage/stream/types/types.go
@@ -24,7 +24,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/x/bsonx"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 // OperType TODO
@@ -206,7 +206,7 @@ func (t TimeStamp) String() string {
 
 // MarshalBSONValue TODO
 func (t TimeStamp) MarshalBSONValue() (bsontype.Type, []byte, error) {
-	return bsonx.Time(time.Unix(int64(t.Sec), int64(t.Nano))).MarshalBSONValue()
+	return bson.TypeDateTime, bsoncore.AppendTime(nil, time.Unix(int64(t.Sec), int64(t.Nano))), nil
 }
 
 type timeStampCopy struct {


### PR DESCRIPTION
## 优化的功能:
- 升级go.mongodb.org/mongo-driver至版本v1.17.9
- 替换mongo-driver过期方法/函数等