### PR TITLE
feat:模型属性添加is_hidden隐藏配置 --story=132514098 前端隐藏模型的字段

### DIFF
--- a/src/common/definitions.go
+++ b/src/common/definitions.go
@@ -652,6 +652,9 @@ const (
 	// BKIsPre the ispre field
 	BKIsPre = "ispre"
 
+	// BKIsHidden the is_hidden field
+	BKIsHidden = "is_hidden"
+
 	// BKObjectUniqueKeys object unique keys field
 	BKObjectUniqueKeys = "keys"
 

--- a/src/common/metadata/attribute.go
+++ b/src/common/metadata/attribute.go
@@ -120,6 +120,7 @@ type Attribute struct {
 	IsRequired        bool        `field:"isrequired" json:"isrequired" bson:"isrequired" mapstructure:"isrequired"`
 	IsReadOnly        bool        `field:"isreadonly" json:"isreadonly" bson:"isreadonly" mapstructure:"isreadonly"`
 	IsOnly            bool        `field:"isonly" json:"isonly" bson:"isonly" mapstructure:"isonly"`
+	IsHidden          bool        `field:"is_hidden" json:"is_hidden" bson:"is_hidden" mapstructure:"is_hidden"`
 	IsSystem          bool        `field:"bk_issystem" json:"bk_issystem" bson:"bk_issystem" mapstructure:"bk_issystem"`
 	IsAPI             bool        `field:"bk_isapi" json:"bk_isapi" bson:"bk_isapi" mapstructure:"bk_isapi"`
 	PropertyType      string      `field:"bk_property_type" json:"bk_property_type" bson:"bk_property_type" mapstructure:"bk_property_type"`

--- a/src/scene_server/admin_server/imports.go
+++ b/src/scene_server/admin_server/imports.go
@@ -123,4 +123,5 @@ import (
 	_ "configcenter/src/scene_server/admin_server/upgrader/y3.14.202603231000"
 	_ "configcenter/src/scene_server/admin_server/upgrader/y3.14.202605111642"
 	_ "configcenter/src/scene_server/admin_server/upgrader/y3.14.202607141200"
+	_ "configcenter/src/scene_server/admin_server/upgrader/y3.14.202607141510"
 )

--- a/src/scene_server/admin_server/upgrader/y3.14.202607141510/add_objatt_column_is_hidden.go
+++ b/src/scene_server/admin_server/upgrader/y3.14.202607141510/add_objatt_column_is_hidden.go
@@ -1,0 +1,35 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云 - 配置平台 (BlueKing - Configuration System) available.
+ * Copyright (C) 2017 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package y3_14_202607141510
+
+import (
+	"context"
+
+	"configcenter/src/common"
+	"configcenter/src/common/blog"
+	"configcenter/src/scene_server/admin_server/upgrader"
+	"configcenter/src/storage/dal"
+)
+
+func addObjAttIsHiddenField(ctx context.Context, db dal.RDB, conf *upgrader.Config) error {
+	if err := db.Table(common.BKTableNameObjAttDes).AddColumn(ctx, common.BKIsHidden, false); err != nil {
+		blog.Errorf("add is_hidden field failed, err: %v", err)
+		return err
+	}
+	return nil
+}

--- a/src/scene_server/admin_server/upgrader/y3.14.202607141510/pkg.go
+++ b/src/scene_server/admin_server/upgrader/y3.14.202607141510/pkg.go
@@ -1,0 +1,41 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云 - 配置平台 (BlueKing - Configuration System) available.
+ * Copyright (C) 2017 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package y3_14_202607141510
+
+import (
+	"context"
+
+	"configcenter/src/common/blog"
+	"configcenter/src/scene_server/admin_server/upgrader"
+	"configcenter/src/storage/dal"
+)
+
+func init() {
+	upgrader.RegistUpgrader("y3.14.202607141510", upgrade)
+}
+
+func upgrade(ctx context.Context, db dal.RDB, conf *upgrader.Config) (err error) {
+	blog.Infof("start execute y3.14.202607141510")
+	err = addObjAttIsHiddenField(ctx, db, conf)
+	if err != nil {
+		blog.Errorf("upgrade y3.14.202607141510 add objattr is_hidden field failed, error: %v", err)
+		return err
+	}
+	blog.Infof("execute y3.14.202607141510, add objattr is_hidden field success!")
+	return nil
+}

--- a/src/scene_server/topo_server/service/object_attribute.go
+++ b/src/scene_server/topo_server/service/object_attribute.go
@@ -62,6 +62,7 @@ func (s *Service) CreateObjectAttribute(ctx *rest.Contexts) {
 		}
 	}
 
+	attr.IsHidden = false
 	// do not support add preset attribute by api
 	attr.IsPre = false
 	isBizCustomField := false
@@ -363,6 +364,50 @@ func (s *Service) UpdateObjectAttribute(ctx *rest.Contexts) {
 	ctx.RespEntity(nil)
 }
 
+// AttributeHidden attribute hiding configuration
+type AttributeHidden struct {
+	IsHidden *bool `json:"is_hidden"`
+}
+
+// UpdateObjectAttributeHidden update the object attribute : is_hidden
+func (s *Service) UpdateObjectAttributeHidden(ctx *rest.Contexts) {
+	data := new(AttributeHidden)
+	if err := ctx.DecodeInto(data); err != nil {
+		ctx.RespAutoError(err)
+		return
+	}
+
+	if data.IsHidden == nil {
+		ctx.RespAutoError(ctx.Kit.CCError.CCErrorf(common.CCErrCommParamsNeedSet, common.BKIsHidden))
+		return
+	}
+
+	// adapt input path param with bk_biz_id and attr id.
+	id, bizID, err := getAttrIDAndBizID(ctx)
+	if err != nil {
+		ctx.RespAutoError(err)
+		return
+	}
+
+	updateData := mapstr.MapStr{
+		common.BKIsHidden: *data.IsHidden,
+	}
+
+	txnErr := s.Engine.CoreAPI.CoreService().Txn().AutoRunTxn(ctx.Kit.Ctx, ctx.Kit.Header, func() error {
+		err := s.Logics.AttributeOperation().UpdateObjectAttribute(ctx.Kit, updateData, id, bizID, false)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if txnErr != nil {
+		ctx.RespAutoError(txnErr)
+		return
+	}
+	ctx.RespEntity(nil)
+}
+
 // updateObjectTableAttribute update the table object attribute
 func (s *Service) updateObjectTableAttribute(ctx *rest.Contexts, id, bizID int64, data mapstr.MapStr) error {
 
@@ -384,6 +429,9 @@ func removeImmutableFields(data mapstr.MapStr) mapstr.MapStr {
 	// TODO: why does remove this????
 	data.Remove(metadata.BKMetadata)
 	data.Remove(common.BKAppIDField)
+
+	// UpdateObjectAttribute should not update is_hidden
+	data.Remove(common.BKIsHidden)
 
 	// UpdateObjectAttribute should not update bk_property_index、bk_property_group
 	data.Remove(common.BKPropertyIndexField)

--- a/src/scene_server/topo_server/service/service_business_initfunc.go
+++ b/src/scene_server/topo_server/service/service_business_initfunc.go
@@ -82,6 +82,10 @@ func (s *Service) initBusinessObjectAttribute(web *restful.WebService) {
 		Handler: s.SearchObjectAttributeForWeb})
 	utility.AddHandler(rest.Action{Verb: http.MethodPut, Path: "/update/objectattr/{id}",
 		Handler: s.UpdateObjectAttribute})
+	// NOTE: this API is exclusively for updating the "hidden" field.
+	// "hidden" is only updatable through this API, not the regular one.
+	utility.AddHandler(rest.Action{Verb: http.MethodPut, Path: "/update/objectattr/hidden/{id}",
+		Handler: s.UpdateObjectAttributeHidden})
 	utility.AddHandler(rest.Action{Verb: http.MethodPut, Path: "/update/objectattr/biz/{bk_biz_id}/id/{id}",
 		Handler: s.UpdateObjectAttribute})
 	utility.AddHandler(rest.Action{Verb: http.MethodDelete, Path: "/delete/objectattr/{id}",


### PR DESCRIPTION
- 模型表字段新加一个属性：is_hidden，默认为false

- 模型字段hidden=true时，不显示给用户，但是接口正常返回数据
- 模型字段属性修改接口，不能修改is_hidden参数
- bk-cmdb 页面不提供对字段供调整is_hidden功能
- 提供专门接口调整字段is_hidden，使用正常的接口权限控制
模型字段隐藏场景
- bk-cmdb 页面在列表，详情，编辑页面不显示hidden=true的字段