### PR TITLE
chore: improve bk-cmdb maintenance path

### DIFF
--- a/pkg/conv/dot.go
+++ b/pkg/conv/dot.go
@@ -20,12 +20,14 @@ import (
 	"strings"
 )
 
+const dotEscape = "\\u002e"
+
 // EncodeDot encode the dot in the string as the unicode value
 func EncodeDot(input string) string {
-	return strings.ReplaceAll(input, ".", "\\u002e")
+	return strings.ReplaceAll(input, ".", dotEscape)
 }
 
 // DecodeDot decode the unicode value of dot in a string to dot
 func DecodeDot(input string) string {
-	return strings.ReplaceAll(input, "\\u002e", ".")
+	return strings.ReplaceAll(input, dotEscape, ".")
 }

--- a/pkg/conv/dot_test.go
+++ b/pkg/conv/dot_test.go
@@ -30,3 +30,25 @@ func TestDot(t *testing.T) {
 	decodedStr := DecodeDot(encodedStr)
 	require.Equal(t, decodedStr, str)
 }
+
+func TestDotEdgeCases(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"empty", ""},
+		{"no_dot", "nodot"},
+		{"k8s_label", "app.kubernetes.io/name"},
+		{"docker_image", "docker.io/library/nginx:1.21.0"},
+		{"semver", "v1.2.3-beta.1"},
+		{"only_dots", "..."},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			encoded := EncodeDot(c.input)
+			decoded := DecodeDot(encoded)
+			require.Equal(t, c.input, decoded)
+		})
+	}
+}


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in pkg/conv/dot.go, src/test/test.go related to CI, Docker, Kubernetes, build tooling, release automation; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.